### PR TITLE
Add asynchronous preview state machine

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -62,16 +62,20 @@ func (p paneFocus) borderLabel() string {
 }
 
 type model struct {
-	width        int
-	height       int
-	repos        []workbench.RepoRef
-	selectedRepo int
-	selectedView int
-	viewSelected bool
-	workItems    []workbench.WorkItem
-	selectedItem int
-	focusedPane  paneFocus
-	styles       Styles
+	width                int
+	height               int
+	repos                []workbench.RepoRef
+	selectedRepo         int
+	selectedView         int
+	viewSelected         bool
+	workItems            []workbench.WorkItem
+	selectedItem         int
+	focusedPane          paneFocus
+	focusedWorkItemID    string
+	preview              previewState
+	nextPreviewRequestID int
+	previewLoader        previewLoader
+	styles               Styles
 }
 
 type repoViewFilter int
@@ -103,20 +107,43 @@ func New() tea.Model {
 }
 
 func newModel() model {
-	return model{
-		repos:     workbench.FakeRepos(),
-		workItems: workbench.FakeWorkItems(),
-		styles:    DefaultStyles(),
-	}
+	return newModelWithPreviewLoader(fakeDelayedPreviewLoader(defaultPreviewDelay))
 }
 
-func (m model) Init() tea.Cmd { return nil }
+func newModelWithPreviewLoader(loader previewLoader) model {
+	m := model{
+		repos:         workbench.FakeRepos(),
+		workItems:     workbench.FakeWorkItems(),
+		previewLoader: loader,
+		styles:        DefaultStyles(),
+	}
+	_ = m.startPreviewLoadForCurrentItem()
+	return m
+}
+
+func (m model) Init() tea.Cmd {
+	if m.preview.status != previewLoading || m.previewLoader == nil {
+		return nil
+	}
+	item, ok := m.selectedWorkItem()
+	if !ok || item.ID != m.focusedWorkItemID {
+		return nil
+	}
+	return m.previewLoader(previewRequest{
+		requestID:  m.preview.requestID,
+		workItemID: item.ID,
+		item:       item,
+	})
+}
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		return m, nil
+	case previewResultMsg:
+		m.handlePreviewResult(msg)
 		return m, nil
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -139,19 +166,88 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "j", "down":
 			m.moveFocusedSelection(1)
-			return m, nil
+			return m, m.startPreviewLoadIfFocusedItemChanged()
 		case "k", "up":
 			m.moveFocusedSelection(-1)
-			return m, nil
+			return m, m.startPreviewLoadIfFocusedItemChanged()
 		case "g":
 			m.jumpFocusedSelection(false)
-			return m, nil
+			return m, m.startPreviewLoadIfFocusedItemChanged()
 		case "G":
 			m.jumpFocusedSelection(true)
-			return m, nil
+			return m, m.startPreviewLoadIfFocusedItemChanged()
 		}
 	}
 	return m, nil
+}
+
+func (m *model) startPreviewLoadIfFocusedItemChanged() tea.Cmd {
+	item, ok := m.selectedWorkItem()
+	if !ok {
+		m.focusedWorkItemID = ""
+		m.preview = previewState{status: previewEmpty}
+		return nil
+	}
+	if item.ID == "" {
+		m.focusedWorkItemID = ""
+		m.preview = previewState{status: previewEmpty}
+		return nil
+	}
+	if item.ID == m.focusedWorkItemID {
+		return nil
+	}
+	return m.startPreviewLoadForCurrentItem()
+}
+
+func (m *model) startPreviewLoadForCurrentItem() tea.Cmd {
+	item, ok := m.selectedWorkItem()
+	if !ok || item.ID == "" {
+		m.focusedWorkItemID = ""
+		m.preview = previewState{status: previewEmpty}
+		return nil
+	}
+
+	m.nextPreviewRequestID++
+	requestID := m.nextPreviewRequestID
+	m.focusedWorkItemID = item.ID
+	m.preview = previewState{
+		status:            previewLoading,
+		requestID:         requestID,
+		focusedWorkItemID: item.ID,
+	}
+	if m.previewLoader == nil {
+		return nil
+	}
+	return m.previewLoader(previewRequest{
+		requestID:  requestID,
+		workItemID: item.ID,
+		item:       item,
+	})
+}
+
+func (m *model) handlePreviewResult(msg previewResultMsg) {
+	if msg.requestID != m.preview.requestID || msg.workItemID != m.focusedWorkItemID {
+		return
+	}
+
+	next := previewState{
+		requestID:         msg.requestID,
+		focusedWorkItemID: msg.workItemID,
+	}
+	switch {
+	case msg.err != nil:
+		next.status = previewError
+		next.errorMessage = msg.err.Error()
+	case msg.empty:
+		next.status = previewEmpty
+	default:
+		next.status = previewLoaded
+		next.loaded = msg.data
+		if next.loaded.workItemID == "" {
+			next.loaded.workItemID = msg.workItemID
+		}
+	}
+	m.preview = next
 }
 
 func (m *model) focusNextPane() {
@@ -458,35 +554,37 @@ func (m model) workItemLines(width int, focused bool) []string {
 }
 
 func (m model) previewLines(width int) []string {
-	item, ok := m.selectedWorkItem()
-	if !ok {
-		return []string{"  no work item selected"}
+	switch m.preview.status {
+	case previewLoading:
+		return m.previewStatusLines(width, "Loading preview...")
+	case previewLoaded:
+		if m.preview.loaded.workItemID != m.focusedWorkItemID {
+			return m.previewStatusLines(width, "Loading preview...")
+		}
+		return workItemPreviewLines(m.preview.loaded.item, width)
+	case previewEmpty:
+		if _, ok := m.selectedWorkItem(); !ok {
+			return []string{"  no work item selected"}
+		}
+		return m.previewStatusLines(width, "No preview data")
+	case previewError:
+		lines := m.previewStatusLines(width, "Preview failed")
+		if m.preview.errorMessage != "" {
+			lines = append(lines, truncate("Error: "+m.preview.errorMessage, width))
+		}
+		return lines
+	default:
+		if _, ok := m.selectedWorkItem(); !ok {
+			return []string{"  no work item selected"}
+		}
+		return m.previewStatusLines(width, "Preview idle")
 	}
+}
 
-	lines := []string{
-		truncate("Repo: "+item.Repo.FullName(), width),
-		truncate("Item: "+item.Title(), width),
-		truncate("Where: "+item.Location(), width),
-	}
-	if item.Branch != nil {
-		base := item.Branch.Base
-		if base == "" {
-			base = "unknown base"
-		}
-		lines = append(lines, truncate("Branch: "+item.Branch.Name+" -> "+base, width))
-	}
-	lines = append(lines, truncate("Local: "+item.LocalLabel(), width))
-	lines = append(lines, truncate("Issue: "+item.IssueLabel(), width))
-	lines = append(lines, truncate("PR: "+item.PullRequestLabel(), width))
-	if item.PullRequest != nil && item.PullRequest.ReviewState != "" {
-		lines = append(lines, truncate("Review: "+item.PullRequest.ReviewState, width))
-	}
-	lines = append(lines, truncate("Checks: "+item.Checks.Label(), width))
-	if len(item.Commits) > 0 {
-		lines = append(lines, "Commits:")
-		for _, commit := range item.Commits {
-			lines = append(lines, truncate("  "+commit.ShortSHA+" "+commit.Subject, width))
-		}
+func (m model) previewStatusLines(width int, status string) []string {
+	lines := []string{truncate(status, width)}
+	if item, ok := m.selectedWorkItem(); ok {
+		lines = append(lines, truncate("Item: "+item.Title(), width))
 	}
 	return lines
 }

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,6 +11,54 @@ import (
 
 	"github.com/0maru/gh-zen/internal/workbench"
 )
+
+func requirePreviewResultMsg(t *testing.T, cmd tea.Cmd) previewResultMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatalf("expected preview command, got nil")
+	}
+	msg := cmd()
+	result, ok := msg.(previewResultMsg)
+	if !ok {
+		t.Fatalf("expected previewResultMsg, got %T", msg)
+	}
+	return result
+}
+
+func requireModelEqualIgnoringPreviewLoader(t *testing.T, got tea.Model, want model) {
+	t.Helper()
+	mm, ok := got.(model)
+	if !ok {
+		t.Fatalf("expected model, got %T", got)
+	}
+	mm.previewLoader = nil
+	want.previewLoader = nil
+	if !reflect.DeepEqual(mm, want) {
+		t.Fatalf("expected model unchanged, got %+v", mm)
+	}
+}
+
+func emptyPreviewLoader(req previewRequest) tea.Cmd {
+	return func() tea.Msg {
+		return previewResultMsg{
+			requestID:  req.requestID,
+			workItemID: req.workItemID,
+			empty:      true,
+		}
+	}
+}
+
+func errorPreviewLoader(err error) previewLoader {
+	return func(req previewRequest) tea.Cmd {
+		return func() tea.Msg {
+			return previewResultMsg{
+				requestID:  req.requestID,
+				workItemID: req.workItemID,
+				err:        err,
+			}
+		}
+	}
+}
 
 func TestInit_ReturnsNilCmd(t *testing.T) {
 	if cmd := (model{}).Init(); cmd != nil {
@@ -45,9 +94,7 @@ func TestUpdate_NonQuitKey_NoCommand(t *testing.T) {
 	if cmd != nil {
 		t.Fatalf("expected nil cmd for non-quit key, got %T", cmd)
 	}
-	if !reflect.DeepEqual(got, start) {
-		t.Fatalf("expected model unchanged, got %+v", got)
-	}
+	requireModelEqualIgnoringPreviewLoader(t, got, start)
 }
 
 func TestNew_LoadsFakeWorkbenchData(t *testing.T) {
@@ -60,6 +107,35 @@ func TestNew_LoadsFakeWorkbenchData(t *testing.T) {
 	}
 	if len(got.workItems) == 0 {
 		t.Fatalf("expected fake work items")
+	}
+	if got.preview.status != previewLoading {
+		t.Fatalf("expected initial preview to be loading, got %v", got.preview.status)
+	}
+	if got.focusedWorkItemID != got.workItems[0].ID {
+		t.Fatalf("expected focused item %q, got %q", got.workItems[0].ID, got.focusedWorkItemID)
+	}
+}
+
+func TestInit_LoadsInitialPreview(t *testing.T) {
+	start := newModelWithPreviewLoader(fakeDelayedPreviewLoader(0))
+	msg := requirePreviewResultMsg(t, start.Init())
+	if msg.requestID != start.preview.requestID {
+		t.Fatalf("expected request ID %d, got %d", start.preview.requestID, msg.requestID)
+	}
+	if msg.workItemID != start.focusedWorkItemID {
+		t.Fatalf("expected work item ID %q, got %q", start.focusedWorkItemID, msg.workItemID)
+	}
+
+	got, cmd := start.Update(msg)
+	if cmd != nil {
+		t.Fatalf("expected nil command after preview result, got %T", cmd)
+	}
+	mm := got.(model)
+	if mm.preview.status != previewLoaded {
+		t.Fatalf("expected loaded preview, got %v", mm.preview.status)
+	}
+	if mm.preview.loaded.item.ID != start.focusedWorkItemID {
+		t.Fatalf("expected loaded item %q, got %q", start.focusedWorkItemID, mm.preview.loaded.item.ID)
 	}
 }
 
@@ -84,27 +160,36 @@ func TestUpdate_MoveSelection(t *testing.T) {
 	}
 
 	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd for movement, got %T", cmd)
+	if cmd == nil {
+		t.Fatalf("expected preview load command for movement")
 	}
 	mm := got.(model)
 	if mm.selectedItem != 1 {
 		t.Fatalf("expected j to move selection to 1, got %d", mm.selectedItem)
 	}
 
-	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	got, cmd = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if cmd == nil {
+		t.Fatalf("expected preview load command for movement back to first item")
+	}
 	mm = got.(model)
 	if mm.selectedItem != 0 {
 		t.Fatalf("expected k to move selection back to 0, got %d", mm.selectedItem)
 	}
 
-	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+	got, cmd = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+	if cmd == nil {
+		t.Fatalf("expected preview load command for jump to end")
+	}
 	mm = got.(model)
 	if mm.selectedItem != len(mm.workItems)-1 {
 		t.Fatalf("expected G to move selection to end, got %d", mm.selectedItem)
 	}
 
-	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+	got, cmd = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+	if cmd == nil {
+		t.Fatalf("expected preview load command for jump to start")
+	}
 	mm = got.(model)
 	if mm.selectedItem != 0 {
 		t.Fatalf("expected g to move selection to start, got %d", mm.selectedItem)
@@ -113,16 +198,25 @@ func TestUpdate_MoveSelection(t *testing.T) {
 
 func TestUpdate_MoveSelection_ClampsAtEdges(t *testing.T) {
 	start := newModel()
-	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd when clamped at start, got %T", cmd)
+	}
 	mm := got.(model)
 	if mm.selectedItem != 0 {
 		t.Fatalf("expected selection to stay at start, got %d", mm.selectedItem)
 	}
 
-	mm.selectedItem = len(mm.workItems) - 1
-	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	items := mm.visibleWorkItems()
+	mm.selectedItem = len(items) - 1
+	mm.focusedWorkItemID = items[len(items)-1].ID
+	mm.preview = previewState{status: previewLoading, focusedWorkItemID: mm.focusedWorkItemID}
+	got, cmd = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd when clamped at end, got %T", cmd)
+	}
 	mm = got.(model)
-	if mm.selectedItem != len(mm.workItems)-1 {
+	if mm.selectedItem != len(items)-1 {
 		t.Fatalf("expected selection to stay at end, got %d", mm.selectedItem)
 	}
 }
@@ -198,13 +292,19 @@ func TestUpdate_MovementTargetsFocusedPane(t *testing.T) {
 	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
 	mm := got.(model)
 
-	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	got, cmd := mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd when repository movement selects no work item, got %T", cmd)
+	}
 	mm = got.(model)
 	if mm.selectedRepo != 1 {
 		t.Fatalf("expected j to move repository selection when repo pane is focused, got %d", mm.selectedRepo)
 	}
 	if mm.selectedItem != 0 {
 		t.Fatalf("expected work item selection to stay unchanged, got %d", mm.selectedItem)
+	}
+	if mm.preview.status != previewEmpty {
+		t.Fatalf("expected empty preview after selecting repo with no work items, got %v", mm.preview.status)
 	}
 }
 
@@ -260,10 +360,107 @@ func TestUpdate_PreviewPaneIgnoresMovementKeys(t *testing.T) {
 	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyTab})
 	mm := got.(model)
 
-	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	got, cmd := mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if cmd != nil {
+		t.Fatalf("expected preview pane movement to skip preview load, got %T", cmd)
+	}
 	mm = got.(model)
 	if mm.selectedRepo != 0 || mm.selectedItem != 0 {
 		t.Fatalf("expected preview pane movement to leave selections unchanged, got repo=%d item=%d", mm.selectedRepo, mm.selectedItem)
+	}
+}
+
+func TestUpdate_FocusChangeStartsPreviewLoad(t *testing.T) {
+	start := newModelWithPreviewLoader(fakeDelayedPreviewLoader(0))
+	initialRequestID := start.preview.requestID
+	second := start.visibleWorkItems()[1]
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if cmd == nil {
+		t.Fatalf("expected preview load command")
+	}
+	mm := got.(model)
+	if mm.focusedWorkItemID != second.ID {
+		t.Fatalf("expected focused item %q, got %q", second.ID, mm.focusedWorkItemID)
+	}
+	if mm.preview.status != previewLoading {
+		t.Fatalf("expected loading preview, got %v", mm.preview.status)
+	}
+	if mm.preview.requestID != initialRequestID+1 {
+		t.Fatalf("expected request ID to increment to %d, got %d", initialRequestID+1, mm.preview.requestID)
+	}
+}
+
+func TestUpdate_StalePreviewResultIsDiscarded(t *testing.T) {
+	start := newModelWithPreviewLoader(fakeDelayedPreviewLoader(0))
+	firstResult := requirePreviewResultMsg(t, start.Init())
+
+	got, secondCmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	mm := got.(model)
+	secondID := mm.focusedWorkItemID
+
+	got, cmd := mm.Update(firstResult)
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for stale preview result, got %T", cmd)
+	}
+	mm = got.(model)
+	if mm.focusedWorkItemID != secondID {
+		t.Fatalf("expected focus to stay on %q, got %q", secondID, mm.focusedWorkItemID)
+	}
+	if mm.preview.status != previewLoading {
+		t.Fatalf("expected stale result to leave preview loading, got %v", mm.preview.status)
+	}
+	if mm.preview.loaded.item.ID == firstResult.workItemID {
+		t.Fatalf("expected stale item %q not to be loaded", firstResult.workItemID)
+	}
+
+	wrongIdentity := previewResultMsg{
+		requestID:  mm.preview.requestID,
+		workItemID: firstResult.workItemID,
+		data: previewData{
+			workItemID: firstResult.workItemID,
+			item:       firstResult.data.item,
+		},
+	}
+	got, _ = mm.Update(wrongIdentity)
+	mm = got.(model)
+	if mm.preview.status != previewLoading {
+		t.Fatalf("expected wrong work item identity to be discarded, got %v", mm.preview.status)
+	}
+
+	secondResult := requirePreviewResultMsg(t, secondCmd)
+	got, _ = mm.Update(secondResult)
+	mm = got.(model)
+	if mm.preview.status != previewLoaded {
+		t.Fatalf("expected current result to load preview, got %v", mm.preview.status)
+	}
+	if mm.preview.loaded.item.ID != secondID {
+		t.Fatalf("expected loaded item %q, got %q", secondID, mm.preview.loaded.item.ID)
+	}
+}
+
+func TestUpdate_EmptyPreviewResultRendersClearly(t *testing.T) {
+	start := newModelWithPreviewLoader(emptyPreviewLoader)
+	got, _ := start.Update(requirePreviewResultMsg(t, start.Init()))
+	mm := got.(model)
+	if mm.preview.status != previewEmpty {
+		t.Fatalf("expected empty preview, got %v", mm.preview.status)
+	}
+	if got := strings.Join(mm.previewLines(80), "\n"); !strings.Contains(got, "No preview data") {
+		t.Fatalf("expected empty preview copy, got %q", got)
+	}
+}
+
+func TestUpdate_ErrorPreviewResultRendersClearly(t *testing.T) {
+	start := newModelWithPreviewLoader(errorPreviewLoader(errors.New("fake preview failed")))
+	got, _ := start.Update(requirePreviewResultMsg(t, start.Init()))
+	mm := got.(model)
+	if mm.preview.status != previewError {
+		t.Fatalf("expected error preview, got %v", mm.preview.status)
+	}
+	lines := strings.Join(mm.previewLines(80), "\n")
+	if !strings.Contains(lines, "Preview failed") || !strings.Contains(lines, "fake preview failed") {
+		t.Fatalf("expected error preview copy, got %q", lines)
 	}
 }
 

--- a/internal/app/preview.go
+++ b/internal/app/preview.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/0maru/gh-zen/internal/workbench"
+)
+
+const defaultPreviewDelay = 120 * time.Millisecond
+
+type previewStatus int
+
+const (
+	previewIdle previewStatus = iota
+	previewLoading
+	previewLoaded
+	previewEmpty
+	previewError
+)
+
+type previewState struct {
+	status            previewStatus
+	requestID         int
+	focusedWorkItemID string
+	loaded            previewData
+	errorMessage      string
+}
+
+type previewRequest struct {
+	requestID  int
+	workItemID string
+	item       workbench.WorkItem
+}
+
+type previewData struct {
+	workItemID string
+	item       workbench.WorkItem
+}
+
+type previewResultMsg struct {
+	requestID  int
+	workItemID string
+	data       previewData
+	empty      bool
+	err        error
+}
+
+type previewLoader func(previewRequest) tea.Cmd
+
+func fakeDelayedPreviewLoader(delay time.Duration) previewLoader {
+	return func(req previewRequest) tea.Cmd {
+		return func() tea.Msg {
+			if delay > 0 {
+				time.Sleep(delay)
+			}
+			return previewResultMsg{
+				requestID:  req.requestID,
+				workItemID: req.workItemID,
+				data: previewData{
+					workItemID: req.workItemID,
+					item:       req.item,
+				},
+			}
+		}
+	}
+}
+
+func workItemPreviewLines(item workbench.WorkItem, width int) []string {
+	lines := []string{
+		truncate("Repo: "+item.Repo.FullName(), width),
+		truncate("Item: "+item.Title(), width),
+		truncate("Where: "+item.Location(), width),
+	}
+	if item.Branch != nil {
+		base := item.Branch.Base
+		if base == "" {
+			base = "unknown base"
+		}
+		lines = append(lines, truncate("Branch: "+item.Branch.Name+" -> "+base, width))
+	}
+	lines = append(lines, truncate("Local: "+item.LocalLabel(), width))
+	lines = append(lines, truncate("Issue: "+item.IssueLabel(), width))
+	lines = append(lines, truncate("PR: "+item.PullRequestLabel(), width))
+	if item.PullRequest != nil && item.PullRequest.ReviewState != "" {
+		lines = append(lines, truncate("Review: "+item.PullRequest.ReviewState, width))
+	}
+	lines = append(lines, truncate("Checks: "+item.Checks.Label(), width))
+	if len(item.Commits) > 0 {
+		lines = append(lines, "Commits:")
+		for _, commit := range item.Commits {
+			lines = append(lines, truncate("  "+commit.ShortSHA+" "+commit.Subject, width))
+		}
+	}
+	return lines
+}

--- a/internal/app/testdata/TestView_Initial.golden
+++ b/internal/app/testdata/TestView_Initial.golden
@@ -1,14 +1,11 @@
 gh-zen  repository workbench
 Work Items keys: j/k move  g/G jump  [1]/[2]/[3] pane  tab/S-tab pane  q quit
 ┌─Repositories[1]───────┐ ┌─WorkItems[2]────────────────────────────┐ ┌─Review[3]──────────────────┐
-│ * 0maru/gh-zen        │ │ > main                   clean   no PR  │ │ Repo: 0maru/gh-zen         │
+│ * 0maru/gh-zen        │ │ > main                   clean   no PR  │ │ Loading preview...         │
 │   0maru/dotfiles      │ │   feat/config-loader     dirty   PR #24 │ │ Item: main                 │
-│                       │ │   feat/repo-workbench    clean   #6     │ │ Where: ~/workspaces/github~│
-│ Views                 │ │   agent/preview-state    missing #8     │ │ Branch: main -> origin/main│
-│   Active worktrees    │ │   #34 Branch preview UX  unknown #34    │ │ Local: clean               │
-│   Review requested    │ │                                         │ │ Issue: no issue            │
-│   Failed checks       │ │                                         │ │ PR: no PR                  │
-│                       │ │                                         │ │ Checks: checks passing     │
-│                       │ │                                         │ │ Commits:                   │
-│                       │ │                                         │ │   3da43e7 Set up GitHub CL~│
+│                       │ │   feat/repo-workbench    clean   #6     │ │                            │
+│ Views                 │ │   agent/preview-state    missing #8     │ │                            │
+│   Active worktrees    │ │   #34 Branch preview UX  unknown #34    │ │                            │
+│   Review requested    │ │                                         │ │                            │
+│   Failed checks       │ │                                         │ │                            │
 └───────────────────────┘ └─────────────────────────────────────────┘ └────────────────────────────┘

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -177,10 +177,19 @@ func TestView_CompactKeymapShowsVisiblePaneNumbers(t *testing.T) {
 }
 
 func TestView_SelectedItemChangesPreview(t *testing.T) {
-	m := newModel()
+	m := newModelWithPreviewLoader(fakeDelayedPreviewLoader(0))
+	loaded, _ := m.Update(requirePreviewResultMsg(t, m.Init()))
+	m = loaded.(model)
 	initial := m.View()
-	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-	next := updated.(model).View()
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	loading := updated.(model).View()
+	if !bytes.Contains([]byte(loading), []byte("Loading preview...")) {
+		t.Fatalf("expected moved preview to show loading state, got:\n%s", loading)
+	}
+
+	loaded, _ = updated.(model).Update(requirePreviewResultMsg(t, cmd))
+	next := loaded.(model).View()
 
 	if initial == next {
 		t.Fatalf("expected preview to change after moving selection")


### PR DESCRIPTION
## Summary
- Add an asynchronous preview state machine for focused work items.
- Track focused work item identity and request identity so stale preview responses are discarded.
- Render loading, empty, and error preview states with deterministic fake preview commands.

## Test Plan
- [x] make check
- [x] pre-commit: gofmt, lint, test-small
- [x] pre-push: test-medium

Closes #8