### PR TITLE
Discover local Git worktrees and status

### DIFF
--- a/internal/localrepo/service.go
+++ b/internal/localrepo/service.go
@@ -58,6 +58,12 @@ func (s Service) DiscoverWorktrees(ctx context.Context, repoPath string) ([]Work
 	}
 	for i := range worktrees {
 		worktree := &worktrees[i]
+		if worktree.Prunable {
+			if missingPath(worktree.Path) {
+				worktree.Missing = true
+			}
+			continue
+		}
 		if missingPath(worktree.Path) {
 			worktree.Missing = true
 			continue
@@ -120,7 +126,7 @@ func ParseWorktreeListPorcelain(output string) ([]Worktree, error) {
 }
 
 func porcelainStatusEntries(output string) []string {
-	output = strings.TrimSpace(output)
+	output = strings.TrimRight(output, "\r\n")
 	if output == "" {
 		return nil
 	}

--- a/internal/localrepo/service.go
+++ b/internal/localrepo/service.go
@@ -29,14 +29,14 @@ type Runner interface {
 // GitRunner runs real Git commands.
 type GitRunner struct{}
 
-// Run executes git with -C dir and returns trimmed combined output.
+// Run executes git with -C dir and returns combined output without trailing newlines.
 func (GitRunner) Run(ctx context.Context, dir string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
 	}
-	return strings.TrimSpace(string(output)), nil
+	return trimGitOutput(output), nil
 }
 
 // Service discovers local repository state behind a Git command boundary.
@@ -131,6 +131,10 @@ func porcelainStatusEntries(output string) []string {
 		return nil
 	}
 	return strings.Split(output, "\n")
+}
+
+func trimGitOutput(output []byte) string {
+	return strings.TrimRight(string(output), "\r\n")
 }
 
 func missingPath(path string) bool {

--- a/internal/localrepo/service.go
+++ b/internal/localrepo/service.go
@@ -1,0 +1,133 @@
+package localrepo
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Worktree describes one local Git worktree discovered from porcelain output.
+type Worktree struct {
+	Path           string
+	Head           string
+	Branch         string
+	Detached       bool
+	Missing        bool
+	Prunable       bool
+	PrunableReason string
+	Dirty          bool
+	StatusEntries  []string
+}
+
+// Runner executes Git commands for the local repository service.
+type Runner interface {
+	Run(ctx context.Context, dir string, args ...string) (string, error)
+}
+
+// GitRunner runs real Git commands.
+type GitRunner struct{}
+
+// Run executes git with -C dir and returns trimmed combined output.
+func (GitRunner) Run(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// Service discovers local repository state behind a Git command boundary.
+type Service struct {
+	Runner Runner
+}
+
+// DiscoverWorktrees lists local worktrees and reads their dirty status.
+func (s Service) DiscoverWorktrees(ctx context.Context, repoPath string) ([]Worktree, error) {
+	runner := s.runner()
+	output, err := runner.Run(ctx, repoPath, "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, fmt.Errorf("list worktrees: %w", err)
+	}
+
+	worktrees, err := ParseWorktreeListPorcelain(output)
+	if err != nil {
+		return nil, err
+	}
+	for i := range worktrees {
+		worktree := &worktrees[i]
+		if missingPath(worktree.Path) {
+			worktree.Missing = true
+			continue
+		}
+		status, err := runner.Run(ctx, worktree.Path, "status", "--porcelain=v1")
+		if err != nil {
+			return nil, fmt.Errorf("read status for %q: %w", worktree.Path, err)
+		}
+		worktree.StatusEntries = porcelainStatusEntries(status)
+		worktree.Dirty = len(worktree.StatusEntries) > 0
+	}
+	return worktrees, nil
+}
+
+func (s Service) runner() Runner {
+	if s.Runner != nil {
+		return s.Runner
+	}
+	return GitRunner{}
+}
+
+// ParseWorktreeListPorcelain parses git worktree list --porcelain output.
+func ParseWorktreeListPorcelain(output string) ([]Worktree, error) {
+	blocks := strings.Split(strings.TrimSpace(output), "\n\n")
+	if len(blocks) == 1 && strings.TrimSpace(blocks[0]) == "" {
+		return nil, nil
+	}
+
+	worktrees := make([]Worktree, 0, len(blocks))
+	for _, block := range blocks {
+		var worktree Worktree
+		for _, line := range strings.Split(block, "\n") {
+			if line == "" {
+				continue
+			}
+			key, value, hasValue := strings.Cut(line, " ")
+			switch key {
+			case "worktree":
+				if !hasValue || value == "" {
+					return nil, fmt.Errorf("worktree porcelain entry missing path")
+				}
+				worktree.Path = value
+			case "HEAD":
+				worktree.Head = value
+			case "branch":
+				worktree.Branch = strings.TrimPrefix(value, "refs/heads/")
+			case "detached":
+				worktree.Detached = true
+			case "prunable":
+				worktree.Prunable = true
+				worktree.PrunableReason = value
+			}
+		}
+		if worktree.Path == "" {
+			return nil, fmt.Errorf("worktree porcelain block missing worktree path")
+		}
+		worktrees = append(worktrees, worktree)
+	}
+	return worktrees, nil
+}
+
+func porcelainStatusEntries(output string) []string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil
+	}
+	return strings.Split(output, "\n")
+}
+
+func missingPath(path string) bool {
+	_, err := os.Stat(path)
+	return os.IsNotExist(err)
+}

--- a/internal/localrepo/service_test.go
+++ b/internal/localrepo/service_test.go
@@ -1,0 +1,180 @@
+package localrepo
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseWorktreeListPorcelain(t *testing.T) {
+	output := strings.TrimSpace(`
+worktree /repo
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+worktree /repo-detached
+HEAD 2222222222222222222222222222222222222222
+detached
+
+worktree /repo-missing
+HEAD 3333333333333333333333333333333333333333
+branch refs/heads/feature
+prunable gitdir file points to non-existent location
+`)
+
+	got, err := ParseWorktreeListPorcelain(output)
+	if err != nil {
+		t.Fatalf("expected porcelain output to parse, got %v", err)
+	}
+
+	want := []Worktree{
+		{Path: "/repo", Head: "1111111111111111111111111111111111111111", Branch: "main"},
+		{Path: "/repo-detached", Head: "2222222222222222222222222222222222222222", Detached: true},
+		{
+			Path:           "/repo-missing",
+			Head:           "3333333333333333333333333333333333333333",
+			Branch:         "feature",
+			Prunable:       true,
+			PrunableReason: "gitdir file points to non-existent location",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected worktrees %+v, got %+v", want, got)
+	}
+}
+
+func TestParseWorktreeListPorcelain_RejectsMalformedBlocks(t *testing.T) {
+	_, err := ParseWorktreeListPorcelain("HEAD abc")
+	if err == nil {
+		t.Fatalf("expected missing worktree path to fail")
+	}
+}
+
+func TestPorcelainStatusEntries(t *testing.T) {
+	got := porcelainStatusEntries(" M file.go\n?? new.go\n")
+	want := []string{"M file.go", "?? new.go"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected status entries %#v, got %#v", want, got)
+	}
+	if entries := porcelainStatusEntries(""); len(entries) != 0 {
+		t.Fatalf("expected empty status entries, got %#v", entries)
+	}
+}
+
+func TestService_DiscoverWorktrees(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories and worktrees")
+	}
+
+	repoDir := initTempGitRepo(t)
+	writeFile(t, filepath.Join(repoDir, "README.md"), "initial\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+
+	featureDir := filepath.Join(t.TempDir(), "feature")
+	runGit(t, repoDir, "worktree", "add", "-b", "feature", featureDir)
+	writeFile(t, filepath.Join(featureDir, "dirty.txt"), "dirty\n")
+
+	worktrees, err := (Service{}).DiscoverWorktrees(context.Background(), repoDir)
+	if err != nil {
+		t.Fatalf("expected worktrees to be discovered, got %v", err)
+	}
+
+	mainWorktree := requireWorktree(t, worktrees, repoDir)
+	if mainWorktree.Branch != "main" {
+		t.Fatalf("expected main branch, got %+v", mainWorktree)
+	}
+	if mainWorktree.Dirty {
+		t.Fatalf("expected main worktree to be clean, got %+v", mainWorktree)
+	}
+
+	featureWorktree := requireWorktree(t, worktrees, featureDir)
+	if featureWorktree.Branch != "feature" {
+		t.Fatalf("expected feature branch, got %+v", featureWorktree)
+	}
+	if !featureWorktree.Dirty || len(featureWorktree.StatusEntries) == 0 {
+		t.Fatalf("expected feature worktree to be dirty, got %+v", featureWorktree)
+	}
+}
+
+func TestService_DiscoverWorktreesMarksMissingWorktrees(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories and worktrees")
+	}
+
+	repoDir := initTempGitRepo(t)
+	writeFile(t, filepath.Join(repoDir, "README.md"), "initial\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+
+	missingDir := filepath.Join(t.TempDir(), "missing")
+	runGit(t, repoDir, "worktree", "add", "-b", "missing", missingDir)
+	if err := os.RemoveAll(missingDir); err != nil {
+		t.Fatalf("remove missing worktree: %v", err)
+	}
+
+	worktrees, err := (Service{}).DiscoverWorktrees(context.Background(), repoDir)
+	if err != nil {
+		t.Fatalf("expected worktrees to be discovered, got %v", err)
+	}
+	missingWorktree := requireWorktree(t, worktrees, missingDir)
+	if !missingWorktree.Missing {
+		t.Fatalf("expected missing worktree flag, got %+v", missingWorktree)
+	}
+}
+
+func requireWorktree(t *testing.T, worktrees []Worktree, path string) Worktree {
+	t.Helper()
+	wantPath := canonicalPath(t, path)
+	for _, worktree := range worktrees {
+		if canonicalPath(t, worktree.Path) == wantPath {
+			return worktree
+		}
+	}
+	t.Fatalf("worktree %q not found in %+v", path, worktrees)
+	return Worktree{}
+}
+
+func canonicalPath(t *testing.T, path string) string {
+	t.Helper()
+	canonical, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return canonical
+	}
+	parent, parentErr := filepath.EvalSymlinks(filepath.Dir(path))
+	if parentErr == nil {
+		return filepath.Join(parent, filepath.Base(path))
+	}
+	return filepath.Clean(path)
+}
+
+func initTempGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test User")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/localrepo/service_test.go
+++ b/internal/localrepo/service_test.go
@@ -85,6 +85,14 @@ func TestPorcelainStatusEntries(t *testing.T) {
 	}
 }
 
+func TestTrimGitOutputPreservesLeadingStatusColumns(t *testing.T) {
+	got := trimGitOutput([]byte(" M file.go\n?? new.go\n"))
+	want := " M file.go\n?? new.go"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
 func TestService_DiscoverWorktreesSkipsStatusForPrunableWorktrees(t *testing.T) {
 	repoDir := t.TempDir()
 	staleDir := filepath.Join(t.TempDir(), "stale")

--- a/internal/localrepo/service_test.go
+++ b/internal/localrepo/service_test.go
@@ -2,6 +2,7 @@ package localrepo
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,6 +10,25 @@ import (
 	"strings"
 	"testing"
 )
+
+type fakeRunner struct {
+	outputs map[string]string
+	errors  map[string]error
+	calls   []string
+}
+
+func (r *fakeRunner) Run(_ context.Context, dir string, args ...string) (string, error) {
+	call := dir + " " + strings.Join(args, " ")
+	r.calls = append(r.calls, call)
+	if err := r.errors[call]; err != nil {
+		return "", err
+	}
+	output, ok := r.outputs[call]
+	if !ok {
+		return "", fmt.Errorf("unexpected git call %s", call)
+	}
+	return output, nil
+}
 
 func TestParseWorktreeListPorcelain(t *testing.T) {
 	output := strings.TrimSpace(`
@@ -56,12 +76,57 @@ func TestParseWorktreeListPorcelain_RejectsMalformedBlocks(t *testing.T) {
 
 func TestPorcelainStatusEntries(t *testing.T) {
 	got := porcelainStatusEntries(" M file.go\n?? new.go\n")
-	want := []string{"M file.go", "?? new.go"}
+	want := []string{" M file.go", "?? new.go"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected status entries %#v, got %#v", want, got)
 	}
 	if entries := porcelainStatusEntries(""); len(entries) != 0 {
 		t.Fatalf("expected empty status entries, got %#v", entries)
+	}
+}
+
+func TestService_DiscoverWorktreesSkipsStatusForPrunableWorktrees(t *testing.T) {
+	repoDir := t.TempDir()
+	staleDir := filepath.Join(t.TempDir(), "stale")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatalf("mkdir stale worktree: %v", err)
+	}
+
+	listCall := repoDir + " worktree list --porcelain"
+	repoStatusCall := repoDir + " status --porcelain=v1"
+	staleStatusCall := staleDir + " status --porcelain=v1"
+	runner := &fakeRunner{
+		outputs: map[string]string{
+			listCall: strings.Join([]string{
+				"worktree " + repoDir,
+				"HEAD 1111111111111111111111111111111111111111",
+				"branch refs/heads/main",
+				"",
+				"worktree " + staleDir,
+				"HEAD 2222222222222222222222222222222222222222",
+				"branch refs/heads/stale",
+				"prunable gitdir file points to non-existent location",
+			}, "\n"),
+			repoStatusCall: "",
+		},
+		errors: map[string]error{
+			staleStatusCall: fmt.Errorf("status should not be called"),
+		},
+	}
+
+	worktrees, err := (Service{Runner: runner}).DiscoverWorktrees(context.Background(), repoDir)
+	if err != nil {
+		t.Fatalf("expected prunable worktree to be skipped, got %v", err)
+	}
+
+	stale := requireWorktree(t, worktrees, staleDir)
+	if !stale.Prunable || stale.Dirty || len(stale.StatusEntries) != 0 {
+		t.Fatalf("expected prunable worktree without status, got %+v", stale)
+	}
+	for _, call := range runner.calls {
+		if call == staleStatusCall {
+			t.Fatalf("expected status call for prunable worktree to be skipped, calls=%#v", runner.calls)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a local repository service boundary for Git command execution.
- Parse git worktree list --porcelain output into local worktree state.
- Read git status --porcelain=v1 for clean, dirty, missing, detached, and prunable worktree state.

## Test Plan
- [x] go test -short ./internal/localrepo
- [x] go test ./internal/localrepo
- [x] make check

Stacked on #29.
Closes #12