### PR TITLE
Add ADRs for TUI direction

### DIFF
--- a/docs/adr/0001-use-charmbracelet-libraries-as-the-tui-foundation.md
+++ b/docs/adr/0001-use-charmbracelet-libraries-as-the-tui-foundation.md
@@ -1,0 +1,77 @@
+# 0001: Use Charmbracelet Libraries as the TUI Foundation
+
+- Status: Accepted
+- Date: 2026-04-25
+
+## Context
+
+`gh-zen` is starting as a Go terminal application. The current `go.mod` already
+contains the core shape of the TUI stack:
+
+- `github.com/charmbracelet/bubbletea`: terminal program runtime and update loop.
+- `github.com/charmbracelet/lipgloss`: terminal styling and layout.
+- `github.com/charmbracelet/bubbles`: reusable TUI components.
+- `github.com/charmbracelet/glamour`: Markdown rendering for GitHub-oriented
+  content.
+- `github.com/cli/go-gh/v2`: Go integration with GitHub CLI behavior and
+  authentication context.
+
+The initial implementation in `main.go` uses Bubble Tea and Lip Gloss directly.
+The rest of the module graph is still early and should be allowed to change as
+the product surface becomes clearer.
+
+## Decision
+
+Use the Charmbracelet ecosystem as the default foundation for the TUI:
+
+- Bubble Tea owns the application loop, message handling, and commands.
+- Lip Gloss owns terminal styling and layout.
+- Bubbles should be preferred for common interactive controls before building
+  custom widgets.
+- Glamour should be used when the app needs to render Markdown-rich GitHub data.
+- GitHub access should stay behind a narrow application boundary instead of
+  being called directly from view rendering or key handling.
+
+This keeps the app idiomatic for Go, testable at the update/model boundary, and
+aligned with libraries already present in the module graph.
+
+## Consequences
+
+Positive:
+
+- The UI can grow from a small model without introducing a custom terminal
+  framework.
+- Bubble Tea keeps state transitions explicit and testable.
+- Lip Gloss and Bubbles reduce one-off terminal layout code.
+- Glamour gives the project a natural path for rendering issue, PR, or
+  Markdown content.
+
+Tradeoffs:
+
+- The project inherits Charmbracelet API and terminal behavior changes.
+- Terminal layout and display-width edge cases still need explicit testing.
+- The TUI model can become coupled to GitHub IO unless commands and data access
+  are kept behind boundaries.
+- Some dependencies may remain indirect until concrete features use them.
+
+## Alternatives Considered
+
+- Plain `fmt` output and manual terminal handling: simpler at first, but likely
+  to accumulate bespoke state and layout code quickly.
+- A different TUI framework such as `tview`: useful for widget-heavy apps, but it
+  does not match the current Bubble Tea model already present in the codebase.
+- A web UI: unnecessary for the current command-line workflow and would add a
+  separate runtime surface.
+
+## Maintenance Notes
+
+This ADR should be revisited when:
+
+- Bubble Tea, Lip Gloss, Bubbles, or Glamour is removed or replaced.
+- A second TUI framework is introduced.
+- GitHub access starts leaking directly into view rendering.
+- The project has enough UI surface that shared layout, key binding, or command
+  patterns need their own ADR.
+
+If this decision stops being current, add a new ADR and mark this one as
+`Superseded` instead of rewriting the history of why the stack was chosen.

--- a/docs/adr/0002-keep-ui-copy-in-english-and-support-unicode-input.md
+++ b/docs/adr/0002-keep-ui-copy-in-english-and-support-unicode-input.md
@@ -1,0 +1,116 @@
+# 0002: Keep UI Copy in English and Support Unicode Input
+
+- Status: Accepted
+- Date: 2026-04-25
+
+## Context
+
+`gh-zen` should provide a stable terminal workflow for GitHub data while keeping
+the product surface small. Application UI copy can stay in English, but user
+input and GitHub content must support Japanese and other Unicode text.
+
+Japanese input in a TUI has two distinct risks:
+
+- Inline composition can be fragile when an IME emits non-ASCII text through
+  terminal key events.
+- Long-form issue, PR, or comment text is more comfortable in a user's editor
+  than in a small terminal composer.
+
+OpenAI Codex CLI was reviewed as a reference point at commit
+`706490ab1b3f79ba807581b35aeeff6222e04cac`. Its TUI keeps UI copy in English,
+supports non-ASCII/IME input without holding the first non-ASCII character in
+paste detection, and opens an external editor only from `$VISUAL` or `$EDITOR`.
+It does not silently fall back to `vim`.
+
+## Decision
+
+Keep application UI copy in English, including labels, help text, menu items,
+shortcut hints, and error messages.
+
+Treat Japanese and other Unicode text as first-class user input and content:
+
+- Preserve UTF-8 text for input fields, search queries, issue titles, comments,
+  and rendered GitHub content.
+- Do not use byte length or rune count for terminal display width, cursor
+  movement, truncation, or wrapping.
+- Prefer Bubbles input components and Charmbracelet display-width-aware helpers
+  before implementing custom text editing behavior.
+- Keep input normalization separate from stored or submitted text. If search
+  needs normalization, normalize only the search query/index path and preserve
+  the original text for display and GitHub API calls.
+
+Support an external editor path for long-form or IME-sensitive input:
+
+- Use `ctrl+g` as the shortcut to edit the current draft in an external editor.
+- Resolve the editor from `$VISUAL`, then `$EDITOR`.
+- Do not fall back to `vim`, `vi`, or any other editor when both variables are
+  unset. Show an actionable error instead.
+- Seed a temporary Markdown file with the current draft, run the editor while
+  the TUI terminal is released, then replace the draft with the saved file
+  contents after the editor exits successfully.
+- Preserve the existing draft if the editor command cannot be resolved, fails to
+  start, or exits unsuccessfully.
+- Trim trailing whitespace from the saved editor contents before applying it.
+
+In Go/Bubble Tea, external editor execution should use Bubble Tea's blocking
+exec path, such as `tea.ExecProcess`, so stdin/stdout and the alternate screen
+are released and restored by the TUI runtime.
+
+## Consequences
+
+Positive:
+
+- English UI copy keeps the application surface simpler and easier to test.
+- Japanese issue titles, comments, and search text remain supported without
+  turning the whole UI into a localization project.
+- Users with complex IME workflows can use their configured editor instead of
+  relying only on inline terminal input.
+- Avoiding a built-in `vim` fallback prevents surprising users who have not
+  chosen an editor for this application.
+
+Tradeoffs:
+
+- New users without `$VISUAL` or `$EDITOR` must configure an editor before using
+  external editing.
+- The inline composer still needs Unicode display-width and cursor tests.
+- External editor behavior depends on the user's shell environment and terminal.
+
+## Implementation Notes
+
+The first implementation should stay narrow:
+
+- Add a small editor resolver that parses `$VISUAL` before `$EDITOR`.
+- Add a draft editor command that writes and reads a temporary `.md` file.
+- Add a Bubble Tea command wrapper that launches the editor with terminal
+  control released.
+- Add focused tests for editor resolution, missing editor errors, failed editor
+  preservation, successful UTF-8 round trips, and trailing whitespace trimming.
+
+Inline composer tests should cover at least:
+
+- Japanese text.
+- Mixed Japanese and ASCII text.
+- Emoji and multi-codepoint grapheme clusters.
+- Narrow terminal widths.
+- Paste and IME-like non-ASCII input sequences.
+
+## Alternatives Considered
+
+- Localized Japanese UI: useful later, but too much surface area before the core
+  workflows are stable.
+- Built-in fallback to `vim`: convenient for some users, but surprising and
+  inconsistent with the user's configured terminal environment.
+- Inline-only input: simpler to build at first, but weaker for long Japanese
+  text and less resilient to terminal IME edge cases.
+
+## Maintenance Notes
+
+This ADR should be revisited when:
+
+- The project adds full localization.
+- External editor behavior changes away from `$VISUAL`/`$EDITOR`.
+- The composer starts implementing custom cursor or wrapping logic.
+- Search adds Japanese-specific normalization rules.
+
+If the editor policy changes, add a new ADR and mark this one as `Superseded`
+instead of silently changing the input contract.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,29 @@
+# Architecture Decision Records
+
+Architecture Decision Records capture durable project decisions. They are not a
+general planning scratchpad, and they should stay small enough to remain
+trustworthy.
+
+## Current Records
+
+- [0001: Use Charmbracelet Libraries as the TUI Foundation](0001-use-charmbracelet-libraries-as-the-tui-foundation.md)
+- [0002: Keep UI Copy in English and Support Unicode Input](0002-keep-ui-copy-in-english-and-support-unicode-input.md)
+
+## Status Values
+
+- `Proposed`: under discussion and not yet the default for new work.
+- `Accepted`: the current direction for new work.
+- `Superseded`: replaced by a newer ADR.
+- `Deprecated`: intentionally retained for history, but no longer guidance.
+
+## Maintenance Rules
+
+- Update an ADR only to clarify the original decision or fix factual mistakes.
+- When the decision changes, add a new ADR and mark the old one as
+  `Superseded`.
+- Delete temporary planning notes once they stop guiding implementation.
+- Move historical documents to `docs/archive/` only when they are useful for
+  archaeology but should not be part of the active project context.
+- Do not depend on an AI-inaccessible location as the source of truth. Active
+  documents should be easy for humans and tools to find; obsolete documents
+  should be clearly marked or removed from the active index.


### PR DESCRIPTION
## Summary
- Add repository instructions for language, workflow, and GitHub metadata conventions.
- Add an ADR index and maintenance rules for architecture decisions.
- Document Charmbracelet as the TUI foundation.
- Define the policy for English UI copy, Unicode input, and external editor behavior.

## Test Plan
- [x] git diff --check
- [x] go test ./...