### PR TITLE
Reload workbench data on refresh

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -14,7 +14,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	cfgpkg "github.com/0maru/gh-zen/internal/config"
-	ghsvc "github.com/0maru/gh-zen/internal/github"
 	"github.com/0maru/gh-zen/internal/workbench"
 )
 
@@ -81,9 +80,9 @@ type model struct {
 	preview              previewState
 	nextPreviewRequestID int
 	previewLoader        previewLoader
-	githubService        ghsvc.Service
-	githubSummary        ghsvc.RepositorySummary
-	githubError          string
+	workbenchReloader    WorkbenchReloader
+	nextReloadRequestID  int
+	activeReloadRequest  workbenchReloadRequest
 	workbenchFilter      cfgpkg.WorkbenchFilter
 	actionRunner         actionRunner
 	statusMessage        string
@@ -96,6 +95,12 @@ type model struct {
 type WorkbenchData struct {
 	Repos     []workbench.RepoRef
 	WorkItems []workbench.WorkItem
+	Reloader  WorkbenchReloader
+}
+
+// WorkbenchReloader reloads runtime workbench data for one selected repository.
+type WorkbenchReloader interface {
+	Load(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult
 }
 
 type repoViewFilter int
@@ -147,14 +152,15 @@ func newModelWithRuntimeConfig(cfg cfgpkg.Config, startupRepo string, loader pre
 
 func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data WorkbenchData, loader previewLoader) model {
 	m := model{
-		repos:           cloneRepoRefs(data.Repos),
-		workItems:       cloneWorkItems(data.WorkItems),
-		previewLoader:   loader,
-		workbenchFilter: cfg.Workbench.Filter,
-		actionRunner:    systemActionRunner{},
-		styles:          DefaultStyles(),
-		keys:            DefaultKeyMap(),
-		help:            newHelpModel(),
+		repos:             cloneRepoRefs(data.Repos),
+		workItems:         cloneWorkItems(data.WorkItems),
+		previewLoader:     loader,
+		workbenchReloader: data.Reloader,
+		workbenchFilter:   cfg.Workbench.Filter,
+		actionRunner:      systemActionRunner{},
+		styles:            DefaultStyles(),
+		keys:              DefaultKeyMap(),
+		help:              newHelpModel(),
 	}
 	m.applyStartupView(cfg.Startup.View)
 	if startupRepo == "" {
@@ -165,15 +171,14 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 	return m
 }
 
-func newModelWithGitHubService(service ghsvc.Service) model {
-	m := newModelWithPreviewLoader(fakeDelayedPreviewLoader(defaultPreviewDelay))
-	m.githubService = service
-	return m
+type workbenchReloadRequest struct {
+	requestID int
+	repo      workbench.RepoRef
 }
 
-type githubSummaryMsg struct {
-	summary ghsvc.RepositorySummary
-	err     error
+type workbenchReloadMsg struct {
+	request workbenchReloadRequest
+	result  workbench.RuntimeLoadResult
 }
 
 func (m model) Init() tea.Cmd {
@@ -203,9 +208,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case actionResultMsg:
 		m.handleActionResult(msg)
 		return m, nil
-	case githubSummaryMsg:
-		m.handleGitHubSummary(msg)
-		return m, nil
+	case workbenchReloadMsg:
+		return m, m.handleWorkbenchReload(msg)
 	case tea.KeyMsg:
 		if action, ok := m.matchedAction(msg); ok {
 			return m, m.handleAction(action)
@@ -321,12 +325,12 @@ func (m *model) handleAction(action actionID) tea.Cmd {
 		m.jumpFocusedSelection(true)
 		return m.startPreviewLoadIfFocusedItemChanged()
 	case actionRefresh:
-		cmd := m.refreshGitHubSummary()
+		cmd := m.refreshWorkbenchData()
 		if cmd == nil {
 			m.statusMessage = "Refresh unavailable"
 			return nil
 		}
-		m.statusMessage = "Refreshing GitHub data..."
+		m.statusMessage = "Reloading workbench data..."
 		return cmd
 	case actionOpenPullRequest:
 		return m.openPullRequest()
@@ -442,30 +446,46 @@ func bestWorkItemURL(item workbench.WorkItem) (string, string, bool) {
 	return "", "", false
 }
 
-func (m model) refreshGitHubSummary() tea.Cmd {
-	if m.githubService == nil {
+func (m *model) refreshWorkbenchData() tea.Cmd {
+	if m.workbenchReloader == nil {
 		return nil
 	}
 	repo, ok := m.selectedRepoRef()
 	if !ok {
 		return nil
 	}
-	repoName := repo.FullName()
+	m.nextReloadRequestID++
+	request := workbenchReloadRequest{
+		requestID: m.nextReloadRequestID,
+		repo:      repo,
+	}
+	m.activeReloadRequest = request
 	return func() tea.Msg {
-		summary, err := m.githubService.RepositorySummary(context.Background(), repoName)
-		return githubSummaryMsg{summary: summary, err: err}
+		return workbenchReloadMsg{
+			request: request,
+			result:  m.workbenchReloader.Load(context.Background(), repo),
+		}
 	}
 }
 
-func (m *model) handleGitHubSummary(msg githubSummaryMsg) {
-	if msg.err != nil {
-		m.githubError = msg.err.Error()
-		m.statusMessage = "Refresh failed: " + msg.err.Error()
-		return
+func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
+	if msg.request != m.activeReloadRequest {
+		return nil
 	}
-	m.githubError = ""
-	m.githubSummary = msg.summary
-	m.statusMessage = "Refreshed GitHub data"
+	repo, ok := m.selectedRepoRef()
+	if !ok || repo != msg.request.repo {
+		m.statusMessage = ""
+		return nil
+	}
+
+	selectedWorkItemID := ""
+	if item, ok := m.selectedWorkItem(); ok {
+		selectedWorkItemID = item.ID
+	}
+	m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
+	m.restoreSelectedWorkItem(selectedWorkItemID)
+	m.statusMessage = "Reloaded workbench data"
+	return m.startPreviewLoadForCurrentItem()
 }
 
 func (m *model) focusNextPane() {
@@ -666,6 +686,42 @@ func filterWorkItems(items []workbench.WorkItem, keep func(workbench.WorkItem) b
 		}
 	}
 	return out
+}
+
+func replaceRepoWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, replacement []workbench.WorkItem) []workbench.WorkItem {
+	out := make([]workbench.WorkItem, 0, len(items)+len(replacement))
+	replaced := false
+	for _, item := range items {
+		if item.Repo == repo {
+			if !replaced {
+				out = append(out, replacement...)
+				replaced = true
+			}
+			continue
+		}
+		out = append(out, item)
+	}
+	if !replaced {
+		out = append(out, replacement...)
+	}
+	return out
+}
+
+func (m *model) restoreSelectedWorkItem(workItemID string) {
+	items := m.visibleWorkItems()
+	if len(items) == 0 {
+		m.selectedItem = 0
+		return
+	}
+	if workItemID != "" {
+		for i, item := range items {
+			if item.ID == workItemID {
+				m.selectedItem = i
+				return
+			}
+		}
+	}
+	m.selectedItem = clamp(m.selectedItem, 0, len(items)-1)
 }
 
 func cloneRepoRefs(repos []workbench.RepoRef) []workbench.RepoRef {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -478,12 +478,14 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		return nil
 	}
 
+	selectedWorkItemRepo := workbench.RepoRef{}
 	selectedWorkItemID := ""
 	if item, ok := m.selectedWorkItem(); ok {
+		selectedWorkItemRepo = item.Repo
 		selectedWorkItemID = item.ID
 	}
 	m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
-	m.restoreSelectedWorkItem(selectedWorkItemID)
+	m.restoreSelectedWorkItem(selectedWorkItemRepo, selectedWorkItemID)
 	m.statusMessage = "Reloaded workbench data"
 	return m.startPreviewLoadForCurrentItem()
 }
@@ -707,7 +709,7 @@ func replaceRepoWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, re
 	return out
 }
 
-func (m *model) restoreSelectedWorkItem(workItemID string) {
+func (m *model) restoreSelectedWorkItem(repo workbench.RepoRef, workItemID string) {
 	items := m.visibleWorkItems()
 	if len(items) == 0 {
 		m.selectedItem = 0
@@ -715,7 +717,7 @@ func (m *model) restoreSelectedWorkItem(workItemID string) {
 	}
 	if workItemID != "" {
 		for i, item := range items {
-			if item.ID == workItemID {
+			if item.Repo == repo && item.ID == workItemID {
 				m.selectedItem = i
 				return
 			}

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -227,6 +227,54 @@ func TestUpdate_RefreshPreservesCurrentSelectionAfterMove(t *testing.T) {
 	}
 }
 
+func TestUpdate_RefreshPreservesSelectedWorkItemRepo(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	repoAOriginal := workbench.WorkItem{
+		ID:       "branch:main",
+		Repo:     repoA,
+		Branch:   &workbench.BranchRef{Name: "main"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/gh-zen"},
+		Local:    &workbench.LocalStatus{State: workbench.LocalClean},
+	}
+	repoAReloaded := repoAOriginal
+	repoAReloaded.Local = &workbench.LocalStatus{State: workbench.LocalDirty, Summary: "1 status entry"}
+	repoBItem := workbench.WorkItem{
+		ID:       "branch:main",
+		Repo:     repoB,
+		Branch:   &workbench.BranchRef{Name: "main"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/dotfiles"},
+		Local:    &workbench.LocalStatus{State: workbench.LocalClean},
+	}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repoA.FullName(): {
+				Repo:  repoA,
+				Items: []workbench.WorkItem{repoAReloaded},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{repoAOriginal, repoBItem},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.setRepoPaneIndex(len(start.repos))
+	start.selectedItem = 1
+	start.focusedWorkItemID = repoBItem.ID
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	mm := got.(model)
+
+	if mm.selectedItem != 1 {
+		t.Fatalf("expected selected item to remain on repo B at index 1, got %d", mm.selectedItem)
+	}
+	if item, ok := mm.selectedWorkItem(); !ok || item.Repo != repoB || item.ID != repoBItem.ID {
+		t.Fatalf("expected selected work item %+v, got %+v ok=%v", repoBItem, item, ok)
+	}
+}
+
 func TestUpdate_StaleRefreshResultIsDiscarded(t *testing.T) {
 	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	cfgpkg "github.com/0maru/gh-zen/internal/config"
-	ghsvc "github.com/0maru/gh-zen/internal/github"
 	"github.com/0maru/gh-zen/internal/workbench"
 )
 
@@ -79,15 +78,28 @@ func (r *fakeActionRunner) Copy(_ context.Context, text string) error {
 	return r.err
 }
 
-func requireGitHubSummaryMsg(t *testing.T, cmd tea.Cmd) githubSummaryMsg {
+type fakeWorkbenchReloader struct {
+	results map[string]workbench.RuntimeLoadResult
+	calls   []workbench.RepoRef
+}
+
+func (r *fakeWorkbenchReloader) Load(_ context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
+	r.calls = append(r.calls, repo)
+	if result, ok := r.results[repo.FullName()]; ok {
+		return result
+	}
+	return workbench.RuntimeLoadResult{Repo: repo}
+}
+
+func requireWorkbenchReloadMsg(t *testing.T, cmd tea.Cmd) workbenchReloadMsg {
 	t.Helper()
 	if cmd == nil {
-		t.Fatalf("expected GitHub summary command, got nil")
+		t.Fatalf("expected workbench reload command, got nil")
 	}
 	msg := cmd()
-	result, ok := msg.(githubSummaryMsg)
+	result, ok := msg.(workbenchReloadMsg)
 	if !ok {
-		t.Fatalf("expected githubSummaryMsg, got %T", msg)
+		t.Fatalf("expected workbenchReloadMsg, got %T", msg)
 	}
 	return result
 }
@@ -98,42 +110,265 @@ func TestInit_ReturnsNilCmd(t *testing.T) {
 	}
 }
 
-func TestUpdate_RefreshLoadsGitHubSummary(t *testing.T) {
-	service := ghsvc.FakeService{
-		Summaries: map[string]ghsvc.RepositorySummary{
-			"0maru/gh-zen": {
-				Repo: "0maru/gh-zen",
-				PullRequests: []workbench.PullRequestRef{
-					{Number: 12, Title: "Add PR links", State: "open"},
-				},
-				Issues: []workbench.IssueRef{
-					{Number: 10, Title: "Config discovery", State: "open", Certain: true},
-				},
-				Checks: workbench.CheckSummary{State: workbench.CheckPassing, Passing: 2},
+func TestUpdate_RefreshReloadsWorkbenchData(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	original := workbench.WorkItem{
+		ID:     "branch:feature",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "feature"},
+		Local:  &workbench.LocalStatus{State: workbench.LocalClean},
+	}
+	reloaded := original
+	reloaded.Local = &workbench.LocalStatus{State: workbench.LocalDirty, Summary: "1 status entry"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{reloaded},
 			},
 		},
 	}
-	start := newModelWithGitHubService(service)
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{original},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
 
 	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	if cmd == nil {
 		t.Fatalf("expected refresh command")
 	}
+	if status := got.(model).statusMessage; status != "Reloading workbench data..." {
+		t.Fatalf("expected reload status, got %q", status)
+	}
 
-	msg := requireGitHubSummaryMsg(t, cmd)
+	msg := requireWorkbenchReloadMsg(t, cmd)
 	got, cmd = got.(model).Update(msg)
-	if cmd != nil {
-		t.Fatalf("expected nil command after GitHub summary, got %T", cmd)
+	if cmd == nil {
+		t.Fatalf("expected preview reload command")
 	}
 	mm := got.(model)
-	if mm.githubSummary.Repo != "0maru/gh-zen" {
-		t.Fatalf("expected GitHub summary repo, got %+v", mm.githubSummary)
+	if len(reloader.calls) != 1 || reloader.calls[0] != repo {
+		t.Fatalf("expected selected repo to reload, got %+v", reloader.calls)
 	}
-	if len(mm.githubSummary.PullRequests) != 1 || len(mm.githubSummary.Issues) != 1 {
-		t.Fatalf("expected PR and issue summaries, got %+v", mm.githubSummary)
+	items := mm.visibleWorkItems()
+	if len(items) != 1 || items[0].Local == nil || items[0].Local.State != workbench.LocalDirty {
+		t.Fatalf("expected reloaded work item, got %+v", items)
 	}
-	if mm.githubSummary.Checks.State != workbench.CheckPassing {
-		t.Fatalf("expected check summary, got %+v", mm.githubSummary.Checks)
+	if mm.selectedItem != 0 || mm.focusedWorkItemID != original.ID {
+		t.Fatalf("expected selection to remain on %q, got item=%d focused=%q", original.ID, mm.selectedItem, mm.focusedWorkItemID)
+	}
+	if status := mm.statusMessage; status != "Reloaded workbench data" {
+		t.Fatalf("expected reloaded status, got %q", status)
+	}
+}
+
+func TestUpdate_RefreshPreservesSelectedWorkItemID(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	first := workbench.WorkItem{ID: "branch:first", Repo: repo, Branch: &workbench.BranchRef{Name: "first"}}
+	second := workbench.WorkItem{ID: "branch:second", Repo: repo, Branch: &workbench.BranchRef{Name: "second"}}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{second, first},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{first, second},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.selectedItem = 1
+	start.focusedWorkItemID = second.ID
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	mm := got.(model)
+
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected selected item to follow stable ID to index 0, got %d", mm.selectedItem)
+	}
+	if item, ok := mm.selectedWorkItem(); !ok || item.ID != second.ID {
+		t.Fatalf("expected selected work item %q, got %+v ok=%v", second.ID, item, ok)
+	}
+}
+
+func TestUpdate_RefreshPreservesCurrentSelectionAfterMove(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	first := workbench.WorkItem{ID: "branch:first", Repo: repo, Branch: &workbench.BranchRef{Name: "first"}}
+	second := workbench.WorkItem{ID: "branch:second", Repo: repo, Branch: &workbench.BranchRef{Name: "second"}}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{first, second},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{first, second},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+	got, _ = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	got, _ = got.(model).Update(msg)
+	mm := got.(model)
+
+	if mm.selectedItem != 1 {
+		t.Fatalf("expected reload to keep moved selection at index 1, got %d", mm.selectedItem)
+	}
+	if item, ok := mm.selectedWorkItem(); !ok || item.ID != second.ID {
+		t.Fatalf("expected selected work item %q, got %+v ok=%v", second.ID, item, ok)
+	}
+}
+
+func TestUpdate_StaleRefreshResultIsDiscarded(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repoA.FullName(): {
+				Repo: repoA,
+				Items: []workbench.WorkItem{{
+					ID:     "branch:updated",
+					Repo:   repoA,
+					Branch: &workbench.BranchRef{Name: "updated"},
+				}},
+			},
+		},
+	}
+	original := workbench.WorkItem{ID: "branch:original", Repo: repoA, Branch: &workbench.BranchRef{Name: "original"}}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{original},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+	mm := got.(model)
+	mm.setRepoPaneIndex(1)
+
+	got, cmd = mm.Update(msg)
+	if cmd != nil {
+		t.Fatalf("expected stale reload to skip preview command, got %T", cmd)
+	}
+	mm = got.(model)
+	if len(mm.workItems) != 1 || mm.workItems[0].ID != original.ID {
+		t.Fatalf("expected stale reload not to replace work items, got %+v", mm.workItems)
+	}
+	if mm.statusMessage != "" {
+		t.Fatalf("expected stale reload to clear loading status, got %q", mm.statusMessage)
+	}
+}
+
+func TestUpdate_RefreshAppliesAfterViewSelectionChange(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	original := workbench.WorkItem{
+		ID:       "branch:feature",
+		Repo:     repo,
+		Branch:   &workbench.BranchRef{Name: "feature"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/feature"},
+		Local:    &workbench.LocalStatus{State: workbench.LocalClean},
+	}
+	reloaded := original
+	reloaded.Local = &workbench.LocalStatus{State: workbench.LocalDirty, Summary: "1 status entry"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{reloaded},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{original},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+	mm := got.(model)
+	mm.setRepoPaneIndex(len(mm.repos))
+
+	got, cmd = mm.Update(msg)
+	if cmd == nil {
+		t.Fatalf("expected view reload to start preview command")
+	}
+	mm = got.(model)
+	items := mm.visibleWorkItems()
+	if len(items) != 1 || items[0].Local == nil || items[0].Local.State != workbench.LocalDirty {
+		t.Fatalf("expected reload result to apply after view selection, got %+v", items)
+	}
+	if status := mm.statusMessage; status != "Reloaded workbench data" {
+		t.Fatalf("expected reloaded status, got %q", status)
+	}
+}
+
+func TestUpdate_OlderRefreshResultDoesNotClearNewerStatus(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	original := workbench.WorkItem{ID: "branch:original", Repo: repo, Branch: &workbench.BranchRef{Name: "original"}}
+	updated := workbench.WorkItem{ID: "branch:updated", Repo: repo, Branch: &workbench.BranchRef{Name: "updated"}}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{updated},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{original},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, firstCmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	firstMsg := requireWorkbenchReloadMsg(t, firstCmd)
+	got, secondCmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if secondCmd == nil {
+		t.Fatalf("expected second refresh command")
+	}
+	got, cmd := got.(model).Update(firstMsg)
+	if cmd != nil {
+		t.Fatalf("expected older reload result to skip preview command, got %T", cmd)
+	}
+	mm := got.(model)
+	if status := mm.statusMessage; status != "Reloading workbench data..." {
+		t.Fatalf("expected newer reload status to remain, got %q", status)
+	}
+	if len(mm.workItems) != 1 || mm.workItems[0].ID != original.ID {
+		t.Fatalf("expected older reload result not to replace work items, got %+v", mm.workItems)
+	}
+}
+
+func TestReplaceRepoWorkItems_PreservesRepositoryOrder(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	repoC := workbench.RepoRef{Owner: "0maru", Name: "notes"}
+	got := replaceRepoWorkItems([]workbench.WorkItem{
+		{ID: "a1", Repo: repoA},
+		{ID: "a2", Repo: repoA},
+		{ID: "b1", Repo: repoB},
+		{ID: "c1", Repo: repoC},
+	}, repoB, []workbench.WorkItem{
+		{ID: "b2", Repo: repoB},
+		{ID: "b3", Repo: repoB},
+	})
+
+	gotIDs := []string{}
+	for _, item := range got {
+		gotIDs = append(gotIDs, item.ID)
+	}
+	wantIDs := []string{"a1", "a2", "b2", "b3", "c1"}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Fatalf("expected replacement to preserve repo order %+v, got %+v", wantIDs, gotIDs)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -38,33 +38,48 @@ func run() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	data := loadStartupWorkbenchData(ctx, loadResult.Config, startupRepo)
+	reloader := runtimeWorkbenchReloader{config: loadResult.Config}
+	data := loadStartupWorkbenchData(ctx, startupRepo, reloader)
 
 	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
 	return err
 }
 
-func loadStartupWorkbenchData(ctx context.Context, cfg config.Config, startupRepo config.StartupRepository) app.WorkbenchData {
-	repo, ok := repoRefFromFullName(startupRepo.Repo)
-	if !ok {
-		return app.WorkbenchData{}
-	}
+type runtimeWorkbenchReloader struct {
+	config config.Config
+}
 
-	data := app.WorkbenchData{Repos: []workbench.RepoRef{repo}}
+func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
 	resolvedPath := config.ResolveRepositoryPath(config.RepositoryPathOptions{
-		Repo:   startupRepo.Repo,
-		Config: cfg,
+		Repo:   repo.FullName(),
+		Config: r.config,
 	})
 	if resolvedPath.Path == "" {
-		return data
+		return workbench.RuntimeLoadResult{Repo: repo}
 	}
-
-	result := (workbench.RuntimeLoader{
+	return (workbench.RuntimeLoader{
 		Repo:     repo,
 		RepoPath: resolvedPath.Path,
 		Local:    localrepo.Service{},
 		GitHub:   github.CLIService{},
 	}).Load(ctx)
+}
+
+func loadStartupWorkbenchData(ctx context.Context, startupRepo config.StartupRepository, reloader app.WorkbenchReloader) app.WorkbenchData {
+	repo, ok := repoRefFromFullName(startupRepo.Repo)
+	if !ok {
+		return app.WorkbenchData{}
+	}
+
+	data := app.WorkbenchData{
+		Repos:    []workbench.RepoRef{repo},
+		Reloader: reloader,
+	}
+	if reloader == nil {
+		return data
+	}
+
+	result := reloader.Load(ctx, repo)
 	data.WorkItems = result.Items
 	return data
 }


### PR DESCRIPTION
## Summary
- Replace the GitHub-summary refresh path with a full workbench reload command.
- Preserve selected work items by stable ID when refreshed data still contains them.
- Discard stale reload responses after repository selection changes.

## Test Plan
- [x] go test ./...
- [x] make check

Depends on #47.
Closes #42
