### PR TITLE
Reject NaN preview width

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 )
@@ -320,7 +321,7 @@ func Validate(cfg Config) error {
 	if !isSafeIdentifier(cfg.UI.Theme) {
 		problems = append(problems, Problem{Path: "ui.theme", Message: "must be a safe identifier"})
 	}
-	if cfg.UI.PreviewWidth <= 0 || cfg.UI.PreviewWidth >= 1 {
+	if math.IsNaN(cfg.UI.PreviewWidth) || cfg.UI.PreviewWidth <= 0 || cfg.UI.PreviewWidth >= 1 {
 		problems = append(problems, Problem{Path: "ui.preview_width", Message: "must be greater than 0 and less than 1"})
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -214,6 +215,19 @@ func TestValidate_RejectsInvalidKnownValues(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("expected validation error to mention %q, got %q", want, err.Error())
 		}
+	}
+}
+
+func TestValidate_RejectsNaNPreviewWidth(t *testing.T) {
+	cfg := Defaults()
+	cfg.UI.PreviewWidth = math.NaN()
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "ui.preview_width") {
+		t.Fatalf("expected validation error to mention ui.preview_width, got %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reject NaN values for ui.preview_width during config validation.
- Add coverage for runtime-injected NaN preview widths.

## Test Plan
- [x] go test -short ./internal/config
- [x] make check