### PR TITLE
Render workbench with Lip Gloss borders

### DIFF
--- a/docs/adr/0008-use-semantic-style-tokens-for-tui-theming.md
+++ b/docs/adr/0008-use-semantic-style-tokens-for-tui-theming.md
@@ -1,0 +1,182 @@
+# 0008: Use Semantic Style Tokens for TUI Theming
+
+- Status: Accepted
+- Date: 2026-04-26
+
+## Context
+
+`gh-zen` should become a dense, scannable terminal UI for repository,
+worktree, issue, pull request, check, and review workflows. The current fake
+workbench shell is intentionally plain while the navigation model is still
+forming, but the target experience should be closer to tools such as `k9s`:
+high contrast, quick to scan, and explicit about focus, key bindings, and status
+state.
+
+Color and emphasis need to communicate meaning:
+
+- Which pane is active.
+- Which row is selected.
+- Which keys are currently available.
+- Which work items are clean, dirty, blocked, passing, failing, pending, or
+  missing.
+- Which text is primary information and which text is supporting context.
+
+At the same time, `gh-zen` already has a layered configuration direction in ADR
+0007. UI theme settings should eventually be configurable globally, per project,
+and per terminal profile. Hard-coding colors directly in render functions would
+make that future configuration harder and would spread visual decisions across
+the Bubble Tea view code.
+
+## Decision
+
+Use semantic style tokens for TUI rendering.
+
+Rendering code should not choose concrete colors directly. Instead, it should
+use named styles that describe meaning and role. Initial tokens should cover at
+least:
+
+```go
+type Styles struct {
+	Title           lipgloss.Style
+	Key             lipgloss.Style
+	KeyDescription  lipgloss.Style
+	Divider         lipgloss.Style
+	PaneBorder      lipgloss.Style
+	PaneTitle       lipgloss.Style
+	PaneTitleActive lipgloss.Style
+	Selected        lipgloss.Style
+	SelectedMuted   lipgloss.Style
+	Muted           lipgloss.Style
+	Success         lipgloss.Style
+	Warning         lipgloss.Style
+	Danger          lipgloss.Style
+}
+```
+
+The first implementation may keep this type in `internal/app` because only the
+workbench shell needs it. Once configuration loading exists, move theme parsing
+and default theme construction behind a dedicated package, such as
+`internal/theme` or `internal/config`, while keeping the application model
+dependent on a resolved `Styles` value.
+
+Start with one built-in dark theme. The theme should be conservative and
+terminal-friendly:
+
+- Title: amber or yellow, bold.
+- Key chords: cyan or blue, bold.
+- Key descriptions: muted foreground.
+- Active pane title: cyan or magenta, bold.
+- Pane separators and dividers: blue-gray or muted foreground.
+- Selected row: bright foreground.
+- Inactive selected row marker: muted foreground.
+- Success: green.
+- Warning and pending: yellow.
+- Danger and failing: red.
+
+Style application should be scoped to stable semantic boundaries:
+
+- Header title.
+- Header keymap.
+- Pane titles.
+- Pane separators and horizontal dividers.
+- Selection markers.
+- Status labels such as checks and local state.
+- Muted secondary text.
+
+Avoid styling large arbitrary text blocks at first. Preview content should remain
+readable even when ANSI color is disabled or when the terminal theme differs
+from the expected dark background.
+
+## Consequences
+
+Positive:
+
+- Visual decisions stay centralized instead of being scattered through render
+  functions.
+- A future `theme` config can map user colors onto stable semantic roles.
+- Tests can focus on semantic rendering behavior and only update output when the
+  chosen default theme changes.
+- The UI can become more scannable without tying business logic to concrete
+  color values.
+- Per-terminal theme overrides from ADR 0007 can reuse the same resolved style
+  surface.
+
+Tradeoffs:
+
+- Even a small style layer adds indirection to view rendering.
+- Golden tests may include ANSI escape sequences once color is enabled.
+- Theme configuration needs validation for unknown style keys and invalid color
+  values.
+- Different terminal color capabilities may require fallback behavior.
+
+## Implementation Notes
+
+Keep the first implementation small:
+
+- Add a `Styles` type and `DefaultStyles()` constructor.
+- Store a resolved `Styles` value on the Bubble Tea model.
+- Apply styles only to header, keymap, pane titles, separators, selection
+  markers, and status labels.
+- Keep render helpers responsible for display width after styling. ANSI escape
+  sequences must not break alignment.
+- Prefer `lipgloss` styles and width helpers over manual ANSI escape sequences.
+
+Testing should follow ADR 0004:
+
+- Small tests cover that styles are applied at expected semantic boundaries.
+- Golden tests may include ANSI output when that is the simplest truthful
+  representation.
+- If ANSI-heavy golden files become hard to review, add a style-disabled test
+  mode for structural view tests and keep a smaller number of styled golden
+  tests.
+
+Theme configuration should be added after the config loader exists:
+
+```toml
+[ui]
+theme = "default-dark"
+
+[themes.default-dark]
+title = "yellow"
+key = "cyan"
+muted = "bright-black"
+success = "green"
+warning = "yellow"
+danger = "red"
+pane_border = "blue"
+```
+
+The exact TOML shape may change, but config should resolve to semantic tokens,
+not direct calls from config values to render functions.
+
+Accessibility and compatibility should be handled explicitly:
+
+- Respect `NO_COLOR` or an equivalent config option.
+- Add a low-color fallback if 24-bit color assumptions become a problem.
+- Avoid relying on color alone for state. Text labels such as `failing`,
+  `pending`, and `review requested` should remain visible.
+- Revisit light-background support once theme configuration exists.
+
+## Alternatives Considered
+
+- Hard-code colors in render functions: fastest initially, but it would make
+  future theme configuration and per-terminal overrides harder.
+- Introduce a full theme package immediately: cleaner layering, but premature
+  before the config loader and real UI surfaces exist.
+- Keep the UI monochrome: simplest and most portable, but weaker for scanning
+  dense repository and review state.
+- Use color only for status labels: useful, but it misses focus, pane boundary,
+  and keymap affordances that make the UI easier to operate.
+
+## Maintenance Notes
+
+This ADR should be revisited when:
+
+- Theme configuration is implemented.
+- The style token set becomes too large or too app-specific.
+- Golden tests become difficult to maintain because of ANSI output.
+- The project adds explicit light, high-contrast, or no-color themes.
+- `gh-zen` moves style construction out of `internal/app`.
+
+If the theming model changes materially, add a new ADR and mark this one as
+`Superseded` instead of rewriting this decision in place.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,6 +13,7 @@ trustworthy.
 - [0005: Package as a GitHub CLI Extension](0005-package-as-a-github-cli-extension.md)
 - [0006: Use Repository Workbench as the Primary Navigation Model](0006-use-repository-workbench-as-the-primary-navigation-model.md)
 - [0007: Use Layered Configuration With Terminal Profiles](0007-use-layered-configuration-with-terminal-profiles.md)
+- [0008: Use Semantic Style Tokens for TUI Theming](0008-use-semantic-style-tokens-for-tui-theming.md)
 
 ## Status Values
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -15,12 +15,33 @@ const (
 	defaultWidth        = 100
 	repoPaneWidth       = 23
 	workItemPaneWidth   = 39
-	paneGapWidth        = 2
+	paneSeparator       = " | "
+	paneSeparatorWidth  = len(paneSeparator)
 	previewPaneMinWidth = 28
 	dividerMaxWidth     = 72
 	compactDividerWidth = 48
-	fullLayoutMinWidth  = repoPaneWidth + workItemPaneWidth + paneGapWidth*2 + previewPaneMinWidth
+	fullLayoutMinWidth  = repoPaneWidth + workItemPaneWidth + paneSeparatorWidth*2 + previewPaneMinWidth
 )
+
+// paneFocus tracks the pane that owns pane-scoped key handling.
+type paneFocus int
+
+const (
+	paneWorkItems paneFocus = iota
+	paneRepositories
+	panePreview
+)
+
+func (p paneFocus) label() string {
+	switch p {
+	case paneRepositories:
+		return "Repositories"
+	case panePreview:
+		return "Preview"
+	default:
+		return "Work Items"
+	}
+}
 
 type model struct {
 	width        int
@@ -29,6 +50,7 @@ type model struct {
 	selectedRepo int
 	workItems    []workbench.WorkItem
 	selectedItem int
+	focusedPane  paneFocus
 }
 
 func New() tea.Model {
@@ -54,26 +76,133 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "q", "ctrl+c", "esc":
 			return m, tea.Quit
+		case "tab":
+			m.focusNextPane()
+			return m, nil
+		case "shift+tab":
+			m.focusPreviousPane()
+			return m, nil
 		case "j", "down":
-			m.moveSelection(1)
+			m.moveFocusedSelection(1)
 			return m, nil
 		case "k", "up":
-			m.moveSelection(-1)
+			m.moveFocusedSelection(-1)
 			return m, nil
 		case "g":
-			m.selectedItem = 0
+			m.jumpFocusedSelection(false)
 			return m, nil
 		case "G":
-			if len(m.workItems) > 0 {
-				m.selectedItem = len(m.workItems) - 1
-			}
+			m.jumpFocusedSelection(true)
 			return m, nil
 		}
 	}
 	return m, nil
 }
 
-func (m *model) moveSelection(delta int) {
+func (m *model) focusNextPane() {
+	m.focusedPane = nextPane(m.activePane(), m.paneOrder())
+}
+
+func (m *model) focusPreviousPane() {
+	m.focusedPane = previousPane(m.activePane(), m.paneOrder())
+}
+
+// paneOrder is the visible pane traversal order for tab navigation.
+func (m model) paneOrder() []paneFocus {
+	if m.isCompact() {
+		return []paneFocus{paneWorkItems, panePreview}
+	}
+	return []paneFocus{paneRepositories, paneWorkItems, panePreview}
+}
+
+// activePane normalizes focus when the current layout hides a pane.
+func (m model) activePane() paneFocus {
+	focus := m.focusedPane
+	for _, pane := range m.paneOrder() {
+		if focus == pane {
+			return focus
+		}
+	}
+	return paneWorkItems
+}
+
+func (m model) isCompact() bool {
+	return m.effectiveWidth() < fullLayoutMinWidth
+}
+
+func (m model) effectiveWidth() int {
+	if m.width <= 0 {
+		return defaultWidth
+	}
+	return m.width
+}
+
+func nextPane(current paneFocus, order []paneFocus) paneFocus {
+	for i, pane := range order {
+		if pane == current {
+			return order[(i+1)%len(order)]
+		}
+	}
+	return order[0]
+}
+
+func previousPane(current paneFocus, order []paneFocus) paneFocus {
+	for i, pane := range order {
+		if pane == current {
+			return order[(i+len(order)-1)%len(order)]
+		}
+	}
+	return order[0]
+}
+
+// moveFocusedSelection keeps j/k scoped to the active pane.
+func (m *model) moveFocusedSelection(delta int) {
+	switch m.activePane() {
+	case paneRepositories:
+		m.moveRepoSelection(delta)
+	case paneWorkItems:
+		m.moveWorkItemSelection(delta)
+	}
+}
+
+// jumpFocusedSelection keeps g/G behavior aligned with the active pane.
+func (m *model) jumpFocusedSelection(toEnd bool) {
+	switch m.activePane() {
+	case paneRepositories:
+		if toEnd {
+			if len(m.repos) > 0 {
+				m.selectedRepo = len(m.repos) - 1
+			}
+			return
+		}
+		m.selectedRepo = 0
+	case paneWorkItems:
+		if toEnd {
+			if len(m.workItems) > 0 {
+				m.selectedItem = len(m.workItems) - 1
+			}
+			return
+		}
+		m.selectedItem = 0
+	}
+}
+
+func (m *model) moveRepoSelection(delta int) {
+	if len(m.repos) == 0 {
+		m.selectedRepo = 0
+		return
+	}
+
+	m.selectedRepo += delta
+	if m.selectedRepo < 0 {
+		m.selectedRepo = 0
+	}
+	if m.selectedRepo >= len(m.repos) {
+		m.selectedRepo = len(m.repos) - 1
+	}
+}
+
+func (m *model) moveWorkItemSelection(delta int) {
 	if len(m.workItems) == 0 {
 		m.selectedItem = 0
 		return
@@ -89,10 +218,7 @@ func (m *model) moveSelection(delta int) {
 }
 
 func (m model) View() string {
-	width := m.width
-	if width <= 0 {
-		width = defaultWidth
-	}
+	width := m.effectiveWidth()
 
 	if width < fullLayoutMinWidth {
 		return m.renderCompact(width)
@@ -101,47 +227,47 @@ func (m model) View() string {
 }
 
 func (m model) renderFull(width int) string {
-	rightWidth := width - repoPaneWidth - workItemPaneWidth - paneGapWidth*2
+	rightWidth := width - repoPaneWidth - workItemPaneWidth - paneSeparatorWidth*2
+	focus := m.activePane()
 
-	left := m.repoLines(repoPaneWidth)
-	middle := m.workItemLines(workItemPaneWidth)
-	right := m.previewLines(rightWidth)
+	left := m.repoLines(repoPaneWidth, focus == paneRepositories)
+	middle := m.workItemLines(workItemPaneWidth, focus == paneWorkItems)
+	right := m.previewLines(rightWidth, focus == panePreview)
 	lines := max(len(left), max(len(middle), len(right)))
 
 	out := []string{
 		"gh-zen  repository workbench",
+		m.keymapLine(width),
 		strings.Repeat("-", min(width, dividerMaxWidth)),
 	}
 	for i := 0; i < lines; i++ {
-		row := pad(lineAt(left, i), repoPaneWidth) + strings.Repeat(" ", paneGapWidth) + pad(lineAt(middle, i), workItemPaneWidth) + strings.Repeat(" ", paneGapWidth) + pad(lineAt(right, i), rightWidth)
+		row := paneRow(lineAt(left, i), lineAt(middle, i), lineAt(right, i), rightWidth)
 		out = append(out, strings.TrimRight(row, " "))
 	}
-	out = append(out, "", "j/k move  g/G jump  q quit")
 	return strings.Join(out, "\n") + "\n"
 }
 
 func (m model) renderCompact(width int) string {
+	focus := m.activePane()
 	lines := []string{
 		"gh-zen workbench",
+		m.keymapLine(width),
 		strings.Repeat("-", min(width, compactDividerWidth)),
 	}
-	lines = append(lines, m.workItemLines(width)...)
+	lines = append(lines, m.workItemLines(width, focus == paneWorkItems)...)
 	lines = append(lines, "")
-	lines = append(lines, m.previewLines(width)...)
-	lines = append(lines, "", "j/k move  q quit")
+	lines = append(lines, strings.Repeat("-", min(width, compactDividerWidth)))
+	lines = append(lines, m.previewLines(width, focus == panePreview)...)
 	return strings.Join(lines, "\n") + "\n"
 }
 
-func (m model) repoLines(width int) []string {
-	lines := []string{"Repositories"}
+func (m model) repoLines(width int, focused bool) []string {
+	lines := []string{paneTitle("Repositories", focused)}
 	if len(m.repos) == 0 {
 		lines = append(lines, "  none")
 	} else {
 		for i, repo := range m.repos {
-			marker := " "
-			if i == m.selectedRepo {
-				marker = ">"
-			}
+			marker := selectionMarker(i == m.selectedRepo, focused)
 			lines = append(lines, truncate(fmt.Sprintf("%s %s", marker, repo.FullName()), width))
 		}
 	}
@@ -149,30 +275,27 @@ func (m model) repoLines(width int) []string {
 	return lines
 }
 
-func (m model) workItemLines(width int) []string {
-	lines := []string{"Work Items"}
+func (m model) workItemLines(width int, focused bool) []string {
+	lines := []string{paneTitle("Work Items", focused)}
 	if len(m.workItems) == 0 {
 		return append(lines, "  no work items")
 	}
 	for i, item := range m.workItems {
-		marker := " "
-		if i == m.selectedItem {
-			marker = ">"
-		}
+		marker := selectionMarker(i == m.selectedItem, focused)
 		row := fmt.Sprintf("%s %-22s %-7s %s", marker, item.Title(), item.LocalLabel(), shortRemoteLabel(item))
 		lines = append(lines, truncate(row, width))
 	}
 	return lines
 }
 
-func (m model) previewLines(width int) []string {
+func (m model) previewLines(width int, focused bool) []string {
 	item, ok := m.selectedWorkItem()
 	if !ok {
-		return []string{"Preview", "  no work item selected"}
+		return []string{paneTitle("Preview", focused), "  no work item selected"}
 	}
 
 	lines := []string{
-		"Preview",
+		paneTitle("Preview", focused),
 		truncate("Repo: "+item.Repo.FullName(), width),
 		truncate("Item: "+item.Title(), width),
 		truncate("Where: "+item.Location(), width),
@@ -198,6 +321,42 @@ func (m model) previewLines(width int) []string {
 		}
 	}
 	return lines
+}
+
+// keymapLine keeps the active pane affordances visible near the title.
+func (m model) keymapLine(width int) string {
+	focus := m.activePane()
+	prefix := focus.label() + " keys: "
+	switch focus {
+	case paneRepositories, paneWorkItems:
+		return truncate(prefix+"j/k move  g/G jump  tab/S-tab pane  q quit", width)
+	case panePreview:
+		return truncate(prefix+"tab/S-tab pane  q quit", width)
+	}
+	return truncate(prefix+"tab/S-tab pane  q quit", width)
+}
+
+func paneTitle(label string, focused bool) string {
+	if focused {
+		return label + " [active]"
+	}
+	return label
+}
+
+// selectionMarker keeps the retained selection visible outside the active pane.
+func selectionMarker(selected, focused bool) string {
+	if !selected {
+		return " "
+	}
+	if focused {
+		return ">"
+	}
+	return "*"
+}
+
+// paneRow renders full-layout columns with visible pane separators.
+func paneRow(left, middle, right string, rightWidth int) string {
+	return pad(left, repoPaneWidth) + paneSeparator + pad(middle, workItemPaneWidth) + paneSeparator + pad(right, rightWidth)
 }
 
 func (m model) selectedWorkItem() (workbench.WorkItem, bool) {
@@ -242,6 +401,7 @@ func pad(s string, width int) string {
 	return s + strings.Repeat(" ", padWidth)
 }
 
+// truncate uses terminal display width so wide characters keep columns aligned.
 func truncate(s string, width int) string {
 	if width <= 0 {
 		return ""

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -12,15 +12,21 @@ import (
 )
 
 const (
-	defaultWidth        = 100
-	repoPaneWidth       = 23
-	workItemPaneWidth   = 39
-	paneSeparator       = " | "
-	paneSeparatorWidth  = len(paneSeparator)
-	previewPaneMinWidth = 28
-	dividerMaxWidth     = 72
-	compactDividerWidth = 48
-	fullLayoutMinWidth  = repoPaneWidth + workItemPaneWidth + paneSeparatorWidth*2 + previewPaneMinWidth
+	defaultWidth          = 100
+	repoPaneWidth         = 23
+	workItemPaneWidth     = 39
+	paneBorderGlyph       = "│"
+	paneBorderWidth       = 2
+	frameBorderWidth      = 2
+	frameHeaderLines      = 2
+	frameBorderLines      = 2
+	horizontalLineGlyph   = "─"
+	frameTopLeftGlyph     = "┌"
+	frameTopRightGlyph    = "┐"
+	frameBottomLeftGlyph  = "└"
+	frameBottomRightGlyph = "┘"
+	previewPaneMinWidth   = 28
+	fullLayoutMinWidth    = repoPaneWidth + workItemPaneWidth + paneBorderWidth*2 + previewPaneMinWidth
 )
 
 // paneFocus tracks the pane that owns pane-scoped key handling.
@@ -51,6 +57,7 @@ type model struct {
 	workItems    []workbench.WorkItem
 	selectedItem int
 	focusedPane  paneFocus
+	styles       Styles
 }
 
 func New() tea.Model {
@@ -61,6 +68,7 @@ func newModel() model {
 	return model{
 		repos:     workbench.FakeRepos(),
 		workItems: workbench.FakeWorkItems(),
+		styles:    DefaultStyles(),
 	}
 }
 
@@ -127,7 +135,7 @@ func (m model) activePane() paneFocus {
 }
 
 func (m model) isCompact() bool {
-	return m.effectiveWidth() < fullLayoutMinWidth
+	return m.effectiveContentWidth() < fullLayoutMinWidth
 }
 
 func (m model) effectiveWidth() int {
@@ -135,6 +143,10 @@ func (m model) effectiveWidth() int {
 		return defaultWidth
 	}
 	return m.width
+}
+
+func (m model) effectiveContentWidth() int {
+	return max(m.effectiveWidth()-frameBorderWidth, 0)
 }
 
 func nextPane(current paneFocus, order []paneFocus) paneFocus {
@@ -227,38 +239,46 @@ func (m model) View() string {
 }
 
 func (m model) renderFull(width int) string {
-	rightWidth := width - repoPaneWidth - workItemPaneWidth - paneSeparatorWidth*2
+	contentWidth := max(width-frameBorderWidth, 0)
+	rightWidth := contentWidth - repoPaneWidth - workItemPaneWidth - paneBorderWidth*2
 	focus := m.activePane()
 
 	left := m.repoLines(repoPaneWidth, focus == paneRepositories)
 	middle := m.workItemLines(workItemPaneWidth, focus == paneWorkItems)
 	right := m.previewLines(rightWidth, focus == panePreview)
-	lines := max(len(left), max(len(middle), len(right)))
+	bodyHeight := m.frameBodyHeight(max(len(left), max(len(middle), len(right))))
 
 	out := []string{
 		"gh-zen  repository workbench",
 		m.keymapLine(width),
-		strings.Repeat("-", min(width, dividerMaxWidth)),
 	}
-	for i := 0; i < lines; i++ {
-		row := paneRow(lineAt(left, i), lineAt(middle, i), lineAt(right, i), rightWidth)
-		out = append(out, strings.TrimRight(row, " "))
-	}
+	body := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		m.renderPane(left, repoPaneWidth, bodyHeight, false),
+		m.renderPane(middle, workItemPaneWidth, bodyHeight, true),
+		m.renderPane(right, rightWidth, bodyHeight, true),
+	)
+	out = append(out, m.renderFrame(trimRightLines(body), width, bodyHeight))
 	return strings.Join(out, "\n") + "\n"
 }
 
 func (m model) renderCompact(width int) string {
+	contentWidth := max(width-frameBorderWidth, 0)
 	focus := m.activePane()
-	lines := []string{
+	out := []string{
 		"gh-zen workbench",
 		m.keymapLine(width),
-		strings.Repeat("-", min(width, compactDividerWidth)),
 	}
-	lines = append(lines, m.workItemLines(width, focus == paneWorkItems)...)
+
+	lines := m.workItemLines(contentWidth, focus == paneWorkItems)
 	lines = append(lines, "")
-	lines = append(lines, strings.Repeat("-", min(width, compactDividerWidth)))
-	lines = append(lines, m.previewLines(width, focus == panePreview)...)
-	return strings.Join(lines, "\n") + "\n"
+	lines = append(lines, m.dividerLine(contentWidth))
+	lines = append(lines, m.previewLines(contentWidth, focus == panePreview)...)
+	bodyHeight := m.frameBodyHeight(len(lines))
+
+	content := renderPaneContent(lines, contentWidth, bodyHeight)
+	out = append(out, m.renderFrame(content, width, bodyHeight))
+	return strings.Join(out, "\n") + "\n"
 }
 
 func (m model) repoLines(width int, focused bool) []string {
@@ -354,9 +374,70 @@ func selectionMarker(selected, focused bool) string {
 	return "*"
 }
 
-// paneRow renders full-layout columns with visible pane separators.
-func paneRow(left, middle, right string, rightWidth int) string {
-	return pad(left, repoPaneWidth) + paneSeparator + pad(middle, workItemPaneWidth) + paneSeparator + pad(right, rightWidth)
+// dividerLine renders horizontal separators through the theme boundary.
+func (m model) dividerLine(width int) string {
+	return m.styles.Divider.Render(strings.Repeat(horizontalLineGlyph, width))
+}
+
+func (m model) frameBodyHeight(contentHeight int) int {
+	if m.height <= 0 {
+		return contentHeight
+	}
+	available := m.height - frameHeaderLines - frameBorderLines
+	if available > contentHeight {
+		return available
+	}
+	return contentHeight
+}
+
+// renderFrame owns the outer workbench rectangle.
+func (m model) renderFrame(content string, width int, bodyHeight int) string {
+	return lipgloss.NewStyle().
+		Width(max(width-frameBorderWidth, 0)).
+		Height(bodyHeight).
+		Border(lipgloss.Border{
+			Top:         horizontalLineGlyph,
+			Bottom:      horizontalLineGlyph,
+			Left:        paneBorderGlyph,
+			Right:       paneBorderGlyph,
+			TopLeft:     frameTopLeftGlyph,
+			TopRight:    frameTopRightGlyph,
+			BottomLeft:  frameBottomLeftGlyph,
+			BottomRight: frameBottomRightGlyph,
+		}, true).
+		BorderForeground(m.styles.FrameBorder.GetForeground()).
+		Render(content)
+}
+
+// renderPane pads pane content and lets Lip Gloss own pane borders.
+func (m model) renderPane(lines []string, width int, height int, bordered bool) string {
+	content := renderPaneContent(lines, width, height)
+	if !bordered {
+		return content
+	}
+	return lipgloss.NewStyle().
+		BorderLeft(true).
+		BorderStyle(lipgloss.Border{Left: paneBorderGlyph}).
+		BorderForeground(m.styles.PaneBorder.GetForeground()).
+		PaddingLeft(1).
+		Render(content)
+}
+
+// renderPaneContent keeps each pane block rectangular before borders are added.
+func renderPaneContent(lines []string, width int, height int) string {
+	out := make([]string, height)
+	for i := range out {
+		out[i] = pad(lineAt(lines, i), width)
+	}
+	return strings.Join(out, "\n")
+}
+
+func trimRightLines(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " ")
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (m model) selectedWorkItem() (workbench.WorkItem, bool) {

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -210,6 +211,22 @@ func TestTruncate_UsesTerminalDisplayWidth(t *testing.T) {
 	}
 	if got != "日本~" {
 		t.Fatalf("expected wide text to truncate with tail, got %q", got)
+	}
+}
+
+func TestRenderPane_UsesLipGlossBorderWidth(t *testing.T) {
+	got := newModel().renderPane([]string{"header", "row"}, 10, 3, true)
+	lines := strings.Split(got, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected bordered pane height 3, got %d in %q", len(lines), got)
+	}
+	for _, line := range lines {
+		if width := lipgloss.Width(line); width != 10+paneBorderWidth {
+			t.Fatalf("expected bordered pane width %d, got %d for %q", 10+paneBorderWidth, width, line)
+		}
+	}
+	if !strings.Contains(got, paneBorderGlyph) {
+		t.Fatalf("expected Lip Gloss pane border, got %q", got)
 	}
 }
 

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -126,6 +126,57 @@ func TestUpdate_MoveSelection_ClampsAtEdges(t *testing.T) {
 	}
 }
 
+func TestUpdate_TabChangesFocusedPane(t *testing.T) {
+	start := newModel()
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for tab, got %T", cmd)
+	}
+	mm := got.(model)
+	if mm.focusedPane != panePreview {
+		t.Fatalf("expected tab to focus preview pane, got %v", mm.focusedPane)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	mm = got.(model)
+	if mm.focusedPane != paneWorkItems {
+		t.Fatalf("expected shift+tab to focus work items pane, got %v", mm.focusedPane)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	mm = got.(model)
+	if mm.focusedPane != paneRepositories {
+		t.Fatalf("expected shift+tab to focus repositories pane, got %v", mm.focusedPane)
+	}
+}
+
+func TestUpdate_MovementTargetsFocusedPane(t *testing.T) {
+	start := newModel()
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	mm := got.(model)
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	mm = got.(model)
+	if mm.selectedRepo != 1 {
+		t.Fatalf("expected j to move repository selection when repo pane is focused, got %d", mm.selectedRepo)
+	}
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected work item selection to stay unchanged, got %d", mm.selectedItem)
+	}
+}
+
+func TestUpdate_PreviewPaneIgnoresMovementKeys(t *testing.T) {
+	start := newModel()
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyTab})
+	mm := got.(model)
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	mm = got.(model)
+	if mm.selectedRepo != 0 || mm.selectedItem != 0 {
+		t.Fatalf("expected preview pane movement to leave selections unchanged, got repo=%d item=%d", mm.selectedRepo, mm.selectedItem)
+	}
+}
+
 func TestUpdate_UnicodeRunes_NoQuit(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/internal/app/styles.go
+++ b/internal/app/styles.go
@@ -1,0 +1,28 @@
+package app
+
+import "github.com/charmbracelet/lipgloss"
+
+// Styles contains semantic rendering tokens for the workbench UI.
+type Styles struct {
+	Title           lipgloss.Style
+	Key             lipgloss.Style
+	KeyDescription  lipgloss.Style
+	Divider         lipgloss.Style
+	FrameBorder     lipgloss.Style
+	PaneBorder      lipgloss.Style
+	PaneTitle       lipgloss.Style
+	PaneTitleActive lipgloss.Style
+	Selected        lipgloss.Style
+	SelectedMuted   lipgloss.Style
+	Muted           lipgloss.Style
+	Success         lipgloss.Style
+	Warning         lipgloss.Style
+	Danger          lipgloss.Style
+}
+
+// DefaultStyles returns the built-in semantic styles.
+func DefaultStyles() Styles {
+	return Styles{
+		FrameBorder: lipgloss.NewStyle().Foreground(lipgloss.Color("#00D7FF")),
+	}
+}

--- a/internal/app/testdata/TestView_Initial.golden
+++ b/internal/app/testdata/TestView_Initial.golden
@@ -1,14 +1,15 @@
 gh-zen  repository workbench
 Work Items keys: j/k move  g/G jump  tab/S-tab pane  q quit
-------------------------------------------------------------------------
-Repositories            | Work Items [active]                     | Preview
-* 0maru/gh-zen          | > main                   clean   no PR  | Repo: 0maru/gh-zen
-  0maru/dotfiles        |   feat/config-loader     dirty   PR #24 | Item: main
-                        |   feat/repo-workbench    clean   #6     | Where: ~/workspaces/github.com/~
-Views                   |   agent/preview-state    missing #8     | Branch: main -> origin/main
-  Active worktrees      |   #34 Branch preview UX  unknown #34    | Local: clean
-  Review requested      |                                         | Issue: no issue
-  Failed checks         |                                         | PR: no PR
-                        |                                         | Checks: checks passing
-                        |                                         | Commits:
-                        |                                         |   3da43e7 Set up GitHub CLI ext~
+┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+│Repositories           │ Work Items [active]                    │ Preview                         │
+│* 0maru/gh-zen         │ > main                   clean   no PR │ Repo: 0maru/gh-zen              │
+│  0maru/dotfiles       │   feat/config-loader     dirty   PR #24│ Item: main                      │
+│                       │   feat/repo-workbench    clean   #6    │ Where: ~/workspaces/github.com/~│
+│Views                  │   agent/preview-state    missing #8    │ Branch: main -> origin/main     │
+│  Active worktrees     │   #34 Branch preview UX  unknown #34   │ Local: clean                    │
+│  Review requested     │                                        │ Issue: no issue                 │
+│  Failed checks        │                                        │ PR: no PR                       │
+│                       │                                        │ Checks: checks passing          │
+│                       │                                        │ Commits:                        │
+│                       │                                        │   3da43e7 Set up GitHub CLI ext~│
+└──────────────────────────────────────────────────────────────────────────────────────────────────┘

--- a/internal/app/testdata/TestView_Initial.golden
+++ b/internal/app/testdata/TestView_Initial.golden
@@ -1,15 +1,14 @@
 gh-zen  repository workbench
+Work Items keys: j/k move  g/G jump  tab/S-tab pane  q quit
 ------------------------------------------------------------------------
-Repositories             Work Items                               Preview
-> 0maru/gh-zen           > main                   clean   no PR   Repo: 0maru/gh-zen
-  0maru/dotfiles           feat/config-loader     dirty   PR #24  Item: main
-                           feat/repo-workbench    clean   #6      Where: ~/workspaces/github.com/0m~
-Views                      agent/preview-state    missing #8      Branch: main -> origin/main
-  Active worktrees         #34 Branch preview UX  unknown #34     Local: clean
-  Review requested                                                Issue: no issue
-  Failed checks                                                   PR: no PR
-                                                                  Checks: checks passing
-                                                                  Commits:
-                                                                    3da43e7 Set up GitHub CLI exten~
-
-j/k move  g/G jump  q quit
+Repositories            | Work Items [active]                     | Preview
+* 0maru/gh-zen          | > main                   clean   no PR  | Repo: 0maru/gh-zen
+  0maru/dotfiles        |   feat/config-loader     dirty   PR #24 | Item: main
+                        |   feat/repo-workbench    clean   #6     | Where: ~/workspaces/github.com/~
+Views                   |   agent/preview-state    missing #8     | Branch: main -> origin/main
+  Active worktrees      |   #34 Branch preview UX  unknown #34    | Local: clean
+  Review requested      |                                         | Issue: no issue
+  Failed checks         |                                         | PR: no PR
+                        |                                         | Checks: checks passing
+                        |                                         | Commits:
+                        |                                         |   3da43e7 Set up GitHub CLI ext~

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 var update = flag.Bool("update", false, "update golden files")
@@ -83,8 +85,32 @@ func TestView_FullLayoutSeparatesPanes(t *testing.T) {
 	if len(lines) < 4 {
 		t.Fatalf("expected full layout output, got:\n%s", got)
 	}
-	if !strings.Contains(lines[3], " | ") {
+	if !strings.Contains(lines[3], paneBorderGlyph) {
 		t.Fatalf("expected visible pane separators in header row, got line %q", lines[3])
+	}
+}
+
+func TestView_FrameFillsWindowHeight(t *testing.T) {
+	m := newModel()
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+	got := updated.(model).View()
+	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+
+	if len(lines) != 24 {
+		t.Fatalf("expected frame to fill window height, got %d lines:\n%s", len(lines), got)
+	}
+	top := ansi.Strip(lines[2])
+	if !strings.HasPrefix(top, frameTopLeftGlyph) || !strings.HasSuffix(top, frameTopRightGlyph) {
+		t.Fatalf("expected top frame border on line 3, got %q", lines[2])
+	}
+	last := ansi.Strip(lines[len(lines)-1])
+	if !strings.HasPrefix(last, frameBottomLeftGlyph) || !strings.HasSuffix(last, frameBottomRightGlyph) {
+		t.Fatalf("expected bottom frame border on last line, got %q", lines[len(lines)-1])
+	}
+	for i, line := range lines[2:] {
+		if width := lipgloss.Width(line); width != 100 {
+			t.Fatalf("expected frame line %d to use full width 100, got %d for %q", i+2, width, line)
+		}
 	}
 }
 

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -50,6 +51,54 @@ func TestView_Compact_HidesRepositoryPane(t *testing.T) {
 	}
 	if !bytes.Contains([]byte(got), []byte("Work Items")) || !bytes.Contains([]byte(got), []byte("Preview")) {
 		t.Fatalf("expected compact view to keep list and preview, got:\n%s", got)
+	}
+}
+
+func TestView_KeymapFollowsFocusedPane(t *testing.T) {
+	m := newModel()
+	initial := m.View()
+	if !bytes.Contains([]byte(initial), []byte("Work Items keys: j/k move")) {
+		t.Fatalf("expected initial header to show work item keys, got:\n%s", initial)
+	}
+	if got := strings.Split(initial, "\n")[1]; !strings.HasPrefix(got, "Work Items keys:") {
+		t.Fatalf("expected keymap directly under title, got line %q", got)
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	next := updated.(model).View()
+	if !bytes.Contains([]byte(next), []byte("Preview keys: tab/S-tab pane  q quit")) {
+		t.Fatalf("expected focused preview header, got:\n%s", next)
+	}
+	if got := strings.Split(next, "\n")[1]; !strings.HasPrefix(got, "Preview keys:") {
+		t.Fatalf("expected preview keymap directly under title, got line %q", got)
+	}
+	if bytes.Contains([]byte(next), []byte("j/k move")) {
+		t.Fatalf("expected preview keymap to omit movement keys, got:\n%s", next)
+	}
+}
+
+func TestView_FullLayoutSeparatesPanes(t *testing.T) {
+	got := newModel().View()
+	lines := strings.Split(got, "\n")
+	if len(lines) < 4 {
+		t.Fatalf("expected full layout output, got:\n%s", got)
+	}
+	if !strings.Contains(lines[3], " | ") {
+		t.Fatalf("expected visible pane separators in header row, got line %q", lines[3])
+	}
+}
+
+func TestView_CompactNormalizesHiddenRepositoryFocus(t *testing.T) {
+	m := newModel()
+	m.width = 50
+	m.focusedPane = paneRepositories
+	got := m.View()
+
+	if !bytes.Contains([]byte(got), []byte("Work Items keys:")) {
+		t.Fatalf("expected compact view to focus visible work items pane, got:\n%s", got)
+	}
+	if bytes.Contains([]byte(got), []byte("Repositories keys:")) {
+		t.Fatalf("expected compact view to hide repository keymap, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add pane-focused key help and separator rendering for the repository workbench.
- Document semantic TUI style tokens and introduce default workbench styles.
- Render the workbench frame and panes with Lip Gloss borders, with golden and view coverage.

## Test Plan
- [x] make test-small
- [x] pre-push hook (test-medium)