### PR TITLE
Add fake repository workbench shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  small:
+    name: Format, lint, and small tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check formatting
+        run: ./scripts/fmt-check.sh
+
+      - name: Run lint
+        run: ./scripts/lint.sh
+
+      - name: Run small tests
+        run: ./scripts/test-small.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,41 @@ jobs:
 
       - name: Run small tests
         run: ./scripts/test-small.sh
+
+  medium:
+    name: Medium tests
+    runs-on: ubuntu-latest
+    needs: small
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run medium tests
+        run: ./scripts/test-medium.sh
+
+  large:
+    name: Large tests
+    runs-on: ubuntu-latest
+    needs: medium
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    env:
+      GH_ZEN_LARGE_TESTS: "1"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run large tests
+        run: ./scripts/test-large.sh

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ help:
 	@printf '  %-18s %s\n' 'install-extension' 'Build and install this checkout as a local gh extension'
 	@printf '  %-18s %s\n' 'run-extension' 'Run the installed gh extension'
 	@printf '  %-18s %s\n' 'fmt' 'Format source files'
+	@printf '  %-18s %s\n' 'fmt-check' 'Check source formatting'
 	@printf '  %-18s %s\n' 'lint' 'Run lint checks'
 	@printf '  %-18s %s\n' 'test-small' 'Run the fast deterministic test gate'
 	@printf '  %-18s %s\n' 'test-medium' 'Run the default local integration test gate'
@@ -38,6 +39,10 @@ run-extension:
 .PHONY: fmt
 fmt:
 	./scripts/fmt.sh
+
+.PHONY: fmt-check
+fmt-check:
+	./scripts/fmt-check.sh
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gh-zen
 
+[![CI](https://github.com/0maru/gh-zen/actions/workflows/ci.yml/badge.svg)](https://github.com/0maru/gh-zen/actions/workflows/ci.yml)
+
 `gh-zen` is a GitHub CLI extension for focused terminal GitHub workflows.
 
 ## Development

--- a/docs/adr/0004-use-lefthook-and-sized-test-gates.md
+++ b/docs/adr/0004-use-lefthook-and-sized-test-gates.md
@@ -33,6 +33,7 @@ The scripts are the stable command boundary:
 
 - `scripts/build.sh` builds the local GitHub CLI extension binary.
 - `scripts/fmt.sh` applies formatting.
+- `scripts/fmt-check.sh` verifies formatting without modifying files.
 - `scripts/lint.sh` runs the local lint gate.
 - `scripts/test-small.sh` runs the fast deterministic test gate.
 - `scripts/test-medium.sh` runs the default local integration test gate.
@@ -73,6 +74,13 @@ Local hook policy:
 - `check` runs formatting, lint, and the medium test gate.
 - `test-large` is a named Lefthook task and is never wired into normal commit or
   push hooks.
+
+CI policy:
+
+- Pull request CI runs formatting check, lint, and the small test gate.
+- Pull request CI should not run medium or large tests by default.
+- Main branch CI may start with the same small gate and can add medium jobs once
+  the medium suite contains meaningful local integration coverage.
 
 Agent hook policy:
 

--- a/docs/adr/0004-use-lefthook-and-sized-test-gates.md
+++ b/docs/adr/0004-use-lefthook-and-sized-test-gates.md
@@ -79,8 +79,8 @@ CI policy:
 
 - Pull request CI runs formatting check, lint, and the small test gate.
 - Pull request CI should not run medium or large tests by default.
-- Main branch CI may start with the same small gate and can add medium jobs once
-  the medium suite contains meaningful local integration coverage.
+- Main branch CI runs the same small gate, then medium tests, then the opt-in
+  large test gate with `GH_ZEN_LARGE_TESTS=1`.
 
 Agent hook policy:
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/muesli/termenv v0.16.0
 )
 
@@ -15,7 +16,6 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/glamour v1.0.0 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -5,11 +5,22 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/0maru/gh-zen/internal/workbench"
 )
 
-const defaultWidth = 100
+const (
+	defaultWidth        = 100
+	repoPaneWidth       = 23
+	workItemPaneWidth   = 39
+	paneGapWidth        = 2
+	previewPaneMinWidth = 28
+	dividerMaxWidth     = 72
+	compactDividerWidth = 48
+	fullLayoutMinWidth  = repoPaneWidth + workItemPaneWidth + paneGapWidth*2 + previewPaneMinWidth
+)
 
 type model struct {
 	width        int
@@ -83,32 +94,26 @@ func (m model) View() string {
 		width = defaultWidth
 	}
 
-	if width < 94 {
+	if width < fullLayoutMinWidth {
 		return m.renderCompact(width)
 	}
 	return m.renderFull(width)
 }
 
 func (m model) renderFull(width int) string {
-	leftWidth := 23
-	middleWidth := 39
-	gapWidth := 2
-	rightWidth := width - leftWidth - middleWidth - gapWidth*2
-	if rightWidth < 28 {
-		rightWidth = 28
-	}
+	rightWidth := width - repoPaneWidth - workItemPaneWidth - paneGapWidth*2
 
-	left := m.repoLines(leftWidth)
-	middle := m.workItemLines(middleWidth)
+	left := m.repoLines(repoPaneWidth)
+	middle := m.workItemLines(workItemPaneWidth)
 	right := m.previewLines(rightWidth)
-	lines := maxInt(len(left), maxInt(len(middle), len(right)))
+	lines := max(len(left), max(len(middle), len(right)))
 
 	out := []string{
 		"gh-zen  repository workbench",
-		strings.Repeat("-", minInt(width, 72)),
+		strings.Repeat("-", min(width, dividerMaxWidth)),
 	}
 	for i := 0; i < lines; i++ {
-		row := pad(lineAt(left, i), leftWidth) + strings.Repeat(" ", gapWidth) + pad(lineAt(middle, i), middleWidth) + strings.Repeat(" ", gapWidth) + pad(lineAt(right, i), rightWidth)
+		row := pad(lineAt(left, i), repoPaneWidth) + strings.Repeat(" ", paneGapWidth) + pad(lineAt(middle, i), workItemPaneWidth) + strings.Repeat(" ", paneGapWidth) + pad(lineAt(right, i), rightWidth)
 		out = append(out, strings.TrimRight(row, " "))
 	}
 	out = append(out, "", "j/k move  g/G jump  q quit")
@@ -118,7 +123,7 @@ func (m model) renderFull(width int) string {
 func (m model) renderCompact(width int) string {
 	lines := []string{
 		"gh-zen workbench",
-		strings.Repeat("-", minInt(width, 48)),
+		strings.Repeat("-", min(width, compactDividerWidth)),
 	}
 	lines = append(lines, m.workItemLines(width)...)
 	lines = append(lines, "")
@@ -182,6 +187,9 @@ func (m model) previewLines(width int) []string {
 	lines = append(lines, truncate("Local: "+item.LocalLabel(), width))
 	lines = append(lines, truncate("Issue: "+item.IssueLabel(), width))
 	lines = append(lines, truncate("PR: "+item.PullRequestLabel(), width))
+	if item.PullRequest != nil && item.PullRequest.ReviewState != "" {
+		lines = append(lines, truncate("Review: "+item.PullRequest.ReviewState, width))
+	}
 	lines = append(lines, truncate("Checks: "+item.Checks.Label(), width))
 	if len(item.Commits) > 0 {
 		lines = append(lines, "Commits:")
@@ -201,13 +209,19 @@ func (m model) selectedWorkItem() (workbench.WorkItem, bool) {
 
 func shortRemoteLabel(item workbench.WorkItem) string {
 	if item.PullRequest != nil {
+		if item.PullRequest.Number == 0 {
+			return "PR"
+		}
 		return fmt.Sprintf("PR #%d", item.PullRequest.Number)
+	}
+	if item.Issue != nil {
+		if item.Issue.Number == 0 {
+			return "issue"
+		}
+		return fmt.Sprintf("#%d", item.Issue.Number)
 	}
 	if item.Branch != nil && item.Branch.RemoteOnly {
 		return "remote"
-	}
-	if item.Issue != nil && item.Branch == nil {
-		return fmt.Sprintf("#%d", item.Issue.Number)
 	}
 	return "no PR"
 }
@@ -221,36 +235,19 @@ func lineAt(lines []string, i int) string {
 
 func pad(s string, width int) string {
 	s = truncate(s, width)
-	if len(s) >= width {
+	padWidth := width - lipgloss.Width(s)
+	if padWidth <= 0 {
 		return s
 	}
-	return s + strings.Repeat(" ", width-len(s))
+	return s + strings.Repeat(" ", padWidth)
 }
 
 func truncate(s string, width int) string {
 	if width <= 0 {
 		return ""
 	}
-	runes := []rune(s)
-	if len(runes) <= width {
+	if lipgloss.Width(s) <= width {
 		return s
 	}
-	if width == 1 {
-		return string(runes[:1])
-	}
-	return string(runes[:width-1]) + "~"
-}
-
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
+	return ansi.Truncate(s, width, "~")
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1,24 +1,34 @@
 package app
 
 import (
+	"fmt"
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
+
+	"github.com/0maru/gh-zen/internal/workbench"
 )
 
-const banner = `
-     ╱|、
-    (˚ˎ。7       g h - z e n
-    |、˜\
-    じしˍ,)ノ
-`
+const defaultWidth = 100
 
 type model struct {
-	width  int
-	height int
+	width        int
+	height       int
+	repos        []workbench.RepoRef
+	selectedRepo int
+	workItems    []workbench.WorkItem
+	selectedItem int
 }
 
 func New() tea.Model {
-	return model{}
+	return newModel()
+}
+
+func newModel() model {
+	return model{
+		repos:     workbench.FakeRepos(),
+		workItems: workbench.FakeWorkItems(),
+	}
 }
 
 func (m model) Init() tea.Cmd { return nil }
@@ -33,13 +43,214 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "q", "ctrl+c", "esc":
 			return m, tea.Quit
+		case "j", "down":
+			m.moveSelection(1)
+			return m, nil
+		case "k", "up":
+			m.moveSelection(-1)
+			return m, nil
+		case "g":
+			m.selectedItem = 0
+			return m, nil
+		case "G":
+			if len(m.workItems) > 0 {
+				m.selectedItem = len(m.workItems) - 1
+			}
+			return m, nil
 		}
 	}
 	return m, nil
 }
 
+func (m *model) moveSelection(delta int) {
+	if len(m.workItems) == 0 {
+		m.selectedItem = 0
+		return
+	}
+
+	m.selectedItem += delta
+	if m.selectedItem < 0 {
+		m.selectedItem = 0
+	}
+	if m.selectedItem >= len(m.workItems) {
+		m.selectedItem = len(m.workItems) - 1
+	}
+}
+
 func (m model) View() string {
-	title := lipgloss.NewStyle().Foreground(lipgloss.Color("99")).Bold(true).Render(banner)
-	hint := lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("  press q to quit")
-	return title + "\n" + hint + "\n"
+	width := m.width
+	if width <= 0 {
+		width = defaultWidth
+	}
+
+	if width < 94 {
+		return m.renderCompact(width)
+	}
+	return m.renderFull(width)
+}
+
+func (m model) renderFull(width int) string {
+	leftWidth := 23
+	middleWidth := 39
+	gapWidth := 2
+	rightWidth := width - leftWidth - middleWidth - gapWidth*2
+	if rightWidth < 28 {
+		rightWidth = 28
+	}
+
+	left := m.repoLines(leftWidth)
+	middle := m.workItemLines(middleWidth)
+	right := m.previewLines(rightWidth)
+	lines := maxInt(len(left), maxInt(len(middle), len(right)))
+
+	out := []string{
+		"gh-zen  repository workbench",
+		strings.Repeat("-", minInt(width, 72)),
+	}
+	for i := 0; i < lines; i++ {
+		row := pad(lineAt(left, i), leftWidth) + strings.Repeat(" ", gapWidth) + pad(lineAt(middle, i), middleWidth) + strings.Repeat(" ", gapWidth) + pad(lineAt(right, i), rightWidth)
+		out = append(out, strings.TrimRight(row, " "))
+	}
+	out = append(out, "", "j/k move  g/G jump  q quit")
+	return strings.Join(out, "\n") + "\n"
+}
+
+func (m model) renderCompact(width int) string {
+	lines := []string{
+		"gh-zen workbench",
+		strings.Repeat("-", minInt(width, 48)),
+	}
+	lines = append(lines, m.workItemLines(width)...)
+	lines = append(lines, "")
+	lines = append(lines, m.previewLines(width)...)
+	lines = append(lines, "", "j/k move  q quit")
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func (m model) repoLines(width int) []string {
+	lines := []string{"Repositories"}
+	if len(m.repos) == 0 {
+		lines = append(lines, "  none")
+	} else {
+		for i, repo := range m.repos {
+			marker := " "
+			if i == m.selectedRepo {
+				marker = ">"
+			}
+			lines = append(lines, truncate(fmt.Sprintf("%s %s", marker, repo.FullName()), width))
+		}
+	}
+	lines = append(lines, "", "Views", "  Active worktrees", "  Review requested", "  Failed checks")
+	return lines
+}
+
+func (m model) workItemLines(width int) []string {
+	lines := []string{"Work Items"}
+	if len(m.workItems) == 0 {
+		return append(lines, "  no work items")
+	}
+	for i, item := range m.workItems {
+		marker := " "
+		if i == m.selectedItem {
+			marker = ">"
+		}
+		row := fmt.Sprintf("%s %-22s %-7s %s", marker, item.Title(), item.LocalLabel(), shortRemoteLabel(item))
+		lines = append(lines, truncate(row, width))
+	}
+	return lines
+}
+
+func (m model) previewLines(width int) []string {
+	item, ok := m.selectedWorkItem()
+	if !ok {
+		return []string{"Preview", "  no work item selected"}
+	}
+
+	lines := []string{
+		"Preview",
+		truncate("Repo: "+item.Repo.FullName(), width),
+		truncate("Item: "+item.Title(), width),
+		truncate("Where: "+item.Location(), width),
+	}
+	if item.Branch != nil {
+		base := item.Branch.Base
+		if base == "" {
+			base = "unknown base"
+		}
+		lines = append(lines, truncate("Branch: "+item.Branch.Name+" -> "+base, width))
+	}
+	lines = append(lines, truncate("Local: "+item.LocalLabel(), width))
+	lines = append(lines, truncate("Issue: "+item.IssueLabel(), width))
+	lines = append(lines, truncate("PR: "+item.PullRequestLabel(), width))
+	lines = append(lines, truncate("Checks: "+item.Checks.Label(), width))
+	if len(item.Commits) > 0 {
+		lines = append(lines, "Commits:")
+		for _, commit := range item.Commits {
+			lines = append(lines, truncate("  "+commit.ShortSHA+" "+commit.Subject, width))
+		}
+	}
+	return lines
+}
+
+func (m model) selectedWorkItem() (workbench.WorkItem, bool) {
+	if len(m.workItems) == 0 || m.selectedItem < 0 || m.selectedItem >= len(m.workItems) {
+		return workbench.WorkItem{}, false
+	}
+	return m.workItems[m.selectedItem], true
+}
+
+func shortRemoteLabel(item workbench.WorkItem) string {
+	if item.PullRequest != nil {
+		return fmt.Sprintf("PR #%d", item.PullRequest.Number)
+	}
+	if item.Branch != nil && item.Branch.RemoteOnly {
+		return "remote"
+	}
+	if item.Issue != nil && item.Branch == nil {
+		return fmt.Sprintf("#%d", item.Issue.Number)
+	}
+	return "no PR"
+}
+
+func lineAt(lines []string, i int) string {
+	if i < 0 || i >= len(lines) {
+		return ""
+	}
+	return lines[i]
+}
+
+func pad(s string, width int) string {
+	s = truncate(s, width)
+	if len(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}
+
+func truncate(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= width {
+		return s
+	}
+	if width == 1 {
+		return string(runes[:1])
+	}
+	return string(runes[:width-1]) + "~"
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"reflect"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -39,8 +40,21 @@ func TestUpdate_NonQuitKey_NoCommand(t *testing.T) {
 	if cmd != nil {
 		t.Fatalf("expected nil cmd for non-quit key, got %T", cmd)
 	}
-	if got != (model{}) {
+	if !reflect.DeepEqual(got, model{}) {
 		t.Fatalf("expected model unchanged, got %+v", got)
+	}
+}
+
+func TestNew_LoadsFakeWorkbenchData(t *testing.T) {
+	got, ok := New().(model)
+	if !ok {
+		t.Fatalf("expected model from New")
+	}
+	if len(got.repos) == 0 {
+		t.Fatalf("expected fake repositories")
+	}
+	if len(got.workItems) == 0 {
+		t.Fatalf("expected fake work items")
 	}
 }
 
@@ -55,6 +69,56 @@ func TestUpdate_WindowSizeMsg_StoresDimensions(t *testing.T) {
 	}
 	if mm.width != 40 || mm.height != 24 {
 		t.Fatalf("expected width=40 height=24, got width=%d height=%d", mm.width, mm.height)
+	}
+}
+
+func TestUpdate_MoveSelection(t *testing.T) {
+	start := newModel()
+	if start.selectedItem != 0 {
+		t.Fatalf("expected initial selection at 0, got %d", start.selectedItem)
+	}
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for movement, got %T", cmd)
+	}
+	mm := got.(model)
+	if mm.selectedItem != 1 {
+		t.Fatalf("expected j to move selection to 1, got %d", mm.selectedItem)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	mm = got.(model)
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected k to move selection back to 0, got %d", mm.selectedItem)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+	mm = got.(model)
+	if mm.selectedItem != len(mm.workItems)-1 {
+		t.Fatalf("expected G to move selection to end, got %d", mm.selectedItem)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+	mm = got.(model)
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected g to move selection to start, got %d", mm.selectedItem)
+	}
+}
+
+func TestUpdate_MoveSelection_ClampsAtEdges(t *testing.T) {
+	start := newModel()
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	mm := got.(model)
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected selection to stay at start, got %d", mm.selectedItem)
+	}
+
+	mm.selectedItem = len(mm.workItems) - 1
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	mm = got.(model)
+	if mm.selectedItem != len(mm.workItems)-1 {
+		t.Fatalf("expected selection to stay at end, got %d", mm.selectedItem)
 	}
 }
 

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/0maru/gh-zen/internal/workbench"
 )
 
 func TestInit_ReturnsNilCmd(t *testing.T) {
@@ -36,11 +39,12 @@ func TestUpdate_QuitOnQuitKeys(t *testing.T) {
 }
 
 func TestUpdate_NonQuitKey_NoCommand(t *testing.T) {
-	got, cmd := (model{}).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	start := newModel()
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	if cmd != nil {
 		t.Fatalf("expected nil cmd for non-quit key, got %T", cmd)
 	}
-	if !reflect.DeepEqual(got, model{}) {
+	if !reflect.DeepEqual(got, start) {
 		t.Fatalf("expected model unchanged, got %+v", got)
 	}
 }
@@ -138,5 +142,32 @@ func TestUpdate_UnicodeRunes_NoQuit(t *testing.T) {
 				t.Fatalf("expected nil cmd for non-quit unicode key, got %T (%v)", cmd, cmd())
 			}
 		})
+	}
+}
+
+func TestPad_UsesTerminalDisplayWidth(t *testing.T) {
+	got := pad("日本", 6)
+	if width := lipgloss.Width(got); width != 6 {
+		t.Fatalf("expected display width 6, got %d for %q", width, got)
+	}
+}
+
+func TestTruncate_UsesTerminalDisplayWidth(t *testing.T) {
+	got := truncate("日本語", 5)
+	if width := lipgloss.Width(got); width > 5 {
+		t.Fatalf("expected display width at most 5, got %d for %q", width, got)
+	}
+	if got != "日本~" {
+		t.Fatalf("expected wide text to truncate with tail, got %q", got)
+	}
+}
+
+func TestShortRemoteLabel_ShowsIssueNumberWhenBranchHasNoPullRequest(t *testing.T) {
+	item := workbench.WorkItem{
+		Branch: &workbench.BranchRef{Name: "feat/issue-linked-work"},
+		Issue:  &workbench.IssueRef{Number: 34, Title: "Branch preview UX", Certain: true},
+	}
+	if got := shortRemoteLabel(item); got != "#34" {
+		t.Fatalf("expected issue number for branch without PR, got %q", got)
 	}
 }

--- a/internal/app/testdata/TestView_Initial.golden
+++ b/internal/app/testdata/TestView_Initial.golden
@@ -3,8 +3,8 @@ gh-zen  repository workbench
 Repositories             Work Items                               Preview
 > 0maru/gh-zen           > main                   clean   no PR   Repo: 0maru/gh-zen
   0maru/dotfiles           feat/config-loader     dirty   PR #24  Item: main
-                           feat/repo-workbench    clean   no PR   Where: ~/workspaces/github.com/0m~
-Views                      agent/preview-state    missing remote  Branch: main -> origin/main
+                           feat/repo-workbench    clean   #6      Where: ~/workspaces/github.com/0m~
+Views                      agent/preview-state    missing #8      Branch: main -> origin/main
   Active worktrees         #34 Branch preview UX  unknown #34     Local: clean
   Review requested                                                Issue: no issue
   Failed checks                                                   PR: no PR

--- a/internal/app/testdata/TestView_Initial.golden
+++ b/internal/app/testdata/TestView_Initial.golden
@@ -1,7 +1,15 @@
-                            
-     ╱|、                   
-    (˚ˎ。7       g h - z e n
-    |、˜\                   
-    じしˍ,)ノ               
-                            
-  press q to quit
+gh-zen  repository workbench
+------------------------------------------------------------------------
+Repositories             Work Items                               Preview
+> 0maru/gh-zen           > main                   clean   no PR   Repo: 0maru/gh-zen
+  0maru/dotfiles           feat/config-loader     dirty   PR #24  Item: main
+                           feat/repo-workbench    clean   no PR   Where: ~/workspaces/github.com/0m~
+Views                      agent/preview-state    missing remote  Branch: main -> origin/main
+  Active worktrees         #34 Branch preview UX  unknown #34     Local: clean
+  Review requested                                                Issue: no issue
+  Failed checks                                                   PR: no PR
+                                                                  Checks: checks passing
+                                                                  Commits:
+                                                                    3da43e7 Set up GitHub CLI exten~
+
+j/k move  g/G jump  q quit

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 var update = flag.Bool("update", false, "update golden files")
@@ -36,5 +38,34 @@ func requireEqualGolden(t *testing.T, got []byte) {
 }
 
 func TestView_Initial(t *testing.T) {
-	requireEqualGolden(t, []byte((model{}).View()))
+	requireEqualGolden(t, []byte(newModel().View()))
+}
+
+func TestView_Compact_HidesRepositoryPane(t *testing.T) {
+	m := newModel()
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 50, Height: 20})
+	got := updated.(model).View()
+	if bytes.Contains([]byte(got), []byte("Repositories")) {
+		t.Fatalf("expected compact view to hide repository pane, got:\n%s", got)
+	}
+	if !bytes.Contains([]byte(got), []byte("Work Items")) || !bytes.Contains([]byte(got), []byte("Preview")) {
+		t.Fatalf("expected compact view to keep list and preview, got:\n%s", got)
+	}
+}
+
+func TestView_SelectedItemChangesPreview(t *testing.T) {
+	m := newModel()
+	initial := m.View()
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	next := updated.(model).View()
+
+	if initial == next {
+		t.Fatalf("expected preview to change after moving selection")
+	}
+	if !bytes.Contains([]byte(next), []byte("feat/config-loader")) {
+		t.Fatalf("expected moved preview to include selected branch, got:\n%s", next)
+	}
+	if !bytes.Contains([]byte(next), []byte("PR #24 open")) {
+		t.Fatalf("expected moved preview to include linked PR, got:\n%s", next)
+	}
 }

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -68,4 +68,7 @@ func TestView_SelectedItemChangesPreview(t *testing.T) {
 	if !bytes.Contains([]byte(next), []byte("PR #24 open")) {
 		t.Fatalf("expected moved preview to include linked PR, got:\n%s", next)
 	}
+	if !bytes.Contains([]byte(next), []byte("Review: review requested")) {
+		t.Fatalf("expected moved preview to include review state, got:\n%s", next)
+	}
 }

--- a/internal/workbench/fixtures.go
+++ b/internal/workbench/fixtures.go
@@ -1,0 +1,72 @@
+package workbench
+
+func FakeRepos() []RepoRef {
+	return []RepoRef{
+		{Owner: "0maru", Name: "gh-zen"},
+		{Owner: "0maru", Name: "dotfiles"},
+	}
+}
+
+func FakeWorkItems() []WorkItem {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	return []WorkItem{
+		{
+			ID:       "worktree-main",
+			Repo:     repo,
+			Branch:   &BranchRef{Name: "main", Base: "origin/main"},
+			Worktree: &WorktreeRef{Path: "~/workspaces/github.com/0maru/gh-zen"},
+			Checks:   CheckSummary{State: CheckPassing, Passing: 3},
+			Local:    &LocalStatus{State: LocalClean},
+			Commits: []CommitRef{
+				{ShortSHA: "3da43e7", Subject: "Set up GitHub CLI extension foundation"},
+			},
+		},
+		{
+			ID:       "worktree-config-loader",
+			Repo:     repo,
+			Branch:   &BranchRef{Name: "feat/config-loader", Base: "main"},
+			Worktree: &WorktreeRef{Path: "~/workspaces/github.com/0maru/gh-zen-agent-a"},
+			Issue:    &IssueRef{Number: 9, Title: "Implement layered config model and merge rules", State: "open", URL: "https://github.com/0maru/gh-zen/issues/9", Certain: true},
+			PullRequest: &PullRequestRef{
+				Number:      24,
+				Title:       "Add layered config model",
+				State:       "open",
+				URL:         "https://github.com/0maru/gh-zen/pull/24",
+				ReviewState: "review requested",
+			},
+			Checks: CheckSummary{State: CheckFailing, Passing: 2, Failing: 1},
+			Local:  &LocalStatus{State: LocalDirty, Summary: "3 files changed"},
+			Commits: []CommitRef{
+				{ShortSHA: "a1b2c3d", Subject: "Add config defaults"},
+				{ShortSHA: "b2c3d4e", Subject: "Test merge precedence"},
+			},
+		},
+		{
+			ID:       "worktree-repo-workbench",
+			Repo:     repo,
+			Branch:   &BranchRef{Name: "feat/repo-workbench", Base: "main"},
+			Worktree: &WorktreeRef{Path: "~/workspaces/github.com/0maru/gh-zen-agent-b"},
+			Issue:    &IssueRef{Number: 6, Title: "Build fake Repository Workbench shell", State: "open", URL: "https://github.com/0maru/gh-zen/issues/6", Certain: true},
+			Checks:   CheckSummary{State: CheckPending, Pending: 2},
+			Local:    &LocalStatus{State: LocalClean},
+			Commits: []CommitRef{
+				{ShortSHA: "c3d4e5f", Subject: "Render work item list"},
+			},
+		},
+		{
+			ID:     "remote-preview-state",
+			Repo:   repo,
+			Branch: &BranchRef{Name: "agent/preview-state", Base: "main", RemoteOnly: true},
+			Issue:  &IssueRef{Number: 8, Title: "Add asynchronous preview state machine", State: "open", URL: "https://github.com/0maru/gh-zen/issues/8", Certain: true},
+			Checks: CheckSummary{State: CheckUnknown},
+			Local:  &LocalStatus{State: LocalMissing, Summary: "no local worktree"},
+		},
+		{
+			ID:     "issue-branch-preview-ux",
+			Repo:   repo,
+			Issue:  &IssueRef{Number: 34, Title: "Branch preview UX", State: "open", URL: "https://github.com/0maru/gh-zen/issues/34", Certain: false},
+			Checks: CheckSummary{State: CheckUnknown},
+			Local:  &LocalStatus{State: LocalUnknown, Summary: "unstarted"},
+		},
+	}
+}

--- a/internal/workbench/types.go
+++ b/internal/workbench/types.go
@@ -55,13 +55,18 @@ type PullRequestRef struct {
 }
 
 func (p PullRequestRef) Label() string {
+	label := p.NumberLabel()
+	if p.Title == "" {
+		return label
+	}
+	return fmt.Sprintf("%s %s", label, p.Title)
+}
+
+func (p PullRequestRef) NumberLabel() string {
 	if p.Number == 0 {
 		return "PR"
 	}
-	if p.Title == "" {
-		return fmt.Sprintf("PR #%d", p.Number)
-	}
-	return fmt.Sprintf("PR #%d %s", p.Number, p.Title)
+	return fmt.Sprintf("PR #%d", p.Number)
 }
 
 type CheckState string
@@ -182,12 +187,20 @@ func (w WorkItem) PullRequestLabel() string {
 	if w.PullRequest == nil {
 		return "no PR"
 	}
-	return fmt.Sprintf("PR #%d %s", w.PullRequest.Number, w.PullRequest.State)
+	label := w.PullRequest.NumberLabel()
+	if w.PullRequest.State == "" {
+		return label
+	}
+	return fmt.Sprintf("%s %s", label, w.PullRequest.State)
 }
 
 func (w WorkItem) IssueLabel() string {
 	if w.Issue == nil {
 		return "no issue"
 	}
-	return w.Issue.Label()
+	label := w.Issue.Label()
+	if !w.Issue.Certain {
+		return fmt.Sprintf("%s (uncertain)", label)
+	}
+	return label
 }

--- a/internal/workbench/types.go
+++ b/internal/workbench/types.go
@@ -1,0 +1,193 @@
+package workbench
+
+import "fmt"
+
+type RepoRef struct {
+	Owner string
+	Name  string
+}
+
+func (r RepoRef) FullName() string {
+	switch {
+	case r.Owner != "" && r.Name != "":
+		return r.Owner + "/" + r.Name
+	case r.Name != "":
+		return r.Name
+	default:
+		return "unknown repo"
+	}
+}
+
+type BranchRef struct {
+	Name       string
+	Base       string
+	RemoteOnly bool
+}
+
+type WorktreeRef struct {
+	Path string
+}
+
+type IssueRef struct {
+	Number  int
+	Title   string
+	State   string
+	URL     string
+	Certain bool
+}
+
+func (i IssueRef) Label() string {
+	if i.Number == 0 {
+		return "issue"
+	}
+	if i.Title == "" {
+		return fmt.Sprintf("#%d", i.Number)
+	}
+	return fmt.Sprintf("#%d %s", i.Number, i.Title)
+}
+
+type PullRequestRef struct {
+	Number      int
+	Title       string
+	State       string
+	URL         string
+	ReviewState string
+}
+
+func (p PullRequestRef) Label() string {
+	if p.Number == 0 {
+		return "PR"
+	}
+	if p.Title == "" {
+		return fmt.Sprintf("PR #%d", p.Number)
+	}
+	return fmt.Sprintf("PR #%d %s", p.Number, p.Title)
+}
+
+type CheckState string
+
+const (
+	CheckUnknown CheckState = "unknown"
+	CheckPassing CheckState = "passing"
+	CheckFailing CheckState = "failing"
+	CheckPending CheckState = "pending"
+)
+
+type CheckSummary struct {
+	State   CheckState
+	Passing int
+	Failing int
+	Pending int
+}
+
+func (c CheckSummary) Label() string {
+	switch c.State {
+	case CheckPassing:
+		return "checks passing"
+	case CheckFailing:
+		if c.Failing > 0 {
+			return fmt.Sprintf("checks failing (%d)", c.Failing)
+		}
+		return "checks failing"
+	case CheckPending:
+		if c.Pending > 0 {
+			return fmt.Sprintf("checks pending (%d)", c.Pending)
+		}
+		return "checks pending"
+	default:
+		return "checks unknown"
+	}
+}
+
+type LocalState string
+
+const (
+	LocalUnknown  LocalState = "unknown"
+	LocalClean    LocalState = "clean"
+	LocalDirty    LocalState = "dirty"
+	LocalDetached LocalState = "detached"
+	LocalMissing  LocalState = "missing"
+)
+
+type LocalStatus struct {
+	State   LocalState
+	Summary string
+}
+
+func (s LocalStatus) Label() string {
+	if s.Summary != "" {
+		return fmt.Sprintf("%s, %s", s.StateLabel(), s.Summary)
+	}
+	return s.StateLabel()
+}
+
+func (s LocalStatus) StateLabel() string {
+	if s.State == "" {
+		return string(LocalUnknown)
+	}
+	return string(s.State)
+}
+
+type CommitRef struct {
+	ShortSHA string
+	Subject  string
+}
+
+type WorkItem struct {
+	ID          string
+	Repo        RepoRef
+	Branch      *BranchRef
+	Worktree    *WorktreeRef
+	Issue       *IssueRef
+	PullRequest *PullRequestRef
+	Checks      CheckSummary
+	Local       *LocalStatus
+	Commits     []CommitRef
+}
+
+func (w WorkItem) Title() string {
+	switch {
+	case w.Branch != nil && w.Branch.Name != "":
+		return w.Branch.Name
+	case w.PullRequest != nil:
+		return w.PullRequest.Label()
+	case w.Issue != nil:
+		return w.Issue.Label()
+	default:
+		return "untracked work"
+	}
+}
+
+func (w WorkItem) Location() string {
+	switch {
+	case w.Worktree != nil && w.Worktree.Path != "":
+		return w.Worktree.Path
+	case w.Branch != nil && w.Branch.RemoteOnly:
+		return "remote only"
+	case w.Issue != nil && w.Branch == nil && w.PullRequest == nil:
+		return "issue only"
+	default:
+		return w.Repo.FullName()
+	}
+}
+
+func (w WorkItem) LocalLabel() string {
+	if w.Local == nil {
+		return string(LocalUnknown)
+	}
+	return w.Local.StateLabel()
+}
+
+func (w WorkItem) PullRequestLabel() string {
+	if w.PullRequest == nil {
+		return "no PR"
+	}
+	return fmt.Sprintf("PR #%d %s", w.PullRequest.Number, w.PullRequest.State)
+}
+
+func (w WorkItem) IssueLabel() string {
+	if w.Issue == nil {
+		return "no issue"
+	}
+	return w.Issue.Label()
+}

--- a/internal/workbench/types_test.go
+++ b/internal/workbench/types_test.go
@@ -27,6 +27,33 @@ func TestWorkItem_ZeroValueSafeLabels(t *testing.T) {
 	}
 }
 
+func TestWorkItem_PullRequestLabel_PartialDataSafe(t *testing.T) {
+	cases := []struct {
+		name string
+		pr   *PullRequestRef
+		want string
+	}{
+		{name: "missing state and number", pr: &PullRequestRef{}, want: "PR"},
+		{name: "number only", pr: &PullRequestRef{Number: 24}, want: "PR #24"},
+		{name: "state", pr: &PullRequestRef{Number: 24, State: "open"}, want: "PR #24 open"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := WorkItem{PullRequest: tc.pr}
+			if got := item.PullRequestLabel(); got != tc.want {
+				t.Fatalf("expected PR label %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestWorkItem_IssueLabel_MarksUncertainIssue(t *testing.T) {
+	item := WorkItem{Issue: &IssueRef{Number: 34, Title: "Branch preview UX"}}
+	if got := item.IssueLabel(); got != "#34 Branch preview UX (uncertain)" {
+		t.Fatalf("expected uncertain issue label, got %q", got)
+	}
+}
+
 func TestFakeWorkItems_CoverRequiredShapes(t *testing.T) {
 	items := FakeWorkItems()
 	if len(items) < 5 {

--- a/internal/workbench/types_test.go
+++ b/internal/workbench/types_test.go
@@ -1,0 +1,84 @@
+package workbench
+
+import "testing"
+
+func TestRepoRef_FullName_ZeroValueSafe(t *testing.T) {
+	if got := (RepoRef{}).FullName(); got != "unknown repo" {
+		t.Fatalf("expected unknown repo, got %q", got)
+	}
+}
+
+func TestWorkItem_ZeroValueSafeLabels(t *testing.T) {
+	item := WorkItem{}
+	if got := item.Title(); got != "untracked work" {
+		t.Fatalf("expected zero-value title to be safe, got %q", got)
+	}
+	if got := item.Location(); got != "unknown repo" {
+		t.Fatalf("expected zero-value location to be safe, got %q", got)
+	}
+	if got := item.LocalLabel(); got != "unknown" {
+		t.Fatalf("expected zero-value local label to be safe, got %q", got)
+	}
+	if got := item.PullRequestLabel(); got != "no PR" {
+		t.Fatalf("expected zero-value PR label to be safe, got %q", got)
+	}
+	if got := item.IssueLabel(); got != "no issue" {
+		t.Fatalf("expected zero-value issue label to be safe, got %q", got)
+	}
+}
+
+func TestFakeWorkItems_CoverRequiredShapes(t *testing.T) {
+	items := FakeWorkItems()
+	if len(items) < 5 {
+		t.Fatalf("expected at least five fake work items, got %d", len(items))
+	}
+
+	var hasCleanWorktree bool
+	var hasDirtyWorktree bool
+	var hasPullRequest bool
+	var hasRemoteOnly bool
+	var hasIssueOnly bool
+
+	seenIDs := map[string]bool{}
+	for _, item := range items {
+		if item.ID == "" {
+			t.Fatalf("fake work item has empty ID: %+v", item)
+		}
+		if seenIDs[item.ID] {
+			t.Fatalf("duplicate fake work item ID %q", item.ID)
+		}
+		seenIDs[item.ID] = true
+
+		if item.Worktree != nil && item.Local != nil && item.Local.State == LocalClean {
+			hasCleanWorktree = true
+		}
+		if item.Worktree != nil && item.Local != nil && item.Local.State == LocalDirty {
+			hasDirtyWorktree = true
+		}
+		if item.PullRequest != nil {
+			hasPullRequest = true
+		}
+		if item.Worktree == nil && item.Branch != nil && item.Branch.RemoteOnly {
+			hasRemoteOnly = true
+		}
+		if item.Worktree == nil && item.Branch == nil && item.PullRequest == nil && item.Issue != nil {
+			hasIssueOnly = true
+		}
+	}
+
+	cases := []struct {
+		name string
+		got  bool
+	}{
+		{"clean worktree", hasCleanWorktree},
+		{"dirty worktree", hasDirtyWorktree},
+		{"PR-linked work", hasPullRequest},
+		{"remote-only branch", hasRemoteOnly},
+		{"issue-only work", hasIssueOnly},
+	}
+	for _, tc := range cases {
+		if !tc.got {
+			t.Fatalf("fake work items are missing %s coverage", tc.name)
+		}
+	}
+}

--- a/scripts/fmt-check.sh
+++ b/scripts/fmt-check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+set -eu
+
+unformatted=$(
+	find . \
+		-name '*.go' \
+		-not -path './.git/*' \
+		-not -path './vendor/*' \
+		-exec gofmt -l {} +
+)
+
+if [ -n "$unformatted" ]; then
+	echo "Go files need formatting:" >&2
+	printf '%s\n' "$unformatted" >&2
+	echo "Run ./scripts/fmt.sh or make fmt." >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary
- Add repo-scoped work item domain types and deterministic fake fixtures.
- Replace the initial banner screen with a fake Repository Workbench shell.
- Add movement, compact rendering, preview, fixture, and golden tests.

Closes #5.
Closes #6.

## Test Plan
- [x] `go test ./...`
- [x] `make check`
- [x] `make build`
