### PR TITLE
Add release workflow and install docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build extension release assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build and upload release assets
+        uses: cli/gh-extension-precompile@v2
+        with:
+          go_version_file: go.mod

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 `gh-zen` is a GitHub CLI extension for focused terminal GitHub workflows.
 
+## Installation
+
+Install the latest release with GitHub CLI:
+
+```sh
+gh extension install 0maru/gh-zen
+```
+
+Run it with:
+
+```sh
+gh zen
+```
+
 ## Development
 
 Install local hooks:
@@ -24,7 +38,9 @@ Build the local extension binary:
 make build
 ```
 
-Install this checkout as a local GitHub CLI extension:
+Install this checkout as a local GitHub CLI extension. `make install-extension`
+builds the root `gh-zen` binary first, then installs or updates the local
+extension link:
 
 ```sh
 make install-extension
@@ -39,3 +55,17 @@ gh zen
 `Makefile` targets are convenience entrypoints. The underlying validation and
 build commands live in `scripts/` so Lefthook, Codex hooks, Claude Code hooks,
 CI, and manual commands can share the same behavior.
+
+## Releases
+
+Pushing a tag that matches `v*`, such as `v0.1.0`, runs the release workflow.
+The workflow uses `cli/gh-extension-precompile@v2` to build platform-specific
+GitHub CLI extension assets from the root Go package and upload them to the
+matching GitHub Release.
+
+Release candidates can use prerelease tags such as `v0.1.0-rc.1`. GitHub CLI
+will install published release assets with:
+
+```sh
+gh extension install 0maru/gh-zen
+```

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ The workflow uses `cli/gh-extension-precompile@v2` to build platform-specific
 GitHub CLI extension assets from the root Go package and upload them to the
 matching GitHub Release.
 
-Release candidates can use prerelease tags such as `v0.1.0-rc.1`. GitHub CLI
-will install published release assets with:
+Release candidates can use prerelease tags such as `v0.1.0-rc.1`. To test a
+specific prerelease, pin the tag explicitly because GitHub CLI resolves an
+unpinned install to the latest stable release when one exists:
 
 ```sh
-gh extension install 0maru/gh-zen
+gh extension install 0maru/gh-zen --pin v0.1.0-rc.1
 ```


### PR DESCRIPTION
## Summary
- Add a tag-driven release workflow using cli/gh-extension-precompile@v2.
- Document release installation with gh extension install 0maru/gh-zen.
- Clarify the local make build and make install-extension development path.

## Test Plan
- [x] git diff --check
- [x] GIT_CONFIG_GLOBAL=/dev/null make check

Stacked on #36.
Closes #19