### PR TITLE
Add read-only work item actions

### DIFF
--- a/internal/app/actions.go
+++ b/internal/app/actions.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+type actionRunner interface {
+	Open(ctx context.Context, target string) error
+	Copy(ctx context.Context, text string) error
+}
+
+type systemActionRunner struct{}
+
+type actionResultMsg struct {
+	success string
+	failure string
+	err     error
+}
+
+func (systemActionRunner) Open(ctx context.Context, target string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.CommandContext(ctx, "open", target)
+	case "windows":
+		cmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		cmd = exec.CommandContext(ctx, "xdg-open", target)
+	}
+	return cmd.Run()
+}
+
+func (systemActionRunner) Copy(ctx context.Context, text string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.CommandContext(ctx, "pbcopy")
+	case "windows":
+		cmd = exec.CommandContext(ctx, "clip")
+	default:
+		return copyWithLinuxClipboard(ctx, text)
+	}
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
+}
+
+func copyWithLinuxClipboard(ctx context.Context, text string) error {
+	if err := runClipboardCommand(ctx, text, "wl-copy"); err == nil {
+		return nil
+	}
+	if err := runClipboardCommand(ctx, text, "xclip", "-selection", "clipboard"); err == nil {
+		return nil
+	}
+	return fmt.Errorf("no supported clipboard command found")
+}
+
+func runClipboardCommand(ctx context.Context, text string, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
+}

--- a/internal/app/actions.go
+++ b/internal/app/actions.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -22,16 +23,32 @@ type actionResultMsg struct {
 }
 
 func (systemActionRunner) Open(ctx context.Context, target string) error {
+	if !isOpenTargetURL(target) {
+		return fmt.Errorf("unsupported URL %q", target)
+	}
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		cmd = exec.CommandContext(ctx, "open", target)
+		cmd = exec.CommandContext(ctx, "open", "--", target)
 	case "windows":
 		cmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", target)
 	default:
 		cmd = exec.CommandContext(ctx, "xdg-open", target)
 	}
 	return cmd.Run()
+}
+
+func isOpenTargetURL(target string) bool {
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return false
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+		return parsed.Host != ""
+	default:
+		return false
+	}
 }
 
 func (systemActionRunner) Copy(ctx context.Context, text string) error {

--- a/internal/app/actions_test.go
+++ b/internal/app/actions_test.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestIsOpenTargetURL(t *testing.T) {
+	cases := []struct {
+		name   string
+		target string
+		want   bool
+	}{
+		{name: "https", target: "https://github.com/0maru/gh-zen/pull/36", want: true},
+		{name: "http", target: "http://example.test/issues/1", want: true},
+		{name: "missing host", target: "https:///path", want: false},
+		{name: "file URL", target: "file:///tmp/worktree", want: false},
+		{name: "option-like value", target: "-psn_0_123", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isOpenTargetURL(tc.target); got != tc.want {
+				t.Fatalf("expected %q validation to be %v, got %v", tc.target, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestSystemActionRunner_OpenRejectsUnsafeTarget(t *testing.T) {
+	err := (systemActionRunner{}).Open(context.Background(), "-psn_0_123")
+	if err == nil {
+		t.Fatal("expected unsafe open target to fail before launching")
+	}
+	if !strings.Contains(err.Error(), "unsupported URL") {
+		t.Fatalf("expected unsupported URL error, got %v", err)
+	}
+}

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -20,8 +20,10 @@ const (
 	actionFocusPane3        actionID = "focus_pane_3"
 	actionToggleHelp        actionID = "toggle_help"
 	actionRefresh           actionID = "refresh"
-	actionOpen              actionID = "open"
-	actionCopy              actionID = "copy"
+	actionOpenPullRequest   actionID = "open_pr"
+	actionOpenIssue         actionID = "open_issue"
+	actionCopyURL           actionID = "copy_url"
+	actionCopyWorktreePath  actionID = "copy_worktree_path"
 	actionQuit              actionID = "quit"
 )
 
@@ -42,8 +44,10 @@ type workbenchKeyMap struct {
 	FocusPane3        key.Binding
 	ToggleHelp        key.Binding
 	Refresh           key.Binding
-	Open              key.Binding
-	Copy              key.Binding
+	OpenPullRequest   key.Binding
+	OpenIssue         key.Binding
+	CopyURL           key.Binding
+	CopyWorktreePath  key.Binding
 	Quit              key.Binding
 }
 
@@ -106,13 +110,21 @@ func DefaultKeyMap() workbenchKeyMap {
 			key.WithKeys("r"),
 			key.WithHelp("r", "refresh"),
 		),
-		Open: key.NewBinding(
-			key.WithKeys("enter", "o"),
-			key.WithHelp("enter/o", "open"),
+		OpenPullRequest: key.NewBinding(
+			key.WithKeys("p"),
+			key.WithHelp("p", "open PR"),
 		),
-		Copy: key.NewBinding(
+		OpenIssue: key.NewBinding(
+			key.WithKeys("i"),
+			key.WithHelp("i", "open issue"),
+		),
+		CopyURL: key.NewBinding(
 			key.WithKeys("y"),
-			key.WithHelp("y", "copy"),
+			key.WithHelp("y", "copy URL"),
+		),
+		CopyWorktreePath: key.NewBinding(
+			key.WithKeys("Y"),
+			key.WithHelp("Y", "copy path"),
 		),
 		Quit: key.NewBinding(
 			key.WithKeys("q", "esc", "ctrl+c"),
@@ -135,8 +147,10 @@ func (k workbenchKeyMap) actionBindings() []actionBinding {
 		{id: actionJumpTop, binding: k.JumpTop},
 		{id: actionJumpBottom, binding: k.JumpBottom},
 		{id: actionRefresh, binding: k.Refresh},
-		{id: actionOpen, binding: k.Open},
-		{id: actionCopy, binding: k.Copy},
+		{id: actionOpenPullRequest, binding: k.OpenPullRequest},
+		{id: actionOpenIssue, binding: k.OpenIssue},
+		{id: actionCopyURL, binding: k.CopyURL},
+		{id: actionCopyWorktreePath, binding: k.CopyWorktreePath},
 	}
 }
 
@@ -144,7 +158,7 @@ func (k workbenchKeyMap) contextualHelp(focus paneFocus, visiblePanes []paneFocu
 	paneNumbers := k.visiblePaneBinding(visiblePanes)
 	paneKeys := combinedBinding("pane", k.FocusPreviousPane, k.FocusNextPane)
 	system := []key.Binding{k.ToggleHelp, k.Quit}
-	actions := []key.Binding{k.Open, k.Copy, k.Refresh}
+	actions := []key.Binding{k.OpenPullRequest, k.OpenIssue, k.CopyURL, k.CopyWorktreePath, k.Refresh}
 	panes := []key.Binding{k.FocusPreviousPane, k.FocusNextPane, paneNumbers}
 
 	short := []key.Binding{paneNumbers, paneKeys, k.ToggleHelp, k.Quit}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -85,6 +85,8 @@ type model struct {
 	githubSummary        ghsvc.RepositorySummary
 	githubError          string
 	workbenchFilter      cfgpkg.WorkbenchFilter
+	actionRunner         actionRunner
+	statusMessage        string
 	styles               Styles
 	keys                 workbenchKeyMap
 	help                 help.Model
@@ -131,6 +133,7 @@ func newModelWithRuntimeConfig(cfg cfgpkg.Config, startupRepo string, loader pre
 		workItems:       workbench.FakeWorkItems(),
 		previewLoader:   loader,
 		workbenchFilter: cfg.Workbench.Filter,
+		actionRunner:    systemActionRunner{},
 		styles:          DefaultStyles(),
 		keys:            DefaultKeyMap(),
 		help:            newHelpModel(),
@@ -178,6 +181,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case previewResultMsg:
 		m.handlePreviewResult(msg)
+		return m, nil
+	case actionResultMsg:
+		m.handleActionResult(msg)
 		return m, nil
 	case githubSummaryMsg:
 		m.handleGitHubSummary(msg)
@@ -297,11 +303,125 @@ func (m *model) handleAction(action actionID) tea.Cmd {
 		m.jumpFocusedSelection(true)
 		return m.startPreviewLoadIfFocusedItemChanged()
 	case actionRefresh:
-		return m.refreshGitHubSummary()
-	case actionOpen, actionCopy:
-		return nil
+		cmd := m.refreshGitHubSummary()
+		if cmd == nil {
+			m.statusMessage = "Refresh unavailable"
+			return nil
+		}
+		m.statusMessage = "Refreshing GitHub data..."
+		return cmd
+	case actionOpenPullRequest:
+		return m.openPullRequest()
+	case actionOpenIssue:
+		return m.openIssue()
+	case actionCopyURL:
+		return m.copyURL()
+	case actionCopyWorktreePath:
+		return m.copyWorktreePath()
 	}
 	return nil
+}
+
+func (m *model) openPullRequest() tea.Cmd {
+	item, ok := m.selectedWorkItem()
+	if !ok {
+		m.statusMessage = "No work item selected"
+		return nil
+	}
+	if item.PullRequest == nil || item.PullRequest.URL == "" {
+		m.statusMessage = "No PR URL for selected work item"
+		return nil
+	}
+	label := item.PullRequest.NumberLabel()
+	m.statusMessage = "Opening " + label + "..."
+	return m.actionCommand("Opened "+label, "Open PR failed", func(ctx context.Context) error {
+		return m.runner().Open(ctx, item.PullRequest.URL)
+	})
+}
+
+func (m *model) openIssue() tea.Cmd {
+	item, ok := m.selectedWorkItem()
+	if !ok {
+		m.statusMessage = "No work item selected"
+		return nil
+	}
+	if item.Issue == nil || item.Issue.URL == "" {
+		m.statusMessage = "No issue URL for selected work item"
+		return nil
+	}
+	label := item.Issue.Label()
+	m.statusMessage = "Opening " + label + "..."
+	return m.actionCommand("Opened "+label, "Open issue failed", func(ctx context.Context) error {
+		return m.runner().Open(ctx, item.Issue.URL)
+	})
+}
+
+func (m *model) copyURL() tea.Cmd {
+	item, ok := m.selectedWorkItem()
+	if !ok {
+		m.statusMessage = "No work item selected"
+		return nil
+	}
+	label, target, ok := bestWorkItemURL(item)
+	if !ok {
+		m.statusMessage = "No URL for selected work item"
+		return nil
+	}
+	m.statusMessage = "Copying " + label + " URL..."
+	return m.actionCommand("Copied "+label+" URL", "Copy URL failed", func(ctx context.Context) error {
+		return m.runner().Copy(ctx, target)
+	})
+}
+
+func (m *model) copyWorktreePath() tea.Cmd {
+	item, ok := m.selectedWorkItem()
+	if !ok {
+		m.statusMessage = "No work item selected"
+		return nil
+	}
+	if item.Worktree == nil || item.Worktree.Path == "" {
+		m.statusMessage = "No worktree path for selected work item"
+		return nil
+	}
+	m.statusMessage = "Copying worktree path..."
+	return m.actionCommand("Copied worktree path", "Copy worktree path failed", func(ctx context.Context) error {
+		return m.runner().Copy(ctx, item.Worktree.Path)
+	})
+}
+
+func (m *model) actionCommand(success string, failure string, run func(context.Context) error) tea.Cmd {
+	return func() tea.Msg {
+		return actionResultMsg{
+			success: success,
+			failure: failure,
+			err:     run(context.Background()),
+		}
+	}
+}
+
+func (m *model) handleActionResult(msg actionResultMsg) {
+	if msg.err != nil {
+		m.statusMessage = fmt.Sprintf("%s: %v", msg.failure, msg.err)
+		return
+	}
+	m.statusMessage = msg.success
+}
+
+func (m model) runner() actionRunner {
+	if m.actionRunner != nil {
+		return m.actionRunner
+	}
+	return systemActionRunner{}
+}
+
+func bestWorkItemURL(item workbench.WorkItem) (string, string, bool) {
+	if item.PullRequest != nil && item.PullRequest.URL != "" {
+		return "PR", item.PullRequest.URL, true
+	}
+	if item.Issue != nil && item.Issue.URL != "" {
+		return "issue", item.Issue.URL, true
+	}
+	return "", "", false
 }
 
 func (m model) refreshGitHubSummary() tea.Cmd {
@@ -322,10 +442,12 @@ func (m model) refreshGitHubSummary() tea.Cmd {
 func (m *model) handleGitHubSummary(msg githubSummaryMsg) {
 	if msg.err != nil {
 		m.githubError = msg.err.Error()
+		m.statusMessage = "Refresh failed: " + msg.err.Error()
 		return
 	}
 	m.githubError = ""
 	m.githubSummary = msg.summary
+	m.statusMessage = "Refreshed GitHub data"
 }
 
 func (m *model) focusNextPane() {
@@ -753,7 +875,11 @@ func (m model) previewStatusLines(width int, status string) []string {
 
 func (m model) headerLines(title string, width int) []string {
 	out := []string{title}
-	return append(out, m.keymapLines(width)...)
+	out = append(out, m.keymapLines(width)...)
+	if m.statusMessage != "" {
+		out = append(out, truncate("Status: "+m.statusMessage, width))
+	}
+	return out
 }
 
 // keymapLines keeps the active pane affordances visible near the title.

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -60,6 +61,22 @@ func errorPreviewLoader(err error) previewLoader {
 			}
 		}
 	}
+}
+
+type fakeActionRunner struct {
+	opened []string
+	copied []string
+	err    error
+}
+
+func (r *fakeActionRunner) Open(_ context.Context, target string) error {
+	r.opened = append(r.opened, target)
+	return r.err
+}
+
+func (r *fakeActionRunner) Copy(_ context.Context, text string) error {
+	r.copied = append(r.copied, text)
+	return r.err
 }
 
 func requireGitHubSummaryMsg(t *testing.T, cmd tea.Cmd) githubSummaryMsg {
@@ -457,9 +474,10 @@ func TestUpdate_ActionKeysAreBound(t *testing.T) {
 		want actionID
 	}{
 		{"refresh", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}, actionRefresh},
-		{"open", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}}, actionOpen},
-		{"enter", tea.KeyMsg{Type: tea.KeyEnter}, actionOpen},
-		{"copy", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}, actionCopy},
+		{"open PR", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}}, actionOpenPullRequest},
+		{"open issue", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}}, actionOpenIssue},
+		{"copy URL", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}, actionCopyURL},
+		{"copy worktree path", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}}, actionCopyWorktreePath},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -471,6 +489,100 @@ func TestUpdate_ActionKeysAreBound(t *testing.T) {
 				t.Fatalf("expected action %s, got %s", tc.want, got)
 			}
 		})
+	}
+}
+
+func TestUpdate_OpenPullRequestRunsActionCommand(t *testing.T) {
+	runner := &fakeActionRunner{}
+	start := newModel()
+	start.actionRunner = runner
+	start.selectedItem = 1
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if cmd == nil {
+		t.Fatalf("expected open PR command")
+	}
+	msg := cmd()
+	if len(runner.opened) != 1 || runner.opened[0] != "https://github.com/0maru/gh-zen/pull/24" {
+		t.Fatalf("expected PR URL to open, got %#v", runner.opened)
+	}
+	got, _ = got.(model).Update(msg)
+	if status := got.(model).statusMessage; status != "Opened PR #24" {
+		t.Fatalf("expected success status, got %q", status)
+	}
+}
+
+func TestUpdate_OpenIssueRunsActionCommand(t *testing.T) {
+	runner := &fakeActionRunner{}
+	start := newModel()
+	start.actionRunner = runner
+	start.selectedItem = 1
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd == nil {
+		t.Fatalf("expected open issue command")
+	}
+	_ = cmd()
+	if len(runner.opened) != 1 || runner.opened[0] != "https://github.com/0maru/gh-zen/issues/9" {
+		t.Fatalf("expected issue URL to open, got %#v", runner.opened)
+	}
+	if status := got.(model).statusMessage; !strings.Contains(status, "Opening #9") {
+		t.Fatalf("expected pending status, got %q", status)
+	}
+}
+
+func TestUpdate_CopyActionsRouteSelectedWorkItemData(t *testing.T) {
+	runner := &fakeActionRunner{}
+	start := newModel()
+	start.actionRunner = runner
+	start.selectedItem = 1
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatalf("expected copy URL command")
+	}
+	got, _ = got.(model).Update(cmd())
+	if len(runner.copied) != 1 || runner.copied[0] != "https://github.com/0maru/gh-zen/pull/24" {
+		t.Fatalf("expected PR URL to copy, got %#v", runner.copied)
+	}
+	if status := got.(model).statusMessage; status != "Copied PR URL" {
+		t.Fatalf("expected copied URL status, got %q", status)
+	}
+
+	got, cmd = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}})
+	if cmd == nil {
+		t.Fatalf("expected copy worktree path command")
+	}
+	_ = cmd()
+	if len(runner.copied) != 2 || runner.copied[1] != "~/workspaces/github.com/0maru/gh-zen-agent-a" {
+		t.Fatalf("expected worktree path to copy, got %#v", runner.copied)
+	}
+}
+
+func TestUpdate_ActionMissingDataSetsStatusWithoutCommand(t *testing.T) {
+	start := newModel()
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if cmd != nil {
+		t.Fatalf("expected nil command when selected item has no PR")
+	}
+	if status := got.(model).statusMessage; status != "No PR URL for selected work item" {
+		t.Fatalf("expected missing PR status, got %q", status)
+	}
+}
+
+func TestUpdate_ActionFailureSetsStatus(t *testing.T) {
+	start := newModel()
+	start.actionRunner = &fakeActionRunner{err: errors.New("launcher failed")}
+	start.selectedItem = 1
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if cmd == nil {
+		t.Fatalf("expected open PR command")
+	}
+	got, _ = got.(model).Update(cmd())
+	if status := got.(model).statusMessage; !strings.Contains(status, "Open PR failed: launcher failed") {
+		t.Fatalf("expected failure status, got %q", status)
 	}
 }
 

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -106,7 +106,7 @@ func TestView_FullHelpShowsContextualActions(t *testing.T) {
 	m.help.ShowAll = true
 	got := ansi.Strip(m.View())
 
-	for _, want := range []string{"enter/o open", "copy", "refresh"} {
+	for _, want := range []string{"p open PR", "i open issue", "y copy URL", "Y copy path", "r refresh"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected full help to include %q, got:\n%s", want, got)
 		}
@@ -120,7 +120,7 @@ func TestView_FullHelpShowsContextualActions(t *testing.T) {
 	if strings.Contains(got, "j down") || strings.Contains(got, "G bottom") {
 		t.Fatalf("expected preview full help to omit movement keys, got:\n%s", got)
 	}
-	if !strings.Contains(got, "enter/o open") || !strings.Contains(got, "refresh") {
+	if !strings.Contains(got, "p open PR") || !strings.Contains(got, "r refresh") {
 		t.Fatalf("expected preview full help to keep actions, got:\n%s", got)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -208,8 +208,10 @@ func Defaults() Config {
 			"focus_pane_3":        {"3"},
 			"toggle_help":         {"?"},
 			"refresh":             {"r"},
-			"open":                {"enter", "o"},
-			"copy":                {"y"},
+			"open_pr":             {"p"},
+			"open_issue":          {"i"},
+			"copy_url":            {"y"},
+			"copy_worktree_path":  {"Y"},
 			"quit":                {"q", "esc", "ctrl+c"},
 		},
 		Repos: ReposConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -66,12 +66,12 @@ func TestMergeLayers_ScalarsUseLastWriterWins(t *testing.T) {
 func TestMerge_KeyBindingsReplacePerAction(t *testing.T) {
 	got := Merge(Defaults(), PartialConfig{
 		Keys: KeyBindings{
-			"open": {"x"},
+			"copy_url": {"x"},
 		},
 	})
 
-	if !reflect.DeepEqual(got.Keys["open"], []string{"x"}) {
-		t.Fatalf("expected open binding to be replaced, got %#v", got.Keys["open"])
+	if !reflect.DeepEqual(got.Keys["copy_url"], []string{"x"}) {
+		t.Fatalf("expected copy URL binding to be replaced, got %#v", got.Keys["copy_url"])
 	}
 	if !reflect.DeepEqual(got.Keys["quit"], []string{"q", "esc", "ctrl+c"}) {
 		t.Fatalf("expected unrelated key binding to remain, got %#v", got.Keys["quit"])
@@ -168,19 +168,19 @@ func TestMerge_DoesNotAliasBaseOrLayer(t *testing.T) {
 	layerRoots := []string{"~/work"}
 	layer := PartialConfig{
 		Repos: ReposConfigLayer{Roots: &layerRoots},
-		Keys:  KeyBindings{"open": {"x"}},
+		Keys:  KeyBindings{"copy_url": {"x"}},
 	}
 
 	got := Merge(base, layer)
-	base.Keys["open"][0] = "base-mutated"
+	base.Keys["copy_url"][0] = "base-mutated"
 	layerRoots[0] = "layer-mutated"
-	layer.Keys["open"][0] = "layer-mutated"
+	layer.Keys["copy_url"][0] = "layer-mutated"
 
 	if !reflect.DeepEqual(got.Repos.Roots, []string{"~/work"}) {
 		t.Fatalf("expected merged roots to be isolated, got %#v", got.Repos.Roots)
 	}
-	if !reflect.DeepEqual(got.Keys["open"], []string{"x"}) {
-		t.Fatalf("expected merged keys to be isolated, got %#v", got.Keys["open"])
+	if !reflect.DeepEqual(got.Keys["copy_url"], []string{"x"}) {
+		t.Fatalf("expected merged keys to be isolated, got %#v", got.Keys["copy_url"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add contextual read-only actions for opening PRs/issues, copying URLs, copying worktree paths, and refreshing GitHub data.
- Surface pending, success, missing-data, and failure status messages in the TUI header.
- Add action runner tests so routing is covered without launching external programs.

## Test Plan
- [x] go test -short ./internal/app ./internal/config
- [x] GIT_CONFIG_GLOBAL=/dev/null make check

Stacked on #35.
Closes #18