### PR TITLE
Add Lefthook validation gates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/scripts/agent-go-check.sh\"",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "apply_patch|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/scripts/agent-go-check.sh\"",
+            "timeout": 120,
+            "statusMessage": "Running Go fast gate"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ profile.cov
 go.work
 go.work.sum
 
+# Local hook overrides
+lefthook-local.yml
+.claude/settings.local.json
+
 # env file
 .env
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,21 @@
 - Run relevant validation after changes, and note any checks that could not be
   run.
 
+## Validation
+
+- Use Lefthook v2.1.1 or newer.
+- Install local Git hooks with `lefthook install` after cloning.
+- Run the fast local gate with `lefthook run pre-commit` or
+  `./scripts/test-small.sh`.
+- Run the normal local gate with `lefthook run check` or `./scripts/check.sh`.
+- Run the push gate with `lefthook run pre-push`.
+- Keep large tests opt-in with `GH_ZEN_LARGE_TESTS=1 ./scripts/test-large.sh`.
+- Use small tests for deterministic model, view, and pure logic coverage.
+- Use medium tests for local integration with temporary files, fixtures, and
+  fake command boundaries.
+- Use large tests only for real external systems such as GitHub API,
+  authenticated `gh`, browser automation, or long-running end-to-end workflows.
+
 ## GitHub
 
 - Use English for commit messages.

--- a/docs/adr/0004-use-lefthook-and-sized-test-gates.md
+++ b/docs/adr/0004-use-lefthook-and-sized-test-gates.md
@@ -1,0 +1,145 @@
+# 0004: Use Lefthook and Sized Test Gates
+
+- Status: Accepted
+- Date: 2026-04-26
+
+## Context
+
+`gh-zen` is expected to grow from a small Bubble Tea application into a GitHub
+workflow tool with local UI logic, GitHub service boundaries, command execution,
+and eventually tests that may depend on real credentials or network access.
+
+The project also needs the same local quality gates to run from several entry
+points:
+
+- Git hooks before commit or push.
+- Manual developer commands.
+- Codex project hooks.
+- Claude Code project hooks.
+- CI jobs once CI is added.
+
+Duplicating `gofmt`, lint, and test commands in each tool would make the checks
+drift over time. Running every possible test after every agent edit would also
+make the coding loop slow, especially once GitHub integration tests exist.
+
+## Decision
+
+Use Lefthook v2.1.1 or newer as the repository Git hook runner, and keep the
+actual format, lint, and test commands behind scripts in `scripts/`.
+
+The scripts are the stable command boundary:
+
+- `scripts/fmt.sh` applies formatting.
+- `scripts/lint.sh` runs the local lint gate.
+- `scripts/test-small.sh` runs the fast deterministic test gate.
+- `scripts/test-medium.sh` runs the default local integration test gate.
+- `scripts/test-large.sh` runs explicitly enabled external tests.
+- `scripts/check.sh` runs the normal local developer check.
+
+Lefthook should call these scripts instead of embedding tool-specific command
+logic directly in `lefthook.yml`.
+
+Use sized test gates:
+
+- Small tests are fast, deterministic, and have no network, credentials,
+  wall-clock, terminal, browser, or GitHub API dependency. They should cover
+  pure logic, Bubble Tea update behavior, deterministic views, and fake service
+  boundaries. The command is `go test -short ./...`.
+- Medium tests may use local integration surfaces such as temporary
+  directories, temporary Git repositories, local command fakes, fixtures, and
+  Markdown rendering. They must still avoid real network access and credentials.
+  The command is `go test ./...`.
+- Large tests may use external systems, real GitHub data, authenticated `gh`
+  behavior, browser automation, or long-running end-to-end workflows. They must
+  be opt-in through both a build tag and an environment variable. The command is
+  `GH_ZEN_LARGE_TESTS=1 go test -tags=large ./...`.
+
+Medium tests that are too slow or environment-sensitive for the small gate
+should call `testing.Short()` and skip when `go test -short` is used. Large tests
+should use the `large` build tag and also require `GH_ZEN_LARGE_TESTS=1` at
+runtime.
+
+Local hook policy:
+
+- `pre-commit` runs formatting, lint, and the small test gate.
+- `pre-push` runs the medium test gate.
+- `check` runs formatting, lint, and the medium test gate.
+- `test-large` is a named Lefthook task and is never wired into normal commit or
+  push hooks.
+
+Agent hook policy:
+
+- Codex and Claude Code project hooks should share the same script boundary as
+  Lefthook.
+- Agent hooks should run only the fast gate after Go-related file edits.
+- Agent hooks should not run medium or large tests automatically after every
+  edit.
+- Agent hooks may apply targeted `gofmt` to edited Go files, then run lint and
+  the small test gate.
+
+## Consequences
+
+Positive:
+
+- Local developers, agents, and CI can reuse the same command boundary.
+- Fast edit loops stay fast because agent hooks stop at the small gate.
+- GitHub API and credential-dependent tests have a clear home without slowing
+  normal commits.
+- The project can add CI later without redesigning the local validation model.
+- Lefthook keeps Git hook configuration small and language-agnostic.
+
+Tradeoffs:
+
+- Contributors need Lefthook v2.1.1 or newer installed before Git hooks run
+  locally.
+- Agent hook behavior depends on Codex and Claude Code project hook support.
+- The small, medium, and large boundaries require discipline when new tests are
+  added.
+- `scripts/check.sh` applies formatting, so it may modify files before running
+  the rest of the validation gate.
+
+## Implementation Notes
+
+Keep scripts small and shell-based until the workflow needs richer logic. If a
+script grows enough to need structured parsing beyond simple command routing,
+move that logic into a small Go helper instead of accumulating fragile shell.
+
+When adding tests:
+
+- Default to small tests for model updates, view rendering, reducers, and pure
+  functions.
+- Use medium tests for local integration with temporary directories, fixtures,
+  and fake command boundaries.
+- Use large tests only when real external behavior is the point of the test.
+- Do not let large tests run unless `GH_ZEN_LARGE_TESTS=1` is set.
+
+When adding new tools:
+
+- Add or update a script in `scripts/` first.
+- Wire Lefthook, Codex, Claude Code, and CI to that script.
+- Avoid copying the same command sequence into multiple tool-specific config
+  files.
+
+## Alternatives Considered
+
+- Python `pre-commit`: mature and widely used, but it introduces a Python-based
+  hook manager into a Go repository and does not remove the need for separate
+  agent hook wiring.
+- Raw Git hooks: minimal dependencies, but hook scripts would live under
+  `.git/hooks` unless manually copied, making them hard to review and share.
+- Running `go test ./...` after every agent edit: simple, but likely too slow
+  once medium integration tests are added.
+- Running large tests by default: too risky because they may require credentials,
+  network access, or mutable external state.
+
+## Maintenance Notes
+
+This ADR should be revisited when:
+
+- CI adopts a different test taxonomy.
+- Lefthook is removed or replaced.
+- Agent hooks become too slow or unreliable for normal development.
+- Large tests become safe enough to run automatically in a dedicated CI job.
+
+If the local validation strategy changes materially, add a new ADR and mark this
+one as `Superseded` instead of rewriting this decision in place.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,7 @@ trustworthy.
 - [0001: Use Charmbracelet Libraries as the TUI Foundation](0001-use-charmbracelet-libraries-as-the-tui-foundation.md)
 - [0002: Keep UI Copy in English and Support Unicode Input](0002-keep-ui-copy-in-english-and-support-unicode-input.md)
 - [0003: Use Yazi-Inspired Object Navigation and Previews](0003-use-yazi-inspired-object-navigation-and-previews.md)
+- [0004: Use Lefthook and Sized Test Gates](0004-use-lefthook-and-sized-test-gates.md)
 
 ## Status Values
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,43 @@
+pre-commit:
+  parallel: false
+  jobs:
+    - name: gofmt
+      glob: "*.go"
+      run: ./scripts/fmt.sh {staged_files}
+      stage_fixed: true
+
+    - name: lint
+      run: ./scripts/lint.sh
+
+    - name: test-small
+      run: ./scripts/test-small.sh
+
+pre-push:
+  jobs:
+    - name: test-medium
+      files: git ls-files
+      run: ./scripts/test-medium.sh {files}
+
+check:
+  jobs:
+    - name: format
+      run: ./scripts/fmt.sh
+
+    - name: lint
+      run: ./scripts/lint.sh
+
+    - name: test-medium
+      run: ./scripts/test-medium.sh
+
+agent-check:
+  jobs:
+    - name: lint
+      run: ./scripts/lint.sh
+
+    - name: test-small
+      run: ./scripts/test-small.sh
+
+test-large:
+  jobs:
+    - name: test-large
+      run: ./scripts/test-large.sh

--- a/scripts/agent-go-check.sh
+++ b/scripts/agent-go-check.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$repo_root"
+
+if ! command -v jq >/dev/null 2>&1; then
+	echo "jq is not installed; running the Go fast gate without targeted formatting." >&2
+	./scripts/lint.sh
+	./scripts/test-small.sh
+	exit 0
+fi
+
+hook_input=$(mktemp)
+changed_paths=$(mktemp)
+trap 'rm -f "$hook_input" "$changed_paths"' EXIT
+
+cat > "$hook_input"
+
+jq -r '
+	[
+		.. | strings | scan("[A-Za-z0-9_./-]+\\.go|[A-Za-z0-9_./-]*go\\.mod|[A-Za-z0-9_./-]*go\\.sum")
+	]
+	| unique
+	| .[]
+' "$hook_input" > "$changed_paths" 2>/dev/null || exit 0
+
+if [ ! -s "$changed_paths" ]; then
+	exit 0
+fi
+
+relevant=0
+
+while IFS= read -r path; do
+	case "$path" in
+		/*)
+			case "$path" in
+				"$repo_root"/*)
+					clean_path=${path#"$repo_root"/}
+					;;
+				*)
+					continue
+					;;
+			esac
+			;;
+		*)
+			clean_path=${path#./}
+			;;
+	esac
+
+	case "$clean_path" in
+		*.go)
+			if [ -f "$clean_path" ]; then
+				./scripts/fmt.sh "$clean_path"
+				relevant=1
+			fi
+			;;
+		go.mod | go.sum | */go.mod | */go.sum)
+			if [ -f "$clean_path" ]; then
+				relevant=1
+			fi
+			;;
+	esac
+done < "$changed_paths"
+
+if [ "$relevant" -ne 1 ]; then
+	exit 0
+fi
+
+if command -v lefthook >/dev/null 2>&1; then
+	lefthook run agent-check
+else
+	./scripts/lint.sh
+	./scripts/test-small.sh
+fi

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -eu
+
+./scripts/fmt.sh
+./scripts/lint.sh
+./scripts/test-medium.sh

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$#" -gt 0 ]; then
+	for path in "$@"; do
+		case "$path" in
+			*.go)
+				if [ -f "$path" ]; then
+					gofmt -w "$path"
+				fi
+				;;
+		esac
+	done
+	exit 0
+fi
+
+find . \
+	-name '*.go' \
+	-not -path './.git/*' \
+	-not -path './vendor/*' \
+	-exec gofmt -w {} +

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+go vet ./...

--- a/scripts/test-large.sh
+++ b/scripts/test-large.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "${GH_ZEN_LARGE_TESTS:-}" != "1" ]; then
+	echo "Large tests are opt-in. Run with GH_ZEN_LARGE_TESTS=1." >&2
+	exit 1
+fi
+
+go test -tags=large ./...

--- a/scripts/test-medium.sh
+++ b/scripts/test-medium.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+go test ./...

--- a/scripts/test-small.sh
+++ b/scripts/test-small.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+go test -short ./...


### PR DESCRIPTION
## Summary
- Add ADR 0004 for Lefthook-based local validation and small/medium/large test gates.
- Add shared validation scripts and Lefthook hooks for pre-commit, pre-push, agent-check, and opt-in large tests.
- Add Codex and Claude Code project hooks that run the fast Go gate after Go-related edits.

## Test Plan
- [x] `sh -n scripts/*.sh`
- [x] `jq empty .codex/hooks.json .claude/settings.json`
- [x] `./scripts/check.sh`
- [x] `go run github.com/evilmartians/lefthook/v2@v2.1.1 validate`
- [x] `go run github.com/evilmartians/lefthook/v2@v2.1.1 run agent-check`
- [x] `go run github.com/evilmartians/lefthook/v2@v2.1.1 run pre-push`
