### PR TITLE
Connect live workbench data to startup

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -92,6 +92,12 @@ type model struct {
 	help                 help.Model
 }
 
+// WorkbenchData contains resolved repository workbench state for app startup.
+type WorkbenchData struct {
+	Repos     []workbench.RepoRef
+	WorkItems []workbench.WorkItem
+}
+
 type repoViewFilter int
 
 const (
@@ -119,6 +125,10 @@ func NewWithConfig(cfg cfgpkg.Config, startupRepo string) tea.Model {
 	return newModelWithRuntimeConfig(cfg, startupRepo, fakeDelayedPreviewLoader(defaultPreviewDelay))
 }
 
+func NewWithWorkbenchData(cfg cfgpkg.Config, startupRepo string, data WorkbenchData) tea.Model {
+	return newModelWithRuntimeData(cfg, startupRepo, data, fakeDelayedPreviewLoader(defaultPreviewDelay))
+}
+
 func newModel() model {
 	return newModelWithPreviewLoader(fakeDelayedPreviewLoader(defaultPreviewDelay))
 }
@@ -128,9 +138,16 @@ func newModelWithPreviewLoader(loader previewLoader) model {
 }
 
 func newModelWithRuntimeConfig(cfg cfgpkg.Config, startupRepo string, loader previewLoader) model {
+	return newModelWithRuntimeData(cfg, startupRepo, WorkbenchData{
+		Repos:     workbench.FakeRepos(),
+		WorkItems: workbench.FakeWorkItems(),
+	}, loader)
+}
+
+func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data WorkbenchData, loader previewLoader) model {
 	m := model{
-		repos:           workbench.FakeRepos(),
-		workItems:       workbench.FakeWorkItems(),
+		repos:           cloneRepoRefs(data.Repos),
+		workItems:       cloneWorkItems(data.WorkItems),
 		previewLoader:   loader,
 		workbenchFilter: cfg.Workbench.Filter,
 		actionRunner:    systemActionRunner{},
@@ -648,6 +665,14 @@ func filterWorkItems(items []workbench.WorkItem, keep func(workbench.WorkItem) b
 		}
 	}
 	return out
+}
+
+func cloneRepoRefs(repos []workbench.RepoRef) []workbench.RepoRef {
+	return append([]workbench.RepoRef(nil), repos...)
+}
+
+func cloneWorkItems(items []workbench.WorkItem) []workbench.WorkItem {
+	return append([]workbench.WorkItem(nil), items...)
 }
 
 func (v repoView) matches(item workbench.WorkItem) bool {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -125,6 +125,7 @@ func NewWithConfig(cfg cfgpkg.Config, startupRepo string) tea.Model {
 	return newModelWithRuntimeConfig(cfg, startupRepo, fakeDelayedPreviewLoader(defaultPreviewDelay))
 }
 
+// NewWithWorkbenchData builds the app model from already resolved workbench data.
 func NewWithWorkbenchData(cfg cfgpkg.Config, startupRepo string, data WorkbenchData) tea.Model {
 	return newModelWithRuntimeData(cfg, startupRepo, data, fakeDelayedPreviewLoader(defaultPreviewDelay))
 }

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -187,6 +187,46 @@ func TestNew_LoadsFakeWorkbenchData(t *testing.T) {
 	}
 }
 
+func TestNewWithWorkbenchData_UsesProvidedData(t *testing.T) {
+	cfg := cfgpkg.Defaults()
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	item := workbench.WorkItem{
+		ID:     "branch:live",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "live"},
+		Local:  &workbench.LocalStatus{State: workbench.LocalClean},
+	}
+
+	got := NewWithWorkbenchData(cfg, repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{item},
+	}).(model)
+
+	if len(got.repos) != 1 || got.repos[0] != repo {
+		t.Fatalf("expected provided repo only, got %+v", got.repos)
+	}
+	if len(got.workItems) != 1 || got.workItems[0].ID != item.ID {
+		t.Fatalf("expected provided work item only, got %+v", got.workItems)
+	}
+	if got.focusedWorkItemID != item.ID {
+		t.Fatalf("expected live item to be focused, got %q", got.focusedWorkItemID)
+	}
+}
+
+func TestNewWithWorkbenchData_EmptyDataDoesNotFallbackToFakeItems(t *testing.T) {
+	got := NewWithWorkbenchData(cfgpkg.Defaults(), "", WorkbenchData{}).(model)
+
+	if len(got.repos) != 0 {
+		t.Fatalf("expected no repos, got %+v", got.repos)
+	}
+	if len(got.workItems) != 0 {
+		t.Fatalf("expected no work items, got %+v", got.workItems)
+	}
+	if got.preview.status != previewEmpty {
+		t.Fatalf("expected empty preview, got %v", got.preview.status)
+	}
+}
+
 func TestInit_LoadsInitialPreview(t *testing.T) {
 	start := newModelWithPreviewLoader(fakeDelayedPreviewLoader(0))
 	msg := requirePreviewResultMsg(t, start.Init())

--- a/internal/config/startup.go
+++ b/internal/config/startup.go
@@ -67,6 +67,23 @@ func ResolveStartupRepository(options StartupRepositoryOptions) (StartupReposito
 
 // CurrentGitRepository resolves owner/repo from the current Git repository's origin remote.
 func CurrentGitRepository(workingDir string) (string, error) {
+	root, err := CurrentGitRepositoryRoot(workingDir)
+	if err != nil {
+		return "", err
+	}
+	remote, err := runGit(root, "remote", "get-url", "origin")
+	if err != nil {
+		return "", fmt.Errorf("origin remote is not configured for %q", root)
+	}
+	repo, err := ParseGitHubRemoteURL(remote)
+	if err != nil {
+		return "", err
+	}
+	return repo, nil
+}
+
+// CurrentGitRepositoryRoot resolves the root path for the current Git checkout.
+func CurrentGitRepositoryRoot(workingDir string) (string, error) {
 	if workingDir == "" {
 		var err error
 		workingDir, err = os.Getwd()
@@ -79,15 +96,7 @@ func CurrentGitRepository(workingDir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("%q is not inside a Git repository", workingDir)
 	}
-	remote, err := runGit(root, "remote", "get-url", "origin")
-	if err != nil {
-		return "", fmt.Errorf("origin remote is not configured for %q", root)
-	}
-	repo, err := ParseGitHubRemoteURL(remote)
-	if err != nil {
-		return "", err
-	}
-	return repo, nil
+	return root, nil
 }
 
 // ParseGitHubRemoteURL converts supported GitHub remote URLs into owner/repo.

--- a/internal/config/startup_test.go
+++ b/internal/config/startup_test.go
@@ -158,6 +158,22 @@ func TestCurrentGitRepository_ResolvesOriginRemote(t *testing.T) {
 	if got != "owner/repo" {
 		t.Fatalf("expected owner/repo, got %q", got)
 	}
+
+	root, err := CurrentGitRepositoryRoot(subdir)
+	if err != nil {
+		t.Fatalf("expected current Git repository root to resolve, got %v", err)
+	}
+	wantRoot, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		t.Fatalf("resolve repo dir symlinks: %v", err)
+	}
+	gotRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve root symlinks: %v", err)
+	}
+	if gotRoot != wantRoot {
+		t.Fatalf("expected root %q, got %q", wantRoot, gotRoot)
+	}
 }
 
 func TestCurrentGitRepository_ReportsActionableErrors(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/0maru/gh-zen/internal/app"
 	"github.com/0maru/gh-zen/internal/config"
+	"github.com/0maru/gh-zen/internal/github"
+	"github.com/0maru/gh-zen/internal/localrepo"
+	"github.com/0maru/gh-zen/internal/workbench"
 )
 
 func main() {
@@ -30,6 +35,50 @@ func run() error {
 		return err
 	}
 
-	_, err = tea.NewProgram(app.NewWithConfig(loadResult.Config, startupRepo.Repo), tea.WithAltScreen()).Run()
+	data := loadStartupWorkbenchData(context.Background(), startupRepo)
+
+	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
 	return err
+}
+
+func loadStartupWorkbenchData(ctx context.Context, startupRepo config.StartupRepository) app.WorkbenchData {
+	repo, ok := repoRefFromFullName(startupRepo.Repo)
+	if !ok {
+		return app.WorkbenchData{}
+	}
+
+	data := app.WorkbenchData{Repos: []workbench.RepoRef{repo}}
+	repoPath, ok := currentCheckoutPathForRepo(startupRepo.Repo)
+	if !ok {
+		return data
+	}
+
+	result := (workbench.RuntimeLoader{
+		Repo:     repo,
+		RepoPath: repoPath,
+		Local:    localrepo.Service{},
+		GitHub:   github.CLIService{},
+	}).Load(ctx)
+	data.WorkItems = result.Items
+	return data
+}
+
+func currentCheckoutPathForRepo(repoName string) (string, bool) {
+	currentRepo, err := config.CurrentGitRepository("")
+	if err != nil || currentRepo != repoName {
+		return "", false
+	}
+	repoPath, err := config.CurrentGitRepositoryRoot("")
+	if err != nil {
+		return "", false
+	}
+	return repoPath, true
+}
+
+func repoRefFromFullName(repoName string) (workbench.RepoRef, bool) {
+	owner, name, ok := strings.Cut(repoName, "/")
+	if !ok || owner == "" || name == "" {
+		return workbench.RepoRef{}, false
+	}
+	return workbench.RepoRef{Owner: owner, Name: name}, true
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -35,7 +36,9 @@ func run() error {
 		return err
 	}
 
-	data := loadStartupWorkbenchData(context.Background(), startupRepo)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data := loadStartupWorkbenchData(ctx, startupRepo)
 
 	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
 	return err
@@ -65,7 +68,7 @@ func loadStartupWorkbenchData(ctx context.Context, startupRepo config.StartupRep
 
 func currentCheckoutPathForRepo(repoName string) (string, bool) {
 	currentRepo, err := config.CurrentGitRepository("")
-	if err != nil || currentRepo != repoName {
+	if err != nil || !sameRepoFullName(currentRepo, repoName) {
 		return "", false
 	}
 	repoPath, err := config.CurrentGitRepositoryRoot("")
@@ -81,4 +84,8 @@ func repoRefFromFullName(repoName string) (workbench.RepoRef, bool) {
 		return workbench.RepoRef{}, false
 	}
 	return workbench.RepoRef{Owner: owner, Name: name}, true
+}
+
+func sameRepoFullName(left string, right string) bool {
+	return strings.EqualFold(left, right)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -19,3 +19,12 @@ func TestRepoRefFromFullName(t *testing.T) {
 		t.Fatalf("expected empty repo name to be rejected")
 	}
 }
+
+func TestSameRepoFullName(t *testing.T) {
+	if !sameRepoFullName("Owner/Repo", "owner/repo") {
+		t.Fatalf("expected repo names to compare case-insensitively")
+	}
+	if sameRepoFullName("owner/other", "owner/repo") {
+		t.Fatalf("expected different repo names not to match")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/0maru/gh-zen/internal/workbench"
+)
+
+func TestRepoRefFromFullName(t *testing.T) {
+	got, ok := repoRefFromFullName("0maru/gh-zen")
+	if !ok {
+		t.Fatalf("expected repo ref to parse")
+	}
+	if want := (workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}); got != want {
+		t.Fatalf("expected %+v, got %+v", want, got)
+	}
+
+	if _, ok := repoRefFromFullName(""); ok {
+		t.Fatalf("expected empty repo name to be rejected")
+	}
+}


### PR DESCRIPTION
## Summary
- Add a workbench data constructor so normal startup can receive resolved live repository data.
- Load the runtime workbench pipeline from the current checkout when it matches the resolved startup repository.
- Keep empty live startup distinct from fake fixture data when no repository can be resolved.

## Test Plan
- [x] go test ./...
- [x] make check

Depends on #45.
Closes #40
