### PR TITLE
Add workbench keymap help

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/0maru/gh-zen
 go 1.26.1
 
 require (
+	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.6
@@ -13,7 +14,6 @@ require (
 	github.com/alecthomas/chroma/v2 v2.20.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/charmbracelet/bubbles v1.0.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/glamour v1.0.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -1,0 +1,210 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+)
+
+type actionID string
+
+const (
+	actionMoveDown          actionID = "move_down"
+	actionMoveUp            actionID = "move_up"
+	actionJumpTop           actionID = "jump_top"
+	actionJumpBottom        actionID = "jump_bottom"
+	actionFocusNextPane     actionID = "focus_next_pane"
+	actionFocusPreviousPane actionID = "focus_previous_pane"
+	actionFocusPane1        actionID = "focus_pane_1"
+	actionFocusPane2        actionID = "focus_pane_2"
+	actionFocusPane3        actionID = "focus_pane_3"
+	actionToggleHelp        actionID = "toggle_help"
+	actionRefresh           actionID = "refresh"
+	actionOpen              actionID = "open"
+	actionCopy              actionID = "copy"
+	actionQuit              actionID = "quit"
+)
+
+type actionBinding struct {
+	id      actionID
+	binding key.Binding
+}
+
+type workbenchKeyMap struct {
+	MoveDown          key.Binding
+	MoveUp            key.Binding
+	JumpTop           key.Binding
+	JumpBottom        key.Binding
+	FocusNextPane     key.Binding
+	FocusPreviousPane key.Binding
+	FocusPane1        key.Binding
+	FocusPane2        key.Binding
+	FocusPane3        key.Binding
+	ToggleHelp        key.Binding
+	Refresh           key.Binding
+	Open              key.Binding
+	Copy              key.Binding
+	Quit              key.Binding
+}
+
+type contextualHelpKeyMap struct {
+	short []key.Binding
+	full  [][]key.Binding
+}
+
+func (k contextualHelpKeyMap) ShortHelp() []key.Binding {
+	return k.short
+}
+
+func (k contextualHelpKeyMap) FullHelp() [][]key.Binding {
+	return k.full
+}
+
+func DefaultKeyMap() workbenchKeyMap {
+	return workbenchKeyMap{
+		MoveDown: key.NewBinding(
+			key.WithKeys("j", "down"),
+			key.WithHelp("j", "down"),
+		),
+		MoveUp: key.NewBinding(
+			key.WithKeys("k", "up"),
+			key.WithHelp("k", "up"),
+		),
+		JumpTop: key.NewBinding(
+			key.WithKeys("g"),
+			key.WithHelp("g", "top"),
+		),
+		JumpBottom: key.NewBinding(
+			key.WithKeys("G"),
+			key.WithHelp("G", "bottom"),
+		),
+		FocusNextPane: key.NewBinding(
+			key.WithKeys("l", "tab"),
+			key.WithHelp("l/tab", "next pane"),
+		),
+		FocusPreviousPane: key.NewBinding(
+			key.WithKeys("h", "shift+tab"),
+			key.WithHelp("h/S-tab", "prev pane"),
+		),
+		FocusPane1: key.NewBinding(
+			key.WithKeys("1"),
+			key.WithHelp("[1]", "pane"),
+		),
+		FocusPane2: key.NewBinding(
+			key.WithKeys("2"),
+			key.WithHelp("[2]", "pane"),
+		),
+		FocusPane3: key.NewBinding(
+			key.WithKeys("3"),
+			key.WithHelp("[3]", "pane"),
+		),
+		ToggleHelp: key.NewBinding(
+			key.WithKeys("?"),
+			key.WithHelp("?", "help"),
+		),
+		Refresh: key.NewBinding(
+			key.WithKeys("r"),
+			key.WithHelp("r", "refresh"),
+		),
+		Open: key.NewBinding(
+			key.WithKeys("enter", "o"),
+			key.WithHelp("enter/o", "open"),
+		),
+		Copy: key.NewBinding(
+			key.WithKeys("y"),
+			key.WithHelp("y", "copy"),
+		),
+		Quit: key.NewBinding(
+			key.WithKeys("q", "esc", "ctrl+c"),
+			key.WithHelp("q", "quit"),
+		),
+	}
+}
+
+func (k workbenchKeyMap) actionBindings() []actionBinding {
+	return []actionBinding{
+		{id: actionQuit, binding: k.Quit},
+		{id: actionToggleHelp, binding: k.ToggleHelp},
+		{id: actionFocusNextPane, binding: k.FocusNextPane},
+		{id: actionFocusPreviousPane, binding: k.FocusPreviousPane},
+		{id: actionFocusPane1, binding: k.FocusPane1},
+		{id: actionFocusPane2, binding: k.FocusPane2},
+		{id: actionFocusPane3, binding: k.FocusPane3},
+		{id: actionMoveDown, binding: k.MoveDown},
+		{id: actionMoveUp, binding: k.MoveUp},
+		{id: actionJumpTop, binding: k.JumpTop},
+		{id: actionJumpBottom, binding: k.JumpBottom},
+		{id: actionRefresh, binding: k.Refresh},
+		{id: actionOpen, binding: k.Open},
+		{id: actionCopy, binding: k.Copy},
+	}
+}
+
+func (k workbenchKeyMap) contextualHelp(focus paneFocus, visiblePanes []paneFocus) contextualHelpKeyMap {
+	paneNumbers := k.visiblePaneBinding(visiblePanes)
+	paneKeys := combinedBinding("pane", k.FocusPreviousPane, k.FocusNextPane)
+	system := []key.Binding{k.ToggleHelp, k.Quit}
+	actions := []key.Binding{k.Open, k.Copy, k.Refresh}
+	panes := []key.Binding{k.FocusPreviousPane, k.FocusNextPane, paneNumbers}
+
+	short := []key.Binding{paneNumbers, paneKeys, k.ToggleHelp, k.Quit}
+	full := [][]key.Binding{panes, actions, system}
+
+	if focus == paneRepositories || focus == paneWorkItems {
+		move := combinedBinding("move", k.MoveDown, k.MoveUp)
+		jump := combinedBinding("jump", k.JumpTop, k.JumpBottom)
+		short = append([]key.Binding{move, jump}, short...)
+		full = append([][]key.Binding{
+			{k.MoveUp, k.MoveDown, k.JumpTop, k.JumpBottom},
+		}, full...)
+	}
+
+	return contextualHelpKeyMap{short: short, full: full}
+}
+
+func (k workbenchKeyMap) visiblePaneBinding(visiblePanes []paneFocus) key.Binding {
+	paneBindings := []key.Binding{k.FocusPane1, k.FocusPane2, k.FocusPane3}
+	visibleCount := min(len(visiblePanes), len(paneBindings))
+	keys := make([]string, 0, visibleCount)
+	helpKeys := make([]string, 0, visibleCount)
+
+	for i := range visibleCount {
+		binding := paneBindings[i]
+		keys = append(keys, binding.Keys()...)
+		helpKeys = append(helpKeys, binding.Help().Key)
+	}
+
+	return key.NewBinding(
+		key.WithKeys(keys...),
+		key.WithHelp(strings.Join(helpKeys, "/"), "pane"),
+	)
+}
+
+func combinedBinding(description string, bindings ...key.Binding) key.Binding {
+	keys := []string{}
+	helpKeys := make([]string, 0, len(bindings))
+
+	for _, binding := range bindings {
+		keys = append(keys, binding.Keys()...)
+		if helpKey := firstHelpKey(binding); helpKey != "" {
+			helpKeys = append(helpKeys, helpKey)
+		}
+	}
+
+	return key.NewBinding(
+		key.WithKeys(keys...),
+		key.WithHelp(strings.Join(helpKeys, "/"), description),
+	)
+}
+
+func firstHelpKey(binding key.Binding) string {
+	helpKey := binding.Help().Key
+	if helpKey == "" {
+		keys := binding.Keys()
+		if len(keys) == 0 {
+			return ""
+		}
+		return keys[0]
+	}
+	return strings.Split(helpKey, "/")[0]
+}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
@@ -19,7 +21,6 @@ const (
 	paneContentPaddingLeft = 1
 	paneBorderGlyph        = "│"
 	paneBorderWidth        = 2
-	frameHeaderLines       = 2
 	frameBorderLines       = 2
 	horizontalLineGlyph    = "─"
 	frameTopLeftGlyph      = "┌"
@@ -72,6 +73,8 @@ type model struct {
 	selectedItem int
 	focusedPane  paneFocus
 	styles       Styles
+	keys         workbenchKeyMap
+	help         help.Model
 }
 
 type repoViewFilter int
@@ -85,11 +88,6 @@ const (
 type repoView struct {
 	label  string
 	filter repoViewFilter
-}
-
-type keyBinding struct {
-	key         string
-	description string
 }
 
 var repoViews = []repoView{
@@ -107,6 +105,8 @@ func newModel() model {
 		repos:     workbench.FakeRepos(),
 		workItems: workbench.FakeWorkItems(),
 		styles:    DefaultStyles(),
+		keys:      DefaultKeyMap(),
+		help:      newHelpModel(),
 	}
 }
 
@@ -119,39 +119,50 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		return m, nil
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "ctrl+c", "esc":
-			return m, tea.Quit
-		case "tab":
-			m.focusNextPane()
-			return m, nil
-		case "shift+tab":
-			m.focusPreviousPane()
-			return m, nil
-		case "1":
-			m.focusPaneByNumber(1)
-			return m, nil
-		case "2":
-			m.focusPaneByNumber(2)
-			return m, nil
-		case "3":
-			m.focusPaneByNumber(3)
-			return m, nil
-		case "j", "down":
-			m.moveFocusedSelection(1)
-			return m, nil
-		case "k", "up":
-			m.moveFocusedSelection(-1)
-			return m, nil
-		case "g":
-			m.jumpFocusedSelection(false)
-			return m, nil
-		case "G":
-			m.jumpFocusedSelection(true)
-			return m, nil
+		if action, ok := m.matchedAction(msg); ok {
+			return m, m.handleAction(action)
 		}
 	}
 	return m, nil
+}
+
+func (m model) matchedAction(msg tea.KeyMsg) (actionID, bool) {
+	for _, binding := range m.keys.actionBindings() {
+		if key.Matches(msg, binding.binding) {
+			return binding.id, true
+		}
+	}
+	return "", false
+}
+
+func (m *model) handleAction(action actionID) tea.Cmd {
+	switch action {
+	case actionQuit:
+		return tea.Quit
+	case actionToggleHelp:
+		m.help.ShowAll = !m.help.ShowAll
+	case actionFocusNextPane:
+		m.focusNextPane()
+	case actionFocusPreviousPane:
+		m.focusPreviousPane()
+	case actionFocusPane1:
+		m.focusPaneByNumber(1)
+	case actionFocusPane2:
+		m.focusPaneByNumber(2)
+	case actionFocusPane3:
+		m.focusPaneByNumber(3)
+	case actionMoveDown:
+		m.moveFocusedSelection(1)
+	case actionMoveUp:
+		m.moveFocusedSelection(-1)
+	case actionJumpTop:
+		m.jumpFocusedSelection(false)
+	case actionJumpBottom:
+		m.jumpFocusedSelection(true)
+	case actionRefresh, actionOpen, actionCopy:
+		return nil
+	}
+	return nil
 }
 
 func (m *model) focusNextPane() {
@@ -381,12 +392,9 @@ func (m model) renderFull(width int) string {
 	left := m.repoLines(paneTextWidth(repoPaneWidth), focus == paneRepositories)
 	middle := m.workItemLines(paneTextWidth(workItemPaneWidth), focus == paneWorkItems)
 	right := m.previewLines(paneTextWidth(rightWidth))
-	bodyHeight := m.frameBodyHeight(max(len(left), max(len(middle), len(right))))
+	out := m.headerLines("gh-zen  repository workbench", width)
+	bodyHeight := m.frameBodyHeight(max(len(left), max(len(middle), len(right))), len(out))
 
-	out := []string{
-		"gh-zen  repository workbench",
-		m.keymapLine(width),
-	}
 	body := lipgloss.JoinHorizontal(
 		lipgloss.Top,
 		m.renderPane(m.paneHeading(paneRepositories), left, repoPaneWidth, bodyHeight, focus == paneRepositories),
@@ -402,17 +410,14 @@ func (m model) renderFull(width int) string {
 func (m model) renderCompact(width int) string {
 	contentWidth := max(width-paneBorderWidth, 0)
 	focus := m.activePane()
-	out := []string{
-		"gh-zen workbench",
-		m.keymapLine(width),
-	}
+	out := m.headerLines("gh-zen workbench", width)
 
 	workLines := m.workItemLines(paneTextWidth(contentWidth), focus == paneWorkItems)
 	previewLines := m.previewLines(paneTextWidth(contentWidth))
 	workHeight := len(workLines)
 	previewHeight := len(previewLines)
 	if m.height > 0 {
-		availableContentHeight := m.height - frameHeaderLines - frameBorderLines*2
+		availableContentHeight := m.height - len(out) - frameBorderLines*2
 		if availableContentHeight > workHeight+previewHeight {
 			previewHeight += availableContentHeight - workHeight - previewHeight
 		}
@@ -491,56 +496,52 @@ func (m model) previewLines(width int) []string {
 	return lines
 }
 
-// keymapLine keeps the active pane affordances visible near the title.
-func (m model) keymapLine(width int) string {
+func (m model) headerLines(title string, width int) []string {
+	out := []string{title}
+	return append(out, m.keymapLines(width)...)
+}
+
+// keymapLines keeps the active pane affordances visible near the title.
+func (m model) keymapLines(width int) []string {
 	focus := m.activePane()
 	prefix := focus.label() + " keys: "
-	paneKey := m.paneNumberKey()
-	switch focus {
-	case paneRepositories, paneWorkItems:
-		return m.renderKeymapLine(prefix, []keyBinding{
-			{key: "j/k", description: "move"},
-			{key: "g/G", description: "jump"},
-			{key: paneKey, description: "pane"},
-			{key: "tab/S-tab", description: "pane"},
-			{key: "q", description: "quit"},
-		}, width)
-	case panePreview:
-		return m.renderKeymapLine(prefix, []keyBinding{
-			{key: paneKey, description: "pane"},
-			{key: "tab/S-tab", description: "pane"},
-			{key: "q", description: "quit"},
-		}, width)
+	helpWidth := max(width-lipgloss.Width(prefix), 0)
+	helpView := m.styledHelp(helpWidth).View(m.keys.contextualHelp(focus, m.paneOrder()))
+	lines := strings.Split(helpView, "\n")
+	indent := strings.Repeat(" ", lipgloss.Width(prefix))
+
+	for i := range lines {
+		if i == 0 {
+			lines[i] = truncate(prefix+lines[i], width)
+			continue
+		}
+		lines[i] = truncate(indent+lines[i], width)
 	}
-	return m.renderKeymapLine(prefix, []keyBinding{
-		{key: paneKey, description: "pane"},
-		{key: "tab/S-tab", description: "pane"},
-		{key: "q", description: "quit"},
-	}, width)
+	return lines
 }
 
-func (m model) paneNumberKey() string {
-	keys := make([]string, len(m.paneOrder()))
-	for i := range keys {
-		keys[i] = fmt.Sprintf("[%d]", i+1)
-	}
-	return strings.Join(keys, "/")
+func (m model) keymapLine(width int) string {
+	return m.keymapLines(width)[0]
 }
 
-func (m model) renderKeymapLine(prefix string, bindings []keyBinding, width int) string {
-	var out strings.Builder
-	out.WriteString(prefix)
-	for i, binding := range bindings {
-		if i > 0 {
-			out.WriteString("  ")
-		}
-		out.WriteString(m.styles.Key.Render(binding.key))
-		if binding.description != "" {
-			out.WriteByte(' ')
-			out.WriteString(binding.description)
-		}
-	}
-	return truncate(out.String(), width)
+func newHelpModel() help.Model {
+	helpModel := help.New()
+	helpModel.ShortSeparator = "  "
+	return helpModel
+}
+
+func (m model) styledHelp(width int) help.Model {
+	helpModel := m.help
+	helpModel.Width = width
+	helpModel.ShortSeparator = "  "
+	helpModel.Styles.ShortKey = m.styles.Key
+	helpModel.Styles.FullKey = m.styles.Key
+	helpModel.Styles.ShortDesc = m.styles.KeyDescription
+	helpModel.Styles.FullDesc = m.styles.KeyDescription
+	helpModel.Styles.ShortSeparator = m.styles.Divider
+	helpModel.Styles.FullSeparator = m.styles.Divider
+	helpModel.Styles.Ellipsis = m.styles.Muted
+	return helpModel
 }
 
 // selectionMarker keeps the retained selection visible outside the active pane.
@@ -554,11 +555,11 @@ func selectionMarker(selected, focused bool) string {
 	return "*"
 }
 
-func (m model) frameBodyHeight(contentHeight int) int {
+func (m model) frameBodyHeight(contentHeight int, headerHeight int) int {
 	if m.height <= 0 {
 		return contentHeight
 	}
-	available := m.height - frameHeaderLines - frameBorderLines
+	available := m.height - headerHeight - frameBorderLines
 	if available > contentHeight {
 		return available
 	}

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -28,7 +28,7 @@ func TestUpdate_QuitOnQuitKeys(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, cmd := (model{}).Update(tc.msg)
+			_, cmd := newModel().Update(tc.msg)
 			if cmd == nil {
 				t.Fatalf("expected quit command, got nil")
 			}
@@ -111,6 +111,24 @@ func TestUpdate_MoveSelection(t *testing.T) {
 	}
 }
 
+func TestUpdate_ArrowKeysMoveSelection(t *testing.T) {
+	start := newModel()
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for arrow movement, got %T", cmd)
+	}
+	mm := got.(model)
+	if mm.selectedItem != 1 {
+		t.Fatalf("expected down arrow to move selection to 1, got %d", mm.selectedItem)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyUp})
+	mm = got.(model)
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected up arrow to move selection back to 0, got %d", mm.selectedItem)
+	}
+}
+
 func TestUpdate_MoveSelection_ClampsAtEdges(t *testing.T) {
 	start := newModel()
 	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
@@ -148,6 +166,25 @@ func TestUpdate_TabChangesFocusedPane(t *testing.T) {
 	mm = got.(model)
 	if mm.focusedPane != paneRepositories {
 		t.Fatalf("expected shift+tab to focus repositories pane, got %v", mm.focusedPane)
+	}
+}
+
+func TestUpdate_HAndLChangeFocusedPane(t *testing.T) {
+	start := newModel()
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for pane focus, got %T", cmd)
+	}
+	mm := got.(model)
+	if mm.focusedPane != paneRepositories {
+		t.Fatalf("expected h to focus repositories pane, got %v", mm.focusedPane)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	mm = got.(model)
+	if mm.focusedPane != paneWorkItems {
+		t.Fatalf("expected l to focus work items pane, got %v", mm.focusedPane)
 	}
 }
 
@@ -205,6 +242,81 @@ func TestUpdate_MovementTargetsFocusedPane(t *testing.T) {
 	}
 	if mm.selectedItem != 0 {
 		t.Fatalf("expected work item selection to stay unchanged, got %d", mm.selectedItem)
+	}
+}
+
+func TestUpdate_ToggleHelpPreservesFocusedWorkItem(t *testing.T) {
+	start := newModel()
+	start.selectedItem = 2
+	start.focusedPane = paneWorkItems
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for help toggle, got %T", cmd)
+	}
+	mm := got.(model)
+	if !mm.help.ShowAll {
+		t.Fatalf("expected ? to show full help")
+	}
+	if mm.selectedItem != 2 || mm.focusedPane != paneWorkItems {
+		t.Fatalf("expected help toggle to preserve focus and selected item, got focus=%v item=%d", mm.focusedPane, mm.selectedItem)
+	}
+
+	got, _ = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	mm = got.(model)
+	if mm.help.ShowAll {
+		t.Fatalf("expected second ? to hide full help")
+	}
+	if mm.selectedItem != 2 || mm.focusedPane != paneWorkItems {
+		t.Fatalf("expected help hide to preserve focus and selected item, got focus=%v item=%d", mm.focusedPane, mm.selectedItem)
+	}
+}
+
+func TestUpdate_KeyOverrideChangesActionAndHelp(t *testing.T) {
+	start := newModel()
+	start.keys.MoveDown.SetKeys("n")
+	start.keys.MoveDown.SetHelp("n", "down")
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for remapped movement, got %T", cmd)
+	}
+	mm := got.(model)
+	if mm.selectedItem != 1 {
+		t.Fatalf("expected remapped n key to move selection to 1, got %d", mm.selectedItem)
+	}
+
+	got, _ = start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	mm = got.(model)
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected original j key to stop moving after override, got %d", mm.selectedItem)
+	}
+	if !strings.Contains(start.keymapLine(defaultWidth), "n/k move") {
+		t.Fatalf("expected help to reflect remapped key, got %q", start.keymapLine(defaultWidth))
+	}
+}
+
+func TestUpdate_ActionKeysAreBound(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  tea.KeyMsg
+		want actionID
+	}{
+		{"refresh", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}, actionRefresh},
+		{"open", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}}, actionOpen},
+		{"enter", tea.KeyMsg{Type: tea.KeyEnter}, actionOpen},
+		{"copy", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}, actionCopy},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := newModel().matchedAction(tc.msg)
+			if !ok {
+				t.Fatalf("expected key to be bound to %s", tc.want)
+			}
+			if got != tc.want {
+				t.Fatalf("expected action %s, got %s", tc.want, got)
+			}
+		})
 	}
 }
 

--- a/internal/app/testdata/TestView_Initial.golden
+++ b/internal/app/testdata/TestView_Initial.golden
@@ -1,5 +1,5 @@
 gh-zen  repository workbench
-Work Items keys: j/k move  g/G jump  [1]/[2]/[3] pane  tab/S-tab pane  q quit
+Work Items keys: j/k move  g/G jump  [1]/[2]/[3] pane  h/l pane  ? help  q quit
 ┌─Repositories[1]───────┐ ┌─WorkItems[2]────────────────────────────┐ ┌─Review[3]──────────────────┐
 │ * 0maru/gh-zen        │ │ > main                   clean   no PR  │ │ Repo: 0maru/gh-zen         │
 │   0maru/dotfiles      │ │   feat/config-loader     dirty   PR #24 │ │ Item: main                 │

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -70,7 +70,7 @@ func TestView_KeymapFollowsFocusedPane(t *testing.T) {
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	next := updated.(model).View()
-	if !bytes.Contains([]byte(next), []byte("Review keys: [1]/[2]/[3] pane  tab/S-tab pane  q quit")) {
+	if !bytes.Contains([]byte(next), []byte("Review keys: [1]/[2]/[3] pane  h/l pane  ? help  q quit")) {
 		t.Fatalf("expected focused review header, got:\n%s", next)
 	}
 	if got := strings.Split(next, "\n")[1]; !strings.HasPrefix(got, "Review keys:") {
@@ -88,7 +88,7 @@ func TestView_KeymapStylesOnlyKeys(t *testing.T) {
 	m := newModel()
 	m.styles.Key = m.styles.Key.Renderer(r)
 	got := m.keymapLine(defaultWidth)
-	want := "Work Items keys: j/k move  g/G jump  [1]/[2]/[3] pane  tab/S-tab pane  q quit"
+	want := "Work Items keys: j/k move  g/G jump  [1]/[2]/[3] pane  h/l pane  ? help  q quit"
 
 	if stripped := ansi.Strip(got); stripped != want {
 		t.Fatalf("expected keymap text to stay unchanged, got %q", stripped)
@@ -98,6 +98,30 @@ func TestView_KeymapStylesOnlyKeys(t *testing.T) {
 	}
 	if strings.Contains(got, m.styles.Key.Render("move")) || strings.Contains(got, m.styles.Key.Render("jump")) {
 		t.Fatalf("expected key descriptions to stay unstyled, got %q", got)
+	}
+}
+
+func TestView_FullHelpShowsContextualActions(t *testing.T) {
+	m := newModel()
+	m.help.ShowAll = true
+	got := ansi.Strip(m.View())
+
+	for _, want := range []string{"enter/o open", "copy", "refresh"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected full help to include %q, got:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, "j down") || !strings.Contains(got, "G bottom") {
+		t.Fatalf("expected full work item help to include movement keys, got:\n%s", got)
+	}
+
+	m.focusedPane = panePreview
+	got = ansi.Strip(m.View())
+	if strings.Contains(got, "j down") || strings.Contains(got, "G bottom") {
+		t.Fatalf("expected preview full help to omit movement keys, got:\n%s", got)
+	}
+	if !strings.Contains(got, "enter/o open") || !strings.Contains(got, "refresh") {
+		t.Fatalf("expected preview full help to keep actions, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add a centralized, action-oriented workbench keymap built on Charmbracelet Bubbles key bindings.
- Replace ad hoc key string handling with action dispatch and contextual help rendering.
- Add full help toggling with `?`, pane navigation via `h/l`, arrow movement, and bindings for refresh, open, copy, and quit.

## Validation

- `make test-small`
- `make check`
- pre-commit hook: `gofmt`, `lint`, `test-small`
- pre-push hook: `test-medium`

Closes #7