### PR TITLE
Add repository instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Repository Instructions
+
+## Communication
+
+- Respond to the user in Japanese unless they ask for another language.
+- Keep repository documents, code comments, commit messages, PR titles, and PR
+  descriptions in English.
+
+## Workflow
+
+- Inspect existing files and project conventions before editing.
+- Keep changes scoped to the requested task.
+- Prefer existing Go, Bubble Tea, and Charmbracelet patterns over introducing
+  new abstractions.
+- Run relevant validation after changes, and note any checks that could not be
+  run.
+
+## GitHub
+
+- Use English for commit messages.
+- Use English for pull request titles and descriptions.
+- Avoid destructive Git operations unless the user explicitly asks for them.


### PR DESCRIPTION
## Summary
- Add repository-level instructions for future agent work.
- Document that repository documents, code comments, commit messages, PR titles, and PR descriptions should be in English.

## Test Plan
- [x] git diff --check