### PR TITLE
[codex] Complete fake workbench navigation shell

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -12,21 +12,22 @@ import (
 )
 
 const (
-	defaultWidth          = 100
-	repoPaneWidth         = 23
-	workItemPaneWidth     = 39
-	paneBorderGlyph       = "│"
-	paneBorderWidth       = 2
-	frameBorderWidth      = 2
-	frameHeaderLines      = 2
-	frameBorderLines      = 2
-	horizontalLineGlyph   = "─"
-	frameTopLeftGlyph     = "┌"
-	frameTopRightGlyph    = "┐"
-	frameBottomLeftGlyph  = "└"
-	frameBottomRightGlyph = "┘"
-	previewPaneMinWidth   = 28
-	fullLayoutMinWidth    = repoPaneWidth + workItemPaneWidth + paneBorderWidth*2 + previewPaneMinWidth
+	defaultWidth           = 100
+	repoPaneWidth          = 23
+	workItemPaneWidth      = 41
+	paneGapWidth           = 1
+	paneContentPaddingLeft = 1
+	paneBorderGlyph        = "│"
+	paneBorderWidth        = 2
+	frameHeaderLines       = 2
+	frameBorderLines       = 2
+	horizontalLineGlyph    = "─"
+	frameTopLeftGlyph      = "┌"
+	frameTopRightGlyph     = "┐"
+	frameBottomLeftGlyph   = "└"
+	frameBottomRightGlyph  = "┘"
+	previewPaneMinWidth    = 28
+	fullLayoutMinWidth     = repoPaneWidth + workItemPaneWidth + previewPaneMinWidth + paneBorderWidth*3 + paneGapWidth*2
 )
 
 // paneFocus tracks the pane that owns pane-scoped key handling.
@@ -43,9 +44,20 @@ func (p paneFocus) label() string {
 	case paneRepositories:
 		return "Repositories"
 	case panePreview:
-		return "Preview"
+		return "Review"
 	default:
 		return "Work Items"
+	}
+}
+
+func (p paneFocus) borderLabel() string {
+	switch p {
+	case paneRepositories:
+		return "Repositories"
+	case panePreview:
+		return "Review"
+	default:
+		return "WorkItems"
 	}
 }
 
@@ -54,10 +66,36 @@ type model struct {
 	height       int
 	repos        []workbench.RepoRef
 	selectedRepo int
+	selectedView int
+	viewSelected bool
 	workItems    []workbench.WorkItem
 	selectedItem int
 	focusedPane  paneFocus
 	styles       Styles
+}
+
+type repoViewFilter int
+
+const (
+	repoViewActiveWorktrees repoViewFilter = iota
+	repoViewReviewRequested
+	repoViewFailedChecks
+)
+
+type repoView struct {
+	label  string
+	filter repoViewFilter
+}
+
+type keyBinding struct {
+	key         string
+	description string
+}
+
+var repoViews = []repoView{
+	{label: "Active worktrees", filter: repoViewActiveWorktrees},
+	{label: "Review requested", filter: repoViewReviewRequested},
+	{label: "Failed checks", filter: repoViewFailedChecks},
 }
 
 func New() tea.Model {
@@ -90,6 +128,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "shift+tab":
 			m.focusPreviousPane()
 			return m, nil
+		case "1":
+			m.focusPaneByNumber(1)
+			return m, nil
+		case "2":
+			m.focusPaneByNumber(2)
+			return m, nil
+		case "3":
+			m.focusPaneByNumber(3)
+			return m, nil
 		case "j", "down":
 			m.moveFocusedSelection(1)
 			return m, nil
@@ -115,6 +162,15 @@ func (m *model) focusPreviousPane() {
 	m.focusedPane = previousPane(m.activePane(), m.paneOrder())
 }
 
+func (m *model) focusPaneByNumber(number int) {
+	order := m.paneOrder()
+	index := number - 1
+	if index < 0 || index >= len(order) {
+		return
+	}
+	m.focusedPane = order[index]
+}
+
 // paneOrder is the visible pane traversal order for tab navigation.
 func (m model) paneOrder() []paneFocus {
 	if m.isCompact() {
@@ -135,7 +191,7 @@ func (m model) activePane() paneFocus {
 }
 
 func (m model) isCompact() bool {
-	return m.effectiveContentWidth() < fullLayoutMinWidth
+	return m.effectiveWidth() < fullLayoutMinWidth
 }
 
 func (m model) effectiveWidth() int {
@@ -143,10 +199,6 @@ func (m model) effectiveWidth() int {
 		return defaultWidth
 	}
 	return m.width
-}
-
-func (m model) effectiveContentWidth() int {
-	return max(m.effectiveWidth()-frameBorderWidth, 0)
 }
 
 func nextPane(current paneFocus, order []paneFocus) paneFocus {
@@ -182,16 +234,15 @@ func (m *model) jumpFocusedSelection(toEnd bool) {
 	switch m.activePane() {
 	case paneRepositories:
 		if toEnd {
-			if len(m.repos) > 0 {
-				m.selectedRepo = len(m.repos) - 1
-			}
+			m.setRepoPaneIndex(m.repoPaneEntryCount() - 1)
 			return
 		}
-		m.selectedRepo = 0
+		m.setRepoPaneIndex(0)
 	case paneWorkItems:
+		items := m.visibleWorkItems()
 		if toEnd {
-			if len(m.workItems) > 0 {
-				m.selectedItem = len(m.workItems) - 1
+			if len(items) > 0 {
+				m.selectedItem = len(items) - 1
 			}
 			return
 		}
@@ -200,22 +251,20 @@ func (m *model) jumpFocusedSelection(toEnd bool) {
 }
 
 func (m *model) moveRepoSelection(delta int) {
-	if len(m.repos) == 0 {
+	count := m.repoPaneEntryCount()
+	if count == 0 {
 		m.selectedRepo = 0
+		m.selectedView = 0
+		m.viewSelected = false
 		return
 	}
 
-	m.selectedRepo += delta
-	if m.selectedRepo < 0 {
-		m.selectedRepo = 0
-	}
-	if m.selectedRepo >= len(m.repos) {
-		m.selectedRepo = len(m.repos) - 1
-	}
+	m.setRepoPaneIndex(clamp(m.repoPaneIndex()+delta, 0, count-1))
 }
 
 func (m *model) moveWorkItemSelection(delta int) {
-	if len(m.workItems) == 0 {
+	items := m.visibleWorkItems()
+	if len(items) == 0 {
 		m.selectedItem = 0
 		return
 	}
@@ -224,8 +273,95 @@ func (m *model) moveWorkItemSelection(delta int) {
 	if m.selectedItem < 0 {
 		m.selectedItem = 0
 	}
-	if m.selectedItem >= len(m.workItems) {
-		m.selectedItem = len(m.workItems) - 1
+	if m.selectedItem >= len(items) {
+		m.selectedItem = len(items) - 1
+	}
+}
+
+func (m model) repoPaneEntryCount() int {
+	return len(m.repos) + len(repoViews)
+}
+
+func (m model) repoPaneIndex() int {
+	if m.viewSelected {
+		return len(m.repos) + clamp(m.selectedView, 0, max(len(repoViews)-1, 0))
+	}
+	return clamp(m.selectedRepo, 0, max(len(m.repos)-1, 0))
+}
+
+func (m *model) setRepoPaneIndex(index int) {
+	count := m.repoPaneEntryCount()
+	if count == 0 {
+		m.selectedRepo = 0
+		m.selectedView = 0
+		m.viewSelected = false
+		m.selectedItem = 0
+		return
+	}
+
+	index = clamp(index, 0, count-1)
+	if index < len(m.repos) {
+		m.selectedRepo = index
+		m.viewSelected = false
+	} else {
+		m.selectedView = index - len(m.repos)
+		m.viewSelected = true
+	}
+	m.selectedItem = 0
+}
+
+func (m model) visibleWorkItems() []workbench.WorkItem {
+	if m.viewSelected {
+		view, ok := m.selectedRepoView()
+		if !ok {
+			return nil
+		}
+		return filterWorkItems(m.workItems, view.matches)
+	}
+
+	repo, ok := m.selectedRepoRef()
+	if !ok {
+		return nil
+	}
+	return filterWorkItems(m.workItems, func(item workbench.WorkItem) bool {
+		return item.Repo == repo
+	})
+}
+
+func (m model) selectedRepoRef() (workbench.RepoRef, bool) {
+	if len(m.repos) == 0 || m.selectedRepo < 0 || m.selectedRepo >= len(m.repos) {
+		return workbench.RepoRef{}, false
+	}
+	return m.repos[m.selectedRepo], true
+}
+
+func (m model) selectedRepoView() (repoView, bool) {
+	if m.selectedView < 0 || m.selectedView >= len(repoViews) {
+		return repoView{}, false
+	}
+	return repoViews[m.selectedView], true
+}
+
+func filterWorkItems(items []workbench.WorkItem, keep func(workbench.WorkItem) bool) []workbench.WorkItem {
+	out := make([]workbench.WorkItem, 0, len(items))
+	for _, item := range items {
+		if keep(item) {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func (v repoView) matches(item workbench.WorkItem) bool {
+	switch v.filter {
+	case repoViewActiveWorktrees:
+		return item.Worktree != nil
+	case repoViewReviewRequested:
+		return item.PullRequest != nil && item.PullRequest.ReviewState == "review requested"
+	case repoViewFailedChecks:
+		return item.Checks.State == workbench.CheckFailing
+	default:
+		return false
 	}
 }
 
@@ -239,13 +375,12 @@ func (m model) View() string {
 }
 
 func (m model) renderFull(width int) string {
-	contentWidth := max(width-frameBorderWidth, 0)
-	rightWidth := contentWidth - repoPaneWidth - workItemPaneWidth - paneBorderWidth*2
+	rightWidth := width - repoPaneWidth - workItemPaneWidth - paneBorderWidth*3 - paneGapWidth*2
 	focus := m.activePane()
 
-	left := m.repoLines(repoPaneWidth, focus == paneRepositories)
-	middle := m.workItemLines(workItemPaneWidth, focus == paneWorkItems)
-	right := m.previewLines(rightWidth, focus == panePreview)
+	left := m.repoLines(paneTextWidth(repoPaneWidth), focus == paneRepositories)
+	middle := m.workItemLines(paneTextWidth(workItemPaneWidth), focus == paneWorkItems)
+	right := m.previewLines(paneTextWidth(rightWidth))
 	bodyHeight := m.frameBodyHeight(max(len(left), max(len(middle), len(right))))
 
 	out := []string{
@@ -254,53 +389,67 @@ func (m model) renderFull(width int) string {
 	}
 	body := lipgloss.JoinHorizontal(
 		lipgloss.Top,
-		m.renderPane(left, repoPaneWidth, bodyHeight, false),
-		m.renderPane(middle, workItemPaneWidth, bodyHeight, true),
-		m.renderPane(right, rightWidth, bodyHeight, true),
+		m.renderPane(m.paneHeading(paneRepositories), left, repoPaneWidth, bodyHeight, focus == paneRepositories),
+		paneGap(bodyHeight+frameBorderLines),
+		m.renderPane(m.paneHeading(paneWorkItems), middle, workItemPaneWidth, bodyHeight, focus == paneWorkItems),
+		paneGap(bodyHeight+frameBorderLines),
+		m.renderPane(m.paneHeading(panePreview), right, rightWidth, bodyHeight, focus == panePreview),
 	)
-	out = append(out, m.renderFrame(trimRightLines(body), width, bodyHeight))
+	out = append(out, body)
 	return strings.Join(out, "\n") + "\n"
 }
 
 func (m model) renderCompact(width int) string {
-	contentWidth := max(width-frameBorderWidth, 0)
+	contentWidth := max(width-paneBorderWidth, 0)
 	focus := m.activePane()
 	out := []string{
 		"gh-zen workbench",
 		m.keymapLine(width),
 	}
 
-	lines := m.workItemLines(contentWidth, focus == paneWorkItems)
-	lines = append(lines, "")
-	lines = append(lines, m.dividerLine(contentWidth))
-	lines = append(lines, m.previewLines(contentWidth, focus == panePreview)...)
-	bodyHeight := m.frameBodyHeight(len(lines))
+	workLines := m.workItemLines(paneTextWidth(contentWidth), focus == paneWorkItems)
+	previewLines := m.previewLines(paneTextWidth(contentWidth))
+	workHeight := len(workLines)
+	previewHeight := len(previewLines)
+	if m.height > 0 {
+		availableContentHeight := m.height - frameHeaderLines - frameBorderLines*2
+		if availableContentHeight > workHeight+previewHeight {
+			previewHeight += availableContentHeight - workHeight - previewHeight
+		}
+	}
 
-	content := renderPaneContent(lines, contentWidth, bodyHeight)
-	out = append(out, m.renderFrame(content, width, bodyHeight))
+	out = append(out,
+		m.renderPane(m.paneHeading(paneWorkItems), workLines, contentWidth, workHeight, focus == paneWorkItems),
+		m.renderPane(m.paneHeading(panePreview), previewLines, contentWidth, previewHeight, focus == panePreview),
+	)
 	return strings.Join(out, "\n") + "\n"
 }
 
 func (m model) repoLines(width int, focused bool) []string {
-	lines := []string{paneTitle("Repositories", focused)}
+	lines := []string{}
 	if len(m.repos) == 0 {
 		lines = append(lines, "  none")
 	} else {
 		for i, repo := range m.repos {
-			marker := selectionMarker(i == m.selectedRepo, focused)
+			marker := selectionMarker(!m.viewSelected && i == m.selectedRepo, focused)
 			lines = append(lines, truncate(fmt.Sprintf("%s %s", marker, repo.FullName()), width))
 		}
 	}
-	lines = append(lines, "", "Views", "  Active worktrees", "  Review requested", "  Failed checks")
+	lines = append(lines, "", "Views")
+	for i, view := range repoViews {
+		marker := selectionMarker(m.viewSelected && i == m.selectedView, focused)
+		lines = append(lines, truncate(fmt.Sprintf("%s %s", marker, view.label), width))
+	}
 	return lines
 }
 
 func (m model) workItemLines(width int, focused bool) []string {
-	lines := []string{paneTitle("Work Items", focused)}
-	if len(m.workItems) == 0 {
-		return append(lines, "  no work items")
+	items := m.visibleWorkItems()
+	if len(items) == 0 {
+		return []string{"  no work items"}
 	}
-	for i, item := range m.workItems {
+	lines := []string{}
+	for i, item := range items {
 		marker := selectionMarker(i == m.selectedItem, focused)
 		row := fmt.Sprintf("%s %-22s %-7s %s", marker, item.Title(), item.LocalLabel(), shortRemoteLabel(item))
 		lines = append(lines, truncate(row, width))
@@ -308,14 +457,13 @@ func (m model) workItemLines(width int, focused bool) []string {
 	return lines
 }
 
-func (m model) previewLines(width int, focused bool) []string {
+func (m model) previewLines(width int) []string {
 	item, ok := m.selectedWorkItem()
 	if !ok {
-		return []string{paneTitle("Preview", focused), "  no work item selected"}
+		return []string{"  no work item selected"}
 	}
 
 	lines := []string{
-		paneTitle("Preview", focused),
 		truncate("Repo: "+item.Repo.FullName(), width),
 		truncate("Item: "+item.Title(), width),
 		truncate("Where: "+item.Location(), width),
@@ -347,20 +495,52 @@ func (m model) previewLines(width int, focused bool) []string {
 func (m model) keymapLine(width int) string {
 	focus := m.activePane()
 	prefix := focus.label() + " keys: "
+	paneKey := m.paneNumberKey()
 	switch focus {
 	case paneRepositories, paneWorkItems:
-		return truncate(prefix+"j/k move  g/G jump  tab/S-tab pane  q quit", width)
+		return m.renderKeymapLine(prefix, []keyBinding{
+			{key: "j/k", description: "move"},
+			{key: "g/G", description: "jump"},
+			{key: paneKey, description: "pane"},
+			{key: "tab/S-tab", description: "pane"},
+			{key: "q", description: "quit"},
+		}, width)
 	case panePreview:
-		return truncate(prefix+"tab/S-tab pane  q quit", width)
+		return m.renderKeymapLine(prefix, []keyBinding{
+			{key: paneKey, description: "pane"},
+			{key: "tab/S-tab", description: "pane"},
+			{key: "q", description: "quit"},
+		}, width)
 	}
-	return truncate(prefix+"tab/S-tab pane  q quit", width)
+	return m.renderKeymapLine(prefix, []keyBinding{
+		{key: paneKey, description: "pane"},
+		{key: "tab/S-tab", description: "pane"},
+		{key: "q", description: "quit"},
+	}, width)
 }
 
-func paneTitle(label string, focused bool) string {
-	if focused {
-		return label + " [active]"
+func (m model) paneNumberKey() string {
+	keys := make([]string, len(m.paneOrder()))
+	for i := range keys {
+		keys[i] = fmt.Sprintf("[%d]", i+1)
 	}
-	return label
+	return strings.Join(keys, "/")
+}
+
+func (m model) renderKeymapLine(prefix string, bindings []keyBinding, width int) string {
+	var out strings.Builder
+	out.WriteString(prefix)
+	for i, binding := range bindings {
+		if i > 0 {
+			out.WriteString("  ")
+		}
+		out.WriteString(m.styles.Key.Render(binding.key))
+		if binding.description != "" {
+			out.WriteByte(' ')
+			out.WriteString(binding.description)
+		}
+	}
+	return truncate(out.String(), width)
 }
 
 // selectionMarker keeps the retained selection visible outside the active pane.
@@ -374,11 +554,6 @@ func selectionMarker(selected, focused bool) string {
 	return "*"
 }
 
-// dividerLine renders horizontal separators through the theme boundary.
-func (m model) dividerLine(width int) string {
-	return m.styles.Divider.Render(strings.Repeat(horizontalLineGlyph, width))
-}
-
 func (m model) frameBodyHeight(contentHeight int) int {
 	if m.height <= 0 {
 		return contentHeight
@@ -390,61 +565,77 @@ func (m model) frameBodyHeight(contentHeight int) int {
 	return contentHeight
 }
 
-// renderFrame owns the outer workbench rectangle.
-func (m model) renderFrame(content string, width int, bodyHeight int) string {
-	return lipgloss.NewStyle().
-		Width(max(width-frameBorderWidth, 0)).
-		Height(bodyHeight).
-		Border(lipgloss.Border{
-			Top:         horizontalLineGlyph,
-			Bottom:      horizontalLineGlyph,
-			Left:        paneBorderGlyph,
-			Right:       paneBorderGlyph,
-			TopLeft:     frameTopLeftGlyph,
-			TopRight:    frameTopRightGlyph,
-			BottomLeft:  frameBottomLeftGlyph,
-			BottomRight: frameBottomRightGlyph,
-		}, true).
-		BorderForeground(m.styles.FrameBorder.GetForeground()).
-		Render(content)
+// renderPane draws a lazygit-style independent pane box.
+func (m model) renderPane(title string, lines []string, width int, height int, focused bool) string {
+	content := renderPaneContent(lines, width, height)
+	contentLines := strings.Split(content, "\n")
+	border := m.styles.PaneBorder.GetForeground()
+	if focused {
+		border = m.styles.FrameBorder.GetForeground()
+	}
+	borderStyle := lipgloss.NewStyle().Foreground(border)
+	leftBorder := borderStyle.Render(paneBorderGlyph)
+	rightBorder := borderStyle.Render(paneBorderGlyph)
+
+	out := make([]string, 0, height+frameBorderLines)
+	out = append(out, m.paneTopBorder(width, title, borderStyle))
+	for i := range height {
+		out = append(out, leftBorder+pad(lineAt(contentLines, i), width)+rightBorder)
+	}
+	out = append(out, borderStyle.Render(frameBottomLeftGlyph+strings.Repeat(horizontalLineGlyph, width)+frameBottomRightGlyph))
+	return strings.Join(out, "\n")
 }
 
-// renderPane pads pane content and lets Lip Gloss own pane borders.
-func (m model) renderPane(lines []string, width int, height int, bordered bool) string {
-	content := renderPaneContent(lines, width, height)
-	if !bordered {
-		return content
+func (m model) paneTopBorder(width int, title string, borderStyle lipgloss.Style) string {
+	title = truncate(horizontalLineGlyph+title, width)
+	line := title + strings.Repeat(horizontalLineGlyph, max(width-lipgloss.Width(title), 0))
+	return borderStyle.Render(frameTopLeftGlyph + line + frameTopRightGlyph)
+}
+
+func paneGap(height int) string {
+	lines := make([]string, height)
+	for i := range lines {
+		lines[i] = strings.Repeat(" ", paneGapWidth)
 	}
-	return lipgloss.NewStyle().
-		BorderLeft(true).
-		BorderStyle(lipgloss.Border{Left: paneBorderGlyph}).
-		BorderForeground(m.styles.PaneBorder.GetForeground()).
-		PaddingLeft(1).
-		Render(content)
+	return strings.Join(lines, "\n")
+}
+
+func paneTextWidth(width int) int {
+	return max(width-paneContentPaddingLeft, 0)
+}
+
+func (m model) paneHeading(pane paneFocus) string {
+	number, ok := m.paneNumber(pane)
+	if !ok {
+		return pane.borderLabel()
+	}
+	return fmt.Sprintf("%s[%d]", pane.borderLabel(), number)
+}
+
+func (m model) paneNumber(pane paneFocus) (int, bool) {
+	for i, visiblePane := range m.paneOrder() {
+		if visiblePane == pane {
+			return i + 1, true
+		}
+	}
+	return 0, false
 }
 
 // renderPaneContent keeps each pane block rectangular before borders are added.
 func renderPaneContent(lines []string, width int, height int) string {
 	out := make([]string, height)
 	for i := range out {
-		out[i] = pad(lineAt(lines, i), width)
+		out[i] = pad(strings.Repeat(" ", paneContentPaddingLeft)+lineAt(lines, i), width)
 	}
 	return strings.Join(out, "\n")
 }
 
-func trimRightLines(s string) string {
-	lines := strings.Split(s, "\n")
-	for i := range lines {
-		lines[i] = strings.TrimRight(lines[i], " ")
-	}
-	return strings.Join(lines, "\n")
-}
-
 func (m model) selectedWorkItem() (workbench.WorkItem, bool) {
-	if len(m.workItems) == 0 || m.selectedItem < 0 || m.selectedItem >= len(m.workItems) {
+	items := m.visibleWorkItems()
+	if len(items) == 0 || m.selectedItem < 0 || m.selectedItem >= len(items) {
 		return workbench.WorkItem{}, false
 	}
-	return m.workItems[m.selectedItem], true
+	return items[m.selectedItem], true
 }
 
 func shortRemoteLabel(item workbench.WorkItem) string {
@@ -480,6 +671,16 @@ func pad(s string, width int) string {
 		return s
 	}
 	return s + strings.Repeat(" ", padWidth)
+}
+
+func clamp(value int, minValue int, maxValue int) int {
+	if value < minValue {
+		return minValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
 }
 
 // truncate uses terminal display width so wide characters keep columns aligned.

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -151,6 +151,48 @@ func TestUpdate_TabChangesFocusedPane(t *testing.T) {
 	}
 }
 
+func TestUpdate_NumberKeysFocusVisiblePanes(t *testing.T) {
+	start := newModel()
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for pane number key, got %T", cmd)
+	}
+	mm := got.(model)
+	if mm.focusedPane != paneRepositories {
+		t.Fatalf("expected 1 to focus repositories pane, got %v", mm.focusedPane)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	mm = got.(model)
+	if mm.focusedPane != paneWorkItems {
+		t.Fatalf("expected 2 to focus work items pane, got %v", mm.focusedPane)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	mm = got.(model)
+	if mm.focusedPane != panePreview {
+		t.Fatalf("expected 3 to focus preview pane, got %v", mm.focusedPane)
+	}
+}
+
+func TestUpdate_NumberKeysFollowCompactVisiblePanes(t *testing.T) {
+	start := newModel()
+	start.width = 50
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	mm := got.(model)
+	if mm.focusedPane != panePreview {
+		t.Fatalf("expected compact 2 to focus preview pane, got %v", mm.focusedPane)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	mm = got.(model)
+	if mm.focusedPane != panePreview {
+		t.Fatalf("expected compact 3 to leave focus unchanged, got %v", mm.focusedPane)
+	}
+}
+
 func TestUpdate_MovementTargetsFocusedPane(t *testing.T) {
 	start := newModel()
 	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
@@ -163,6 +205,53 @@ func TestUpdate_MovementTargetsFocusedPane(t *testing.T) {
 	}
 	if mm.selectedItem != 0 {
 		t.Fatalf("expected work item selection to stay unchanged, got %d", mm.selectedItem)
+	}
+}
+
+func TestUpdate_RepositoryViewsFilterWorkItems(t *testing.T) {
+	start := newModel()
+	start.focusedPane = paneRepositories
+	start.selectedItem = 2
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	mm := got.(model)
+	if mm.viewSelected {
+		t.Fatalf("expected first repository movement to select another repo, got view selected")
+	}
+	if items := mm.visibleWorkItems(); len(items) != 0 {
+		t.Fatalf("expected dotfiles repo to have no fake work items, got %d", len(items))
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	mm = got.(model)
+	if !mm.viewSelected || mm.selectedView != int(repoViewActiveWorktrees) {
+		t.Fatalf("expected active worktrees view, got viewSelected=%v selectedView=%d", mm.viewSelected, mm.selectedView)
+	}
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected filter change to reset selected work item, got %d", mm.selectedItem)
+	}
+	active := mm.visibleWorkItems()
+	if len(active) == 0 {
+		t.Fatalf("expected active worktrees view to include work items")
+	}
+	for _, item := range active {
+		if item.Worktree == nil {
+			t.Fatalf("expected active worktrees view to exclude item without worktree: %+v", item)
+		}
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	mm = got.(model)
+	reviewRequested := mm.visibleWorkItems()
+	if len(reviewRequested) != 1 || reviewRequested[0].PullRequest == nil || reviewRequested[0].PullRequest.ReviewState != "review requested" {
+		t.Fatalf("expected review requested view to include only review-requested PR work, got %+v", reviewRequested)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	mm = got.(model)
+	failedChecks := mm.visibleWorkItems()
+	if len(failedChecks) != 1 || failedChecks[0].Checks.State != workbench.CheckFailing {
+		t.Fatalf("expected failed checks view to include only failing-check work, got %+v", failedChecks)
 	}
 }
 
@@ -215,10 +304,13 @@ func TestTruncate_UsesTerminalDisplayWidth(t *testing.T) {
 }
 
 func TestRenderPane_UsesLipGlossBorderWidth(t *testing.T) {
-	got := newModel().renderPane([]string{"header", "row"}, 10, 3, true)
+	got := newModel().renderPane("Demo[1]", []string{"header", "row"}, 10, 3, true)
 	lines := strings.Split(got, "\n")
-	if len(lines) != 3 {
-		t.Fatalf("expected bordered pane height 3, got %d in %q", len(lines), got)
+	if len(lines) != 5 {
+		t.Fatalf("expected bordered pane height 5, got %d in %q", len(lines), got)
+	}
+	if !strings.Contains(lines[0], "Demo[1]") {
+		t.Fatalf("expected pane title in top border, got %q", lines[0])
 	}
 	for _, line := range lines {
 		if width := lipgloss.Width(line); width != 10+paneBorderWidth {

--- a/internal/app/styles.go
+++ b/internal/app/styles.go
@@ -23,6 +23,8 @@ type Styles struct {
 // DefaultStyles returns the built-in semantic styles.
 func DefaultStyles() Styles {
 	return Styles{
+		Key:         lipgloss.NewStyle().Foreground(lipgloss.Color("#5AA9FF")),
 		FrameBorder: lipgloss.NewStyle().Foreground(lipgloss.Color("#00D7FF")),
+		PaneBorder:  lipgloss.NewStyle().Foreground(lipgloss.Color("#3A4856")),
 	}
 }

--- a/internal/app/testdata/TestView_Initial.golden
+++ b/internal/app/testdata/TestView_Initial.golden
@@ -1,15 +1,14 @@
 gh-zen  repository workbench
-Work Items keys: j/k move  g/G jump  tab/S-tab pane  q quit
-┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
-│Repositories           │ Work Items [active]                    │ Preview                         │
-│* 0maru/gh-zen         │ > main                   clean   no PR │ Repo: 0maru/gh-zen              │
-│  0maru/dotfiles       │   feat/config-loader     dirty   PR #24│ Item: main                      │
-│                       │   feat/repo-workbench    clean   #6    │ Where: ~/workspaces/github.com/~│
-│Views                  │   agent/preview-state    missing #8    │ Branch: main -> origin/main     │
-│  Active worktrees     │   #34 Branch preview UX  unknown #34   │ Local: clean                    │
-│  Review requested     │                                        │ Issue: no issue                 │
-│  Failed checks        │                                        │ PR: no PR                       │
-│                       │                                        │ Checks: checks passing          │
-│                       │                                        │ Commits:                        │
-│                       │                                        │   3da43e7 Set up GitHub CLI ext~│
-└──────────────────────────────────────────────────────────────────────────────────────────────────┘
+Work Items keys: j/k move  g/G jump  [1]/[2]/[3] pane  tab/S-tab pane  q quit
+┌─Repositories[1]───────┐ ┌─WorkItems[2]────────────────────────────┐ ┌─Review[3]──────────────────┐
+│ * 0maru/gh-zen        │ │ > main                   clean   no PR  │ │ Repo: 0maru/gh-zen         │
+│   0maru/dotfiles      │ │   feat/config-loader     dirty   PR #24 │ │ Item: main                 │
+│                       │ │   feat/repo-workbench    clean   #6     │ │ Where: ~/workspaces/github~│
+│ Views                 │ │   agent/preview-state    missing #8     │ │ Branch: main -> origin/main│
+│   Active worktrees    │ │   #34 Branch preview UX  unknown #34    │ │ Local: clean               │
+│   Review requested    │ │                                         │ │ Issue: no issue            │
+│   Failed checks       │ │                                         │ │ PR: no PR                  │
+│                       │ │                                         │ │ Checks: checks passing     │
+│                       │ │                                         │ │ Commits:                   │
+│                       │ │                                         │ │   3da43e7 Set up GitHub CL~│
+└───────────────────────┘ └─────────────────────────────────────────┘ └────────────────────────────┘

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"flag"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
 )
 
 var update = flag.Bool("update", false, "update golden files")
@@ -51,8 +53,8 @@ func TestView_Compact_HidesRepositoryPane(t *testing.T) {
 	if bytes.Contains([]byte(got), []byte("Repositories")) {
 		t.Fatalf("expected compact view to hide repository pane, got:\n%s", got)
 	}
-	if !bytes.Contains([]byte(got), []byte("Work Items")) || !bytes.Contains([]byte(got), []byte("Preview")) {
-		t.Fatalf("expected compact view to keep list and preview, got:\n%s", got)
+	if !bytes.Contains([]byte(got), []byte("WorkItems[1]")) || !bytes.Contains([]byte(got), []byte("Review[2]")) {
+		t.Fatalf("expected compact view to keep list and review panes, got:\n%s", got)
 	}
 }
 
@@ -68,14 +70,34 @@ func TestView_KeymapFollowsFocusedPane(t *testing.T) {
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	next := updated.(model).View()
-	if !bytes.Contains([]byte(next), []byte("Preview keys: tab/S-tab pane  q quit")) {
-		t.Fatalf("expected focused preview header, got:\n%s", next)
+	if !bytes.Contains([]byte(next), []byte("Review keys: [1]/[2]/[3] pane  tab/S-tab pane  q quit")) {
+		t.Fatalf("expected focused review header, got:\n%s", next)
 	}
-	if got := strings.Split(next, "\n")[1]; !strings.HasPrefix(got, "Preview keys:") {
-		t.Fatalf("expected preview keymap directly under title, got line %q", got)
+	if got := strings.Split(next, "\n")[1]; !strings.HasPrefix(got, "Review keys:") {
+		t.Fatalf("expected review keymap directly under title, got line %q", got)
 	}
 	if bytes.Contains([]byte(next), []byte("j/k move")) {
 		t.Fatalf("expected preview keymap to omit movement keys, got:\n%s", next)
+	}
+}
+
+func TestView_KeymapStylesOnlyKeys(t *testing.T) {
+	r := lipgloss.NewRenderer(io.Discard)
+	r.SetColorProfile(termenv.TrueColor)
+
+	m := newModel()
+	m.styles.Key = m.styles.Key.Renderer(r)
+	got := m.keymapLine(defaultWidth)
+	want := "Work Items keys: j/k move  g/G jump  [1]/[2]/[3] pane  tab/S-tab pane  q quit"
+
+	if stripped := ansi.Strip(got); stripped != want {
+		t.Fatalf("expected keymap text to stay unchanged, got %q", stripped)
+	}
+	if !strings.Contains(got, m.styles.Key.Render("j/k")+" move") {
+		t.Fatalf("expected j/k key to be styled without styling description, got %q", got)
+	}
+	if strings.Contains(got, m.styles.Key.Render("move")) || strings.Contains(got, m.styles.Key.Render("jump")) {
+		t.Fatalf("expected key descriptions to stay unstyled, got %q", got)
 	}
 }
 
@@ -85,8 +107,21 @@ func TestView_FullLayoutSeparatesPanes(t *testing.T) {
 	if len(lines) < 4 {
 		t.Fatalf("expected full layout output, got:\n%s", got)
 	}
-	if !strings.Contains(lines[3], paneBorderGlyph) {
-		t.Fatalf("expected visible pane separators in header row, got line %q", lines[3])
+	top := ansi.Strip(lines[2])
+	if strings.Count(top, frameTopLeftGlyph) != 3 || strings.Count(top, frameTopRightGlyph) != 3 {
+		t.Fatalf("expected three independent pane boxes, got top line %q", top)
+	}
+	if !strings.Contains(top, frameTopRightGlyph+" "+frameTopLeftGlyph) {
+		t.Fatalf("expected visible gap between pane boxes, got top line %q", top)
+	}
+	for _, title := range []string{"Repositories[1]", "WorkItems[2]", "Review[3]"} {
+		if !strings.Contains(top, title) {
+			t.Fatalf("expected top border to include pane title %q, got %q", title, top)
+		}
+	}
+	body := ansi.Strip(lines[3])
+	if strings.Count(body, paneBorderGlyph) != 6 {
+		t.Fatalf("expected each pane row to have left and right borders, got %q", body)
 	}
 }
 
@@ -125,6 +160,19 @@ func TestView_CompactNormalizesHiddenRepositoryFocus(t *testing.T) {
 	}
 	if bytes.Contains([]byte(got), []byte("Repositories keys:")) {
 		t.Fatalf("expected compact view to hide repository keymap, got:\n%s", got)
+	}
+}
+
+func TestView_CompactKeymapShowsVisiblePaneNumbers(t *testing.T) {
+	m := newModel()
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 50, Height: 20})
+	got := updated.(model).View()
+
+	if !bytes.Contains([]byte(got), []byte("[1]/[2] pane")) {
+		t.Fatalf("expected compact keymap to show visible pane numbers, got:\n%s", got)
+	}
+	if bytes.Contains([]byte(got), []byte("[1]/[2]/[3] pane")) {
+		t.Fatalf("expected compact keymap to omit hidden repository number, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Render the fake Repository Workbench as independent lazygit-style pane boxes with pane numbers in the border titles.
- Add direct pane focus keys and keymap styling for pane shortcuts.
- Make repository Views selectable and use them to filter the fake work item list.

## Why

This completes the fake-data Repository Workbench shell expected by issues #5 and #6, including a functional left-pane filter surface instead of static View labels.

## Validation

- make test-small
- make check
- make build

## Notes

The PR is draft so the UI shape and label wording can still be adjusted before review.