### PR TITLE
Add layered config model

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -567,6 +567,34 @@ func isRepoFullName(value string) bool {
 	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
 		return false
 	}
+	return isRepoOwner(owner) && isRepoName(name)
+}
+
+func isRepoOwner(value string) bool {
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isRepoName(value string) bool {
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return false
+		}
+	}
 	return true
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -571,12 +571,24 @@ func isRepoFullName(value string) bool {
 }
 
 func isRepoOwner(value string) bool {
+	if value == "" || value[0] == '-' || value[len(value)-1] == '-' {
+		return false
+	}
+
+	previousHyphen := false
 	for _, r := range value {
 		switch {
 		case r >= 'a' && r <= 'z':
+			previousHyphen = false
 		case r >= 'A' && r <= 'Z':
+			previousHyphen = false
 		case r >= '0' && r <= '9':
+			previousHyphen = false
 		case r == '-':
+			if previousHyphen {
+				return false
+			}
+			previousHyphen = true
 		default:
 			return false
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,588 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	// StartupViewWorkbench is the initial repository workbench view.
+	StartupViewWorkbench StartupView = "workbench"
+
+	// PullRequestAny leaves pull request presence unfiltered.
+	PullRequestAny PullRequestFilter = "any"
+	// PullRequestPresent keeps work items that have a pull request.
+	PullRequestPresent PullRequestFilter = "present"
+	// PullRequestAbsent keeps work items that do not have a pull request.
+	PullRequestAbsent PullRequestFilter = "absent"
+
+	// LocalStatusAny leaves local status unfiltered.
+	LocalStatusAny LocalStatusFilter = "any"
+	// LocalStatusClean keeps clean local work items.
+	LocalStatusClean LocalStatusFilter = "clean"
+	// LocalStatusDirty keeps dirty local work items.
+	LocalStatusDirty LocalStatusFilter = "dirty"
+	// LocalStatusDetached keeps detached local work items.
+	LocalStatusDetached LocalStatusFilter = "detached"
+	// LocalStatusMissing keeps missing local work items.
+	LocalStatusMissing LocalStatusFilter = "missing"
+)
+
+// StartupView identifies the view selected at startup.
+type StartupView string
+
+// PullRequestFilter configures workbench pull request presence filtering.
+type PullRequestFilter string
+
+// LocalStatusFilter configures workbench local status filtering.
+type LocalStatusFilter string
+
+// Config is a resolved runtime configuration.
+type Config struct {
+	Startup   StartupConfig   `toml:"startup"`
+	UI        UIConfig        `toml:"ui"`
+	Keys      KeyBindings     `toml:"keys"`
+	Repos     ReposConfig     `toml:"repos"`
+	Worktrees WorktreesConfig `toml:"worktrees"`
+	Workbench WorkbenchConfig `toml:"workbench"`
+}
+
+// StartupConfig contains startup selection settings.
+type StartupConfig struct {
+	Repo string      `toml:"repo"`
+	View StartupView `toml:"view"`
+}
+
+// UIConfig contains display preferences independent from rendering code.
+type UIConfig struct {
+	Theme        string  `toml:"theme"`
+	PreviewWidth float64 `toml:"preview_width"`
+	ShowIcons    bool    `toml:"show_icons"`
+}
+
+// KeyBindings maps action IDs to ordered key sequences.
+type KeyBindings map[string][]string
+
+// ReposConfig contains repository discovery and per-repository settings.
+type ReposConfig struct {
+	Roots        []string                    `toml:"roots"`
+	Repositories map[string]RepositoryConfig `toml:"repositories"`
+}
+
+// RepositoryConfig contains settings scoped to one owner/repo.
+type RepositoryConfig struct {
+	DefaultBranch string `toml:"default_branch"`
+	WorktreeRoot  string `toml:"worktree_root"`
+}
+
+// WorktreesConfig contains local worktree include and exclude patterns.
+type WorktreesConfig struct {
+	Include []string `toml:"include"`
+	Exclude []string `toml:"exclude"`
+}
+
+// WorkbenchConfig contains filters used by the repository workbench.
+type WorkbenchConfig struct {
+	Filter         WorkbenchFilter            `toml:"filter"`
+	BranchPatterns []string                   `toml:"branch_patterns"`
+	SavedFilters   map[string]WorkbenchFilter `toml:"saved_filters"`
+}
+
+// WorkbenchFilter configures a deterministic workbench item filter.
+type WorkbenchFilter struct {
+	Worktree      string            `toml:"worktree"`
+	BranchPattern string            `toml:"branch_pattern"`
+	PullRequest   PullRequestFilter `toml:"pull_request"`
+	LocalStatus   LocalStatusFilter `toml:"local_status"`
+}
+
+// PartialConfig is one optional configuration layer before merge resolution.
+type PartialConfig struct {
+	Startup     StartupConfigLayer   `toml:"startup"`
+	UI          UIConfigLayer        `toml:"ui"`
+	Keys        KeyBindings          `toml:"keys"`
+	Repos       ReposConfigLayer     `toml:"repos"`
+	Worktrees   WorktreesConfigLayer `toml:"worktrees"`
+	Workbench   WorkbenchConfigLayer `toml:"workbench"`
+	UnknownKeys []string             `toml:"-"`
+}
+
+// StartupConfigLayer is the optional form of StartupConfig.
+type StartupConfigLayer struct {
+	Repo *string      `toml:"repo"`
+	View *StartupView `toml:"view"`
+}
+
+// UIConfigLayer is the optional form of UIConfig.
+type UIConfigLayer struct {
+	Theme        *string  `toml:"theme"`
+	PreviewWidth *float64 `toml:"preview_width"`
+	ShowIcons    *bool    `toml:"show_icons"`
+}
+
+// ReposConfigLayer is the optional form of ReposConfig.
+type ReposConfigLayer struct {
+	Roots        *[]string                        `toml:"roots"`
+	Repositories map[string]RepositoryConfigLayer `toml:"repositories"`
+}
+
+// RepositoryConfigLayer is the optional form of RepositoryConfig.
+type RepositoryConfigLayer struct {
+	DefaultBranch *string `toml:"default_branch"`
+	WorktreeRoot  *string `toml:"worktree_root"`
+}
+
+// WorktreesConfigLayer is the optional form of WorktreesConfig.
+type WorktreesConfigLayer struct {
+	Include *[]string `toml:"include"`
+	Exclude *[]string `toml:"exclude"`
+}
+
+// WorkbenchConfigLayer is the optional form of WorkbenchConfig.
+type WorkbenchConfigLayer struct {
+	Filter         WorkbenchFilterLayer            `toml:"filter"`
+	BranchPatterns *[]string                       `toml:"branch_patterns"`
+	SavedFilters   map[string]WorkbenchFilterLayer `toml:"saved_filters"`
+}
+
+// WorkbenchFilterLayer is the optional form of WorkbenchFilter.
+type WorkbenchFilterLayer struct {
+	Worktree      *string            `toml:"worktree"`
+	BranchPattern *string            `toml:"branch_pattern"`
+	PullRequest   *PullRequestFilter `toml:"pull_request"`
+	LocalStatus   *LocalStatusFilter `toml:"local_status"`
+}
+
+// Diagnostic describes a non-fatal configuration warning.
+type Diagnostic struct {
+	Path    string
+	Message string
+}
+
+// Problem describes a fatal configuration validation problem.
+type Problem struct {
+	Path    string
+	Message string
+}
+
+// ValidationError groups fatal configuration validation problems.
+type ValidationError struct {
+	Problems []Problem
+}
+
+func (e ValidationError) Error() string {
+	if len(e.Problems) == 1 {
+		problem := e.Problems[0]
+		return fmt.Sprintf("%s: %s", problem.Path, problem.Message)
+	}
+
+	parts := make([]string, 0, len(e.Problems))
+	for _, problem := range e.Problems {
+		parts = append(parts, fmt.Sprintf("%s: %s", problem.Path, problem.Message))
+	}
+	return fmt.Sprintf("%d config validation errors: %s", len(e.Problems), strings.Join(parts, "; "))
+}
+
+// Defaults returns the built-in runtime configuration.
+func Defaults() Config {
+	return Config{
+		Startup: StartupConfig{
+			View: StartupViewWorkbench,
+		},
+		UI: UIConfig{
+			Theme:        "default",
+			PreviewWidth: 0.45,
+			ShowIcons:    true,
+		},
+		Keys: KeyBindings{
+			"move_down":           {"j", "down"},
+			"move_up":             {"k", "up"},
+			"jump_top":            {"g"},
+			"jump_bottom":         {"G"},
+			"focus_next_pane":     {"l", "tab"},
+			"focus_previous_pane": {"h", "shift+tab"},
+			"focus_pane_1":        {"1"},
+			"focus_pane_2":        {"2"},
+			"focus_pane_3":        {"3"},
+			"toggle_help":         {"?"},
+			"refresh":             {"r"},
+			"open":                {"enter", "o"},
+			"copy":                {"y"},
+			"quit":                {"q", "esc", "ctrl+c"},
+		},
+		Repos: ReposConfig{
+			Repositories: map[string]RepositoryConfig{},
+		},
+		Workbench: WorkbenchConfig{
+			Filter:       defaultWorkbenchFilter(),
+			SavedFilters: map[string]WorkbenchFilter{},
+		},
+	}
+}
+
+// MergeLayers applies all layers over the built-in defaults in order.
+func MergeLayers(layers ...PartialConfig) Config {
+	cfg := Defaults()
+	for _, layer := range layers {
+		cfg = Merge(cfg, layer)
+	}
+	return cfg
+}
+
+// Merge applies one stronger optional configuration layer over a resolved base.
+func Merge(base Config, layer PartialConfig) Config {
+	out := cloneConfig(base)
+
+	if layer.Startup.Repo != nil {
+		out.Startup.Repo = *layer.Startup.Repo
+	}
+	if layer.Startup.View != nil {
+		out.Startup.View = *layer.Startup.View
+	}
+
+	if layer.UI.Theme != nil {
+		out.UI.Theme = *layer.UI.Theme
+	}
+	if layer.UI.PreviewWidth != nil {
+		out.UI.PreviewWidth = *layer.UI.PreviewWidth
+	}
+	if layer.UI.ShowIcons != nil {
+		out.UI.ShowIcons = *layer.UI.ShowIcons
+	}
+
+	if len(layer.Keys) > 0 {
+		if out.Keys == nil {
+			out.Keys = KeyBindings{}
+		}
+		for action, bindings := range layer.Keys {
+			out.Keys[action] = cloneStrings(bindings)
+		}
+	}
+
+	if layer.Repos.Roots != nil {
+		out.Repos.Roots = cloneStrings(*layer.Repos.Roots)
+	}
+	if len(layer.Repos.Repositories) > 0 {
+		if out.Repos.Repositories == nil {
+			out.Repos.Repositories = map[string]RepositoryConfig{}
+		}
+		for name, repoLayer := range layer.Repos.Repositories {
+			repo := out.Repos.Repositories[name]
+			if repoLayer.DefaultBranch != nil {
+				repo.DefaultBranch = *repoLayer.DefaultBranch
+			}
+			if repoLayer.WorktreeRoot != nil {
+				repo.WorktreeRoot = *repoLayer.WorktreeRoot
+			}
+			out.Repos.Repositories[name] = repo
+		}
+	}
+
+	if layer.Worktrees.Include != nil {
+		out.Worktrees.Include = cloneStrings(*layer.Worktrees.Include)
+	}
+	if layer.Worktrees.Exclude != nil {
+		out.Worktrees.Exclude = cloneStrings(*layer.Worktrees.Exclude)
+	}
+
+	out.Workbench.Filter = mergeWorkbenchFilter(out.Workbench.Filter, layer.Workbench.Filter)
+	if layer.Workbench.BranchPatterns != nil {
+		out.Workbench.BranchPatterns = cloneStrings(*layer.Workbench.BranchPatterns)
+	}
+	if len(layer.Workbench.SavedFilters) > 0 {
+		if out.Workbench.SavedFilters == nil {
+			out.Workbench.SavedFilters = map[string]WorkbenchFilter{}
+		}
+		for name, filterLayer := range layer.Workbench.SavedFilters {
+			filter, ok := out.Workbench.SavedFilters[name]
+			if !ok {
+				filter = defaultWorkbenchFilter()
+			}
+			out.Workbench.SavedFilters[name] = mergeWorkbenchFilter(filter, filterLayer)
+		}
+	}
+
+	return out
+}
+
+// Validate returns an error when a resolved configuration contains invalid known values.
+func Validate(cfg Config) error {
+	var problems []Problem
+
+	if cfg.Startup.View != StartupViewWorkbench {
+		problems = append(problems, Problem{Path: "startup.view", Message: "must be workbench"})
+	}
+	if cfg.Startup.Repo != "" && !isRepoFullName(cfg.Startup.Repo) {
+		problems = append(problems, Problem{Path: "startup.repo", Message: "must use owner/repo format"})
+	}
+
+	if !isSafeIdentifier(cfg.UI.Theme) {
+		problems = append(problems, Problem{Path: "ui.theme", Message: "must be a safe identifier"})
+	}
+	if cfg.UI.PreviewWidth <= 0 || cfg.UI.PreviewWidth >= 1 {
+		problems = append(problems, Problem{Path: "ui.preview_width", Message: "must be greater than 0 and less than 1"})
+	}
+
+	problems = append(problems, validateKeyBindings("keys", cfg.Keys)...)
+	problems = append(problems, validateStringList("repos.roots", cfg.Repos.Roots)...)
+	problems = append(problems, validateRepositories(cfg.Repos.Repositories)...)
+	problems = append(problems, validateStringList("worktrees.include", cfg.Worktrees.Include)...)
+	problems = append(problems, validateStringList("worktrees.exclude", cfg.Worktrees.Exclude)...)
+	problems = append(problems, validateStringList("workbench.branch_patterns", cfg.Workbench.BranchPatterns)...)
+	problems = append(problems, validateWorkbenchFilter("workbench.filter", cfg.Workbench.Filter)...)
+	problems = append(problems, validateSavedFilters(cfg.Workbench.SavedFilters)...)
+
+	if len(problems) > 0 {
+		return ValidationError{Problems: problems}
+	}
+	return nil
+}
+
+// ValidateLayer validates a single optional layer and returns non-fatal unknown-key diagnostics.
+func ValidateLayer(layer PartialConfig) ([]Diagnostic, error) {
+	warnings := make([]Diagnostic, 0, len(layer.UnknownKeys))
+	for _, key := range layer.UnknownKeys {
+		path := strings.TrimSpace(key)
+		if path == "" {
+			path = "<unknown>"
+		}
+		warnings = append(warnings, Diagnostic{Path: path, Message: "unknown configuration key"})
+	}
+
+	if err := Validate(Merge(Defaults(), layer)); err != nil {
+		return warnings, err
+	}
+	return warnings, nil
+}
+
+func mergeWorkbenchFilter(base WorkbenchFilter, layer WorkbenchFilterLayer) WorkbenchFilter {
+	if base.PullRequest == "" {
+		base.PullRequest = PullRequestAny
+	}
+	if base.LocalStatus == "" {
+		base.LocalStatus = LocalStatusAny
+	}
+	if layer.Worktree != nil {
+		base.Worktree = *layer.Worktree
+	}
+	if layer.BranchPattern != nil {
+		base.BranchPattern = *layer.BranchPattern
+	}
+	if layer.PullRequest != nil {
+		base.PullRequest = *layer.PullRequest
+	}
+	if layer.LocalStatus != nil {
+		base.LocalStatus = *layer.LocalStatus
+	}
+	return base
+}
+
+func defaultWorkbenchFilter() WorkbenchFilter {
+	return WorkbenchFilter{
+		PullRequest: PullRequestAny,
+		LocalStatus: LocalStatusAny,
+	}
+}
+
+func cloneConfig(cfg Config) Config {
+	return Config{
+		Startup: cfg.Startup,
+		UI:      cfg.UI,
+		Keys:    cloneKeyBindings(cfg.Keys),
+		Repos: ReposConfig{
+			Roots:        cloneStrings(cfg.Repos.Roots),
+			Repositories: cloneRepositories(cfg.Repos.Repositories),
+		},
+		Worktrees: WorktreesConfig{
+			Include: cloneStrings(cfg.Worktrees.Include),
+			Exclude: cloneStrings(cfg.Worktrees.Exclude),
+		},
+		Workbench: WorkbenchConfig{
+			Filter:         cfg.Workbench.Filter,
+			BranchPatterns: cloneStrings(cfg.Workbench.BranchPatterns),
+			SavedFilters:   cloneSavedFilters(cfg.Workbench.SavedFilters),
+		},
+	}
+}
+
+func cloneKeyBindings(bindings KeyBindings) KeyBindings {
+	if bindings == nil {
+		return nil
+	}
+	out := make(KeyBindings, len(bindings))
+	for action, keys := range bindings {
+		out[action] = cloneStrings(keys)
+	}
+	return out
+}
+
+func cloneRepositories(repos map[string]RepositoryConfig) map[string]RepositoryConfig {
+	if repos == nil {
+		return nil
+	}
+	out := make(map[string]RepositoryConfig, len(repos))
+	for name, repo := range repos {
+		out[name] = repo
+	}
+	return out
+}
+
+func cloneSavedFilters(filters map[string]WorkbenchFilter) map[string]WorkbenchFilter {
+	if filters == nil {
+		return nil
+	}
+	out := make(map[string]WorkbenchFilter, len(filters))
+	for name, filter := range filters {
+		out[name] = filter
+	}
+	return out
+}
+
+func cloneStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	return append([]string(nil), values...)
+}
+
+func validateKeyBindings(path string, bindings KeyBindings) []Problem {
+	var problems []Problem
+	if len(bindings) == 0 {
+		return append(problems, Problem{Path: path, Message: "must define at least one action"})
+	}
+
+	actions := make([]string, 0, len(bindings))
+	for action := range bindings {
+		actions = append(actions, action)
+	}
+	sort.Strings(actions)
+
+	for _, action := range actions {
+		actionPath := path + "." + action
+		if !isSafeIdentifier(action) {
+			problems = append(problems, Problem{Path: actionPath, Message: "action must be a safe identifier"})
+		}
+		keys := bindings[action]
+		if len(keys) == 0 {
+			problems = append(problems, Problem{Path: actionPath, Message: "must define at least one key"})
+			continue
+		}
+		for i, key := range keys {
+			if strings.TrimSpace(key) == "" {
+				problems = append(problems, Problem{Path: fmt.Sprintf("%s[%d]", actionPath, i), Message: "key must not be empty"})
+			}
+		}
+	}
+
+	return problems
+}
+
+func validateStringList(path string, values []string) []Problem {
+	var problems []Problem
+	for i, value := range values {
+		if strings.TrimSpace(value) == "" {
+			problems = append(problems, Problem{Path: fmt.Sprintf("%s[%d]", path, i), Message: "must not be empty"})
+		}
+	}
+	return problems
+}
+
+func validateRepositories(repos map[string]RepositoryConfig) []Problem {
+	var problems []Problem
+	names := make([]string, 0, len(repos))
+	for name := range repos {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if !isRepoFullName(name) {
+			problems = append(problems, Problem{Path: fmt.Sprintf("repos.repositories.%s", name), Message: "must use owner/repo format"})
+		}
+		if strings.TrimSpace(repos[name].DefaultBranch) != repos[name].DefaultBranch {
+			problems = append(problems, Problem{Path: fmt.Sprintf("repos.repositories.%s.default_branch", name), Message: "must not have surrounding whitespace"})
+		}
+		if strings.TrimSpace(repos[name].WorktreeRoot) != repos[name].WorktreeRoot {
+			problems = append(problems, Problem{Path: fmt.Sprintf("repos.repositories.%s.worktree_root", name), Message: "must not have surrounding whitespace"})
+		}
+	}
+	return problems
+}
+
+func validateSavedFilters(filters map[string]WorkbenchFilter) []Problem {
+	var problems []Problem
+	names := make([]string, 0, len(filters))
+	for name := range filters {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if !isSafeIdentifier(name) {
+			problems = append(problems, Problem{Path: fmt.Sprintf("workbench.saved_filters.%s", name), Message: "name must be a safe identifier"})
+		}
+		problems = append(problems, validateWorkbenchFilter(fmt.Sprintf("workbench.saved_filters.%s", name), filters[name])...)
+	}
+	return problems
+}
+
+func validateWorkbenchFilter(path string, filter WorkbenchFilter) []Problem {
+	var problems []Problem
+	if strings.TrimSpace(filter.Worktree) != filter.Worktree {
+		problems = append(problems, Problem{Path: path + ".worktree", Message: "must not have surrounding whitespace"})
+	}
+	if strings.TrimSpace(filter.BranchPattern) != filter.BranchPattern {
+		problems = append(problems, Problem{Path: path + ".branch_pattern", Message: "must not have surrounding whitespace"})
+	}
+	if !isPullRequestFilter(filter.PullRequest) {
+		problems = append(problems, Problem{Path: path + ".pull_request", Message: "must be any, present, or absent"})
+	}
+	if !isLocalStatusFilter(filter.LocalStatus) {
+		problems = append(problems, Problem{Path: path + ".local_status", Message: "must be any, clean, dirty, detached, or missing"})
+	}
+	return problems
+}
+
+func isPullRequestFilter(value PullRequestFilter) bool {
+	switch value {
+	case PullRequestAny, PullRequestPresent, PullRequestAbsent:
+		return true
+	default:
+		return false
+	}
+}
+
+func isLocalStatusFilter(value LocalStatusFilter) bool {
+	switch value {
+	case LocalStatusAny, LocalStatusClean, LocalStatusDirty, LocalStatusDetached, LocalStatusMissing:
+		return true
+	default:
+		return false
+	}
+}
+
+func isRepoFullName(value string) bool {
+	owner, name, ok := strings.Cut(value, "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return false
+	}
+	return true
+}
+
+func isSafeIdentifier(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -217,6 +217,54 @@ func TestValidate_RejectsInvalidKnownValues(t *testing.T) {
 	}
 }
 
+func TestValidate_RejectsRepositoryNamesWithWhitespace(t *testing.T) {
+	cfg := Defaults()
+	cfg.Startup.Repo = " owner/repo"
+	cfg.Repos.Repositories = map[string]RepositoryConfig{
+		"owner /repo": {},
+	}
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	for _, want := range []string{
+		"startup.repo",
+		"repos.repositories.owner /repo",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected validation error to mention %q, got %q", want, err.Error())
+		}
+	}
+}
+
+func TestIsRepoFullName_ValidatesOwnerAndRepositorySegments(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "basic", value: "owner/repo", want: true},
+		{name: "owner hyphen", value: "owner-name/repo", want: true},
+		{name: "repo punctuation", value: "owner/repo.name_test", want: true},
+		{name: "leading whitespace", value: " owner/repo", want: false},
+		{name: "trailing whitespace", value: "owner/repo ", want: false},
+		{name: "owner whitespace", value: "owner /repo", want: false},
+		{name: "repo whitespace", value: "owner/re po", want: false},
+		{name: "owner slash", value: "owner/team/repo", want: false},
+		{name: "owner underscore", value: "owner_name/repo", want: false},
+		{name: "empty owner", value: "/repo", want: false},
+		{name: "empty repo", value: "owner/", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRepoFullName(tc.value); got != tc.want {
+				t.Fatalf("expected %q validation to be %v, got %v", tc.value, tc.want, got)
+			}
+		})
+	}
+}
+
 func TestValidateLayer_ReturnsUnknownKeyWarnings(t *testing.T) {
 	warnings, err := ValidateLayer(PartialConfig{
 		UnknownKeys: []string{"ui.unused", "workbench.future"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,267 @@
+package config
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDefaults_AreUsable(t *testing.T) {
+	got := Defaults()
+
+	if err := Validate(got); err != nil {
+		t.Fatalf("expected defaults to validate, got %v", err)
+	}
+	if got.Startup.View != StartupViewWorkbench {
+		t.Fatalf("expected default startup view %q, got %q", StartupViewWorkbench, got.Startup.View)
+	}
+	if got.UI.Theme != "default" || got.UI.PreviewWidth != 0.45 || !got.UI.ShowIcons {
+		t.Fatalf("unexpected default UI config: %+v", got.UI)
+	}
+	if len(got.Keys["quit"]) == 0 {
+		t.Fatalf("expected default quit key bindings")
+	}
+	if got.Workbench.Filter.PullRequest != PullRequestAny || got.Workbench.Filter.LocalStatus != LocalStatusAny {
+		t.Fatalf("expected unfiltered workbench default, got %+v", got.Workbench.Filter)
+	}
+}
+
+func TestMergeLayers_ScalarsUseLastWriterWins(t *testing.T) {
+	globalRepo := "0maru/gh-zen"
+	projectRepo := "0maru/dotfiles"
+	theme := "high_contrast"
+	previewWidth := 0.35
+	showIcons := false
+
+	got := MergeLayers(
+		PartialConfig{
+			Startup: StartupConfigLayer{Repo: str(globalRepo)},
+			UI:      UIConfigLayer{Theme: str(theme)},
+		},
+		PartialConfig{
+			Startup: StartupConfigLayer{Repo: str(projectRepo)},
+			UI: UIConfigLayer{
+				PreviewWidth: float64Ptr(previewWidth),
+				ShowIcons:    boolPtr(showIcons),
+			},
+		},
+	)
+
+	if got.Startup.Repo != projectRepo {
+		t.Fatalf("expected stronger startup repo %q, got %q", projectRepo, got.Startup.Repo)
+	}
+	if got.UI.Theme != theme {
+		t.Fatalf("expected weaker theme to remain %q, got %q", theme, got.UI.Theme)
+	}
+	if got.UI.PreviewWidth != previewWidth {
+		t.Fatalf("expected preview width %.2f, got %.2f", previewWidth, got.UI.PreviewWidth)
+	}
+	if got.UI.ShowIcons {
+		t.Fatalf("expected false scalar override to be preserved")
+	}
+}
+
+func TestMerge_KeyBindingsReplacePerAction(t *testing.T) {
+	got := Merge(Defaults(), PartialConfig{
+		Keys: KeyBindings{
+			"open": {"x"},
+		},
+	})
+
+	if !reflect.DeepEqual(got.Keys["open"], []string{"x"}) {
+		t.Fatalf("expected open binding to be replaced, got %#v", got.Keys["open"])
+	}
+	if !reflect.DeepEqual(got.Keys["quit"], []string{"q", "esc", "ctrl+c"}) {
+		t.Fatalf("expected unrelated key binding to remain, got %#v", got.Keys["quit"])
+	}
+}
+
+func TestMerge_ListsReplace(t *testing.T) {
+	got := MergeLayers(
+		PartialConfig{
+			Repos:     ReposConfigLayer{Roots: stringList("~/src", "~/work")},
+			Worktrees: WorktreesConfigLayer{Include: stringList("~/src/*")},
+			Workbench: WorkbenchConfigLayer{
+				BranchPatterns: stringList("feat/*", "fix/*"),
+			},
+		},
+		PartialConfig{
+			Repos: ReposConfigLayer{Roots: stringList("~/repos")},
+			Workbench: WorkbenchConfigLayer{
+				BranchPatterns: stringList(),
+			},
+		},
+	)
+
+	if !reflect.DeepEqual(got.Repos.Roots, []string{"~/repos"}) {
+		t.Fatalf("expected repo roots to be replaced, got %#v", got.Repos.Roots)
+	}
+	if !reflect.DeepEqual(got.Worktrees.Include, []string{"~/src/*"}) {
+		t.Fatalf("expected untouched worktree include list to remain, got %#v", got.Worktrees.Include)
+	}
+	if len(got.Workbench.BranchPatterns) != 0 {
+		t.Fatalf("expected explicit empty list to replace branch patterns, got %#v", got.Workbench.BranchPatterns)
+	}
+}
+
+func TestMerge_MapsDeepMerge(t *testing.T) {
+	defaultBranch := "main"
+	initialRoot := "~/src/gh-zen"
+	strongerRoot := "~/worktrees/gh-zen"
+	present := PullRequestPresent
+	dirty := LocalStatusDirty
+	branchPattern := "feat/*"
+
+	got := MergeLayers(
+		PartialConfig{
+			Repos: ReposConfigLayer{
+				Repositories: map[string]RepositoryConfigLayer{
+					"0maru/gh-zen": {
+						DefaultBranch: str(defaultBranch),
+						WorktreeRoot:  str(initialRoot),
+					},
+				},
+			},
+			Workbench: WorkbenchConfigLayer{
+				SavedFilters: map[string]WorkbenchFilterLayer{
+					"review": {
+						PullRequest: ptr(present),
+						LocalStatus: ptr(dirty),
+					},
+				},
+			},
+		},
+		PartialConfig{
+			Repos: ReposConfigLayer{
+				Repositories: map[string]RepositoryConfigLayer{
+					"0maru/gh-zen": {
+						WorktreeRoot: str(strongerRoot),
+					},
+				},
+			},
+			Workbench: WorkbenchConfigLayer{
+				SavedFilters: map[string]WorkbenchFilterLayer{
+					"review": {
+						BranchPattern: str(branchPattern),
+					},
+				},
+			},
+		},
+	)
+
+	repo := got.Repos.Repositories["0maru/gh-zen"]
+	if repo.DefaultBranch != defaultBranch || repo.WorktreeRoot != strongerRoot {
+		t.Fatalf("expected repository map to deep merge, got %+v", repo)
+	}
+
+	filter := got.Workbench.SavedFilters["review"]
+	if filter.PullRequest != PullRequestPresent || filter.LocalStatus != LocalStatusDirty || filter.BranchPattern != branchPattern {
+		t.Fatalf("expected saved filter map to deep merge, got %+v", filter)
+	}
+}
+
+func TestMerge_DoesNotAliasBaseOrLayer(t *testing.T) {
+	base := Defaults()
+	base.Repos.Roots = []string{"~/src"}
+	layerRoots := []string{"~/work"}
+	layer := PartialConfig{
+		Repos: ReposConfigLayer{Roots: &layerRoots},
+		Keys:  KeyBindings{"open": {"x"}},
+	}
+
+	got := Merge(base, layer)
+	base.Keys["open"][0] = "base-mutated"
+	layerRoots[0] = "layer-mutated"
+	layer.Keys["open"][0] = "layer-mutated"
+
+	if !reflect.DeepEqual(got.Repos.Roots, []string{"~/work"}) {
+		t.Fatalf("expected merged roots to be isolated, got %#v", got.Repos.Roots)
+	}
+	if !reflect.DeepEqual(got.Keys["open"], []string{"x"}) {
+		t.Fatalf("expected merged keys to be isolated, got %#v", got.Keys["open"])
+	}
+}
+
+func TestValidate_RejectsInvalidKnownValues(t *testing.T) {
+	cfg := Defaults()
+	cfg.Startup.Repo = "not-a-repo"
+	cfg.Startup.View = StartupView("issues")
+	cfg.UI.PreviewWidth = 1
+	cfg.Keys["open"] = nil
+	cfg.Repos.Roots = []string{" "}
+	cfg.Workbench.Filter.PullRequest = PullRequestFilter("maybe")
+	cfg.Workbench.Filter.LocalStatus = LocalStatusFilter("stale")
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+
+	var validationErr ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T", err)
+	}
+	for _, want := range []string{
+		"startup.repo",
+		"startup.view",
+		"ui.preview_width",
+		"keys.open",
+		"repos.roots[0]",
+		"workbench.filter.pull_request",
+		"workbench.filter.local_status",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected validation error to mention %q, got %q", want, err.Error())
+		}
+	}
+}
+
+func TestValidateLayer_ReturnsUnknownKeyWarnings(t *testing.T) {
+	warnings, err := ValidateLayer(PartialConfig{
+		UnknownKeys: []string{"ui.unused", "workbench.future"},
+	})
+	if err != nil {
+		t.Fatalf("expected unknown keys to be non-fatal, got %v", err)
+	}
+	if len(warnings) != 2 {
+		t.Fatalf("expected two warnings, got %#v", warnings)
+	}
+	if warnings[0].Path != "ui.unused" || warnings[0].Message == "" {
+		t.Fatalf("unexpected warning: %+v", warnings[0])
+	}
+}
+
+func TestValidateLayer_RejectsInvalidKnownValues(t *testing.T) {
+	view := StartupView("issues")
+	warnings, err := ValidateLayer(PartialConfig{
+		Startup:     StartupConfigLayer{View: &view},
+		UnknownKeys: []string{"future.option"},
+	})
+	if err == nil {
+		t.Fatalf("expected invalid known value to be fatal")
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected unknown key warning to be preserved, got %#v", warnings)
+	}
+}
+
+func str(value string) *string {
+	return &value
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
+}
+
+func stringList(values ...string) *[]string {
+	return &values
+}
+
+func ptr[T any](value T) *T {
+	return &value
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -246,6 +246,7 @@ func TestIsRepoFullName_ValidatesOwnerAndRepositorySegments(t *testing.T) {
 	}{
 		{name: "basic", value: "owner/repo", want: true},
 		{name: "owner hyphen", value: "owner-name/repo", want: true},
+		{name: "numeric owner", value: "123/repo", want: true},
 		{name: "repo punctuation", value: "owner/repo.name_test", want: true},
 		{name: "leading whitespace", value: " owner/repo", want: false},
 		{name: "trailing whitespace", value: "owner/repo ", want: false},
@@ -253,6 +254,9 @@ func TestIsRepoFullName_ValidatesOwnerAndRepositorySegments(t *testing.T) {
 		{name: "repo whitespace", value: "owner/re po", want: false},
 		{name: "owner slash", value: "owner/team/repo", want: false},
 		{name: "owner underscore", value: "owner_name/repo", want: false},
+		{name: "owner leading hyphen", value: "-team/repo", want: false},
+		{name: "owner trailing hyphen", value: "team-/repo", want: false},
+		{name: "owner consecutive hyphens", value: "team--name/repo", want: false},
 		{name: "empty owner", value: "/repo", want: false},
 		{name: "empty repo", value: "owner/", want: false},
 	}


### PR DESCRIPTION
## Summary
- Add runtime config and optional layer types for startup, UI, keys, repos, worktrees, and workbench filters.
- Implement built-in defaults, layer merge rules, validation, and unknown-key diagnostics.
- Cover scalar, map, list, key-binding, and validation behavior with small tests.

## Test Plan
- [x] make check

Closes #9