### PR TITLE
Connect live workbench data to startup

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -92,6 +92,12 @@ type model struct {
 	help                 help.Model
 }
 
+// WorkbenchData contains resolved repository workbench state for app startup.
+type WorkbenchData struct {
+	Repos     []workbench.RepoRef
+	WorkItems []workbench.WorkItem
+}
+
 type repoViewFilter int
 
 const (
@@ -119,6 +125,10 @@ func NewWithConfig(cfg cfgpkg.Config, startupRepo string) tea.Model {
 	return newModelWithRuntimeConfig(cfg, startupRepo, fakeDelayedPreviewLoader(defaultPreviewDelay))
 }
 
+func NewWithWorkbenchData(cfg cfgpkg.Config, startupRepo string, data WorkbenchData) tea.Model {
+	return newModelWithRuntimeData(cfg, startupRepo, data, fakeDelayedPreviewLoader(defaultPreviewDelay))
+}
+
 func newModel() model {
 	return newModelWithPreviewLoader(fakeDelayedPreviewLoader(defaultPreviewDelay))
 }
@@ -128,9 +138,16 @@ func newModelWithPreviewLoader(loader previewLoader) model {
 }
 
 func newModelWithRuntimeConfig(cfg cfgpkg.Config, startupRepo string, loader previewLoader) model {
+	return newModelWithRuntimeData(cfg, startupRepo, WorkbenchData{
+		Repos:     workbench.FakeRepos(),
+		WorkItems: workbench.FakeWorkItems(),
+	}, loader)
+}
+
+func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data WorkbenchData, loader previewLoader) model {
 	m := model{
-		repos:           workbench.FakeRepos(),
-		workItems:       workbench.FakeWorkItems(),
+		repos:           cloneRepoRefs(data.Repos),
+		workItems:       cloneWorkItems(data.WorkItems),
 		previewLoader:   loader,
 		workbenchFilter: cfg.Workbench.Filter,
 		actionRunner:    systemActionRunner{},
@@ -648,6 +665,14 @@ func filterWorkItems(items []workbench.WorkItem, keep func(workbench.WorkItem) b
 		}
 	}
 	return out
+}
+
+func cloneRepoRefs(repos []workbench.RepoRef) []workbench.RepoRef {
+	return append([]workbench.RepoRef(nil), repos...)
+}
+
+func cloneWorkItems(items []workbench.WorkItem) []workbench.WorkItem {
+	return append([]workbench.WorkItem(nil), items...)
 }
 
 func (v repoView) matches(item workbench.WorkItem) bool {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -125,6 +125,7 @@ func NewWithConfig(cfg cfgpkg.Config, startupRepo string) tea.Model {
 	return newModelWithRuntimeConfig(cfg, startupRepo, fakeDelayedPreviewLoader(defaultPreviewDelay))
 }
 
+// NewWithWorkbenchData builds the app model from already resolved workbench data.
 func NewWithWorkbenchData(cfg cfgpkg.Config, startupRepo string, data WorkbenchData) tea.Model {
 	return newModelWithRuntimeData(cfg, startupRepo, data, fakeDelayedPreviewLoader(defaultPreviewDelay))
 }

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -187,6 +187,46 @@ func TestNew_LoadsFakeWorkbenchData(t *testing.T) {
 	}
 }
 
+func TestNewWithWorkbenchData_UsesProvidedData(t *testing.T) {
+	cfg := cfgpkg.Defaults()
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	item := workbench.WorkItem{
+		ID:     "branch:live",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "live"},
+		Local:  &workbench.LocalStatus{State: workbench.LocalClean},
+	}
+
+	got := NewWithWorkbenchData(cfg, repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{item},
+	}).(model)
+
+	if len(got.repos) != 1 || got.repos[0] != repo {
+		t.Fatalf("expected provided repo only, got %+v", got.repos)
+	}
+	if len(got.workItems) != 1 || got.workItems[0].ID != item.ID {
+		t.Fatalf("expected provided work item only, got %+v", got.workItems)
+	}
+	if got.focusedWorkItemID != item.ID {
+		t.Fatalf("expected live item to be focused, got %q", got.focusedWorkItemID)
+	}
+}
+
+func TestNewWithWorkbenchData_EmptyDataDoesNotFallbackToFakeItems(t *testing.T) {
+	got := NewWithWorkbenchData(cfgpkg.Defaults(), "", WorkbenchData{}).(model)
+
+	if len(got.repos) != 0 {
+		t.Fatalf("expected no repos, got %+v", got.repos)
+	}
+	if len(got.workItems) != 0 {
+		t.Fatalf("expected no work items, got %+v", got.workItems)
+	}
+	if got.preview.status != previewEmpty {
+		t.Fatalf("expected empty preview, got %v", got.preview.status)
+	}
+}
+
 func TestInit_LoadsInitialPreview(t *testing.T) {
 	start := newModelWithPreviewLoader(fakeDelayedPreviewLoader(0))
 	msg := requirePreviewResultMsg(t, start.Init())

--- a/internal/config/repository_path.go
+++ b/internal/config/repository_path.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RepositoryPathOptions configures local checkout path resolution.
+type RepositoryPathOptions struct {
+	Repo       string
+	Config     Config
+	WorkingDir string
+}
+
+// RepositoryPathResult contains a resolved local path and non-fatal diagnostics.
+type RepositoryPathResult struct {
+	Repo        string
+	Path        string
+	Diagnostics []Diagnostic
+}
+
+// ResolveRepositoryPath maps an owner/repo name to a local checkout path.
+func ResolveRepositoryPath(options RepositoryPathOptions) RepositoryPathResult {
+	result := RepositoryPathResult{Repo: options.Repo}
+	if options.Repo == "" {
+		return result
+	}
+
+	currentRepo, currentErr := CurrentGitRepository(options.WorkingDir)
+	if currentErr == nil {
+		if sameRepoName(currentRepo, options.Repo) {
+			if root, err := CurrentGitRepositoryRoot(options.WorkingDir); err == nil {
+				result.Path = root
+				return result
+			}
+		}
+	} else {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Path:    "current_git",
+			Message: currentErr.Error(),
+		})
+	}
+
+	for i, root := range options.Config.Repos.Roots {
+		rootPath := expandHomePath(root)
+		matchedPath, diagnostics := findRepositoryInRoot(rootPath, options.Repo, i)
+		result.Diagnostics = append(result.Diagnostics, diagnostics...)
+		if matchedPath != "" {
+			result.Path = matchedPath
+			return result
+		}
+	}
+
+	result.Diagnostics = append(result.Diagnostics, Diagnostic{
+		Path:    "repos",
+		Message: fmt.Sprintf("no local checkout found for %s", options.Repo),
+	})
+	return result
+}
+
+func findRepositoryInRoot(root string, repoName string, rootIndex int) (string, []Diagnostic) {
+	diagnostics := []Diagnostic{}
+	info, err := os.Stat(root)
+	if err != nil {
+		return "", []Diagnostic{repositoryRootDiagnostic(rootIndex, fmt.Sprintf("%q is not accessible: %v", root, err))}
+	}
+	if !info.IsDir() {
+		return "", []Diagnostic{repositoryRootDiagnostic(rootIndex, fmt.Sprintf("%q is not a directory", root))}
+	}
+
+	var matchedPath string
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			diagnostics = append(diagnostics, repositoryRootDiagnostic(rootIndex, fmt.Sprintf("read %q: %v", path, walkErr)))
+			if entry != nil && entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		if entry.Name() == ".git" {
+			return filepath.SkipDir
+		}
+		if !hasGitMetadata(path) {
+			return nil
+		}
+
+		repo, err := CurrentGitRepository(path)
+		if err != nil {
+			diagnostics = append(diagnostics, Diagnostic{
+				Path:    path,
+				Message: err.Error(),
+			})
+			return nil
+		}
+		if sameRepoName(repo, repoName) {
+			matchedRoot, err := CurrentGitRepositoryRoot(path)
+			if err != nil {
+				diagnostics = append(diagnostics, Diagnostic{
+					Path:    path,
+					Message: err.Error(),
+				})
+				return filepath.SkipDir
+			}
+			matchedPath = matchedRoot
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		diagnostics = append(diagnostics, repositoryRootDiagnostic(rootIndex, fmt.Sprintf("scan %q: %v", root, err)))
+	}
+	return matchedPath, diagnostics
+}
+
+func hasGitMetadata(path string) bool {
+	_, err := os.Stat(filepath.Join(path, ".git"))
+	return err == nil
+}
+
+func repositoryRootDiagnostic(index int, message string) Diagnostic {
+	return Diagnostic{
+		Path:    fmt.Sprintf("repos.roots[%d]", index),
+		Message: message,
+	}
+}
+
+func sameRepoName(left string, right string) bool {
+	return strings.EqualFold(left, right)
+}
+
+func expandHomePath(path string) string {
+	if path == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+	}
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, filepath.FromSlash(strings.TrimPrefix(path, "~/")))
+		}
+	}
+	return path
+}

--- a/internal/config/repository_path_test.go
+++ b/internal/config/repository_path_test.go
@@ -1,0 +1,183 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveRepositoryPath_PrefersMatchingCurrentCheckout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	current := initTempGitRepo(t)
+	runGitCommand(t, current, "remote", "add", "origin", "git@github.com:owner/repo.git")
+	nested := filepath.Join(current, "nested")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+
+	root := t.TempDir()
+	other := filepath.Join(root, "owner", "repo")
+	initTempGitRepoAt(t, other)
+	runGitCommand(t, other, "remote", "add", "origin", "git@github.com:owner/repo.git")
+
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{root}
+	got := ResolveRepositoryPath(RepositoryPathOptions{
+		Repo:       "owner/repo",
+		Config:     cfg,
+		WorkingDir: nested,
+	})
+
+	if !sameResolvedPath(t, got.Path, current) {
+		t.Fatalf("expected current checkout %q to win, got %+v", current, got)
+	}
+}
+
+func TestResolveRepositoryPath_FindsConfiguredRootCheckout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	checkout := filepath.Join(root, "owner", "repo")
+	initTempGitRepoAt(t, checkout)
+	runGitCommand(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{root}
+	got := ResolveRepositoryPath(RepositoryPathOptions{
+		Repo:       "owner/repo",
+		Config:     cfg,
+		WorkingDir: t.TempDir(),
+	})
+
+	if !sameResolvedPath(t, got.Path, checkout) {
+		t.Fatalf("expected checkout %q, got %+v", checkout, got)
+	}
+	if len(got.Diagnostics) == 0 || !strings.Contains(got.Diagnostics[0].Message, "not inside a Git repository") {
+		t.Fatalf("expected current Git diagnostic before root match, got %+v", got.Diagnostics)
+	}
+}
+
+func TestResolveRepositoryPath_DiagnosticsForMissingAndUnsupportedPaths(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	unsupported := filepath.Join(root, "unsupported")
+	initTempGitRepoAt(t, unsupported)
+	runGitCommand(t, unsupported, "remote", "add", "origin", "https://example.com/owner/repo.git")
+
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{filepath.Join(root, "missing"), root}
+	got := ResolveRepositoryPath(RepositoryPathOptions{
+		Repo:       "owner/repo",
+		Config:     cfg,
+		WorkingDir: t.TempDir(),
+	})
+
+	if got.Path != "" {
+		t.Fatalf("expected no checkout to resolve, got %+v", got)
+	}
+	if !hasDiagnosticContaining(got.Diagnostics, "repos.roots[0]", "not accessible") {
+		t.Fatalf("expected missing root diagnostic, got %+v", got.Diagnostics)
+	}
+	if !hasDiagnosticContaining(got.Diagnostics, unsupported, "unsupported GitHub remote host") {
+		t.Fatalf("expected unsupported remote diagnostic, got %+v", got.Diagnostics)
+	}
+	if !hasDiagnosticContaining(got.Diagnostics, "repos", "no local checkout found") {
+		t.Fatalf("expected no checkout diagnostic, got %+v", got.Diagnostics)
+	}
+}
+
+func TestResolveRepositoryPath_FindsNestedCheckoutInsideUnmatchedGitRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	parent := filepath.Join(root, "parent")
+	initTempGitRepoAt(t, parent)
+	runGitCommand(t, parent, "remote", "add", "origin", "https://github.com/owner/parent.git")
+
+	nested := filepath.Join(parent, "nested", "repo")
+	initTempGitRepoAt(t, nested)
+	runGitCommand(t, nested, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{root}
+	got := ResolveRepositoryPath(RepositoryPathOptions{
+		Repo:       "owner/repo",
+		Config:     cfg,
+		WorkingDir: t.TempDir(),
+	})
+
+	if !sameResolvedPath(t, got.Path, nested) {
+		t.Fatalf("expected nested checkout %q, got %+v", nested, got)
+	}
+}
+
+func TestResolveRepositoryPath_FindsNestedCheckoutAfterParentRemoteParseError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	parent := filepath.Join(root, "parent")
+	initTempGitRepoAt(t, parent)
+	runGitCommand(t, parent, "remote", "add", "origin", "https://example.com/owner/parent.git")
+
+	nested := filepath.Join(parent, "nested", "repo")
+	initTempGitRepoAt(t, nested)
+	runGitCommand(t, nested, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{root}
+	got := ResolveRepositoryPath(RepositoryPathOptions{
+		Repo:       "owner/repo",
+		Config:     cfg,
+		WorkingDir: t.TempDir(),
+	})
+
+	if !sameResolvedPath(t, got.Path, nested) {
+		t.Fatalf("expected nested checkout %q, got %+v", nested, got)
+	}
+	if !hasDiagnosticContaining(got.Diagnostics, parent, "unsupported GitHub remote host") {
+		t.Fatalf("expected parent remote parse diagnostic, got %+v", got.Diagnostics)
+	}
+}
+
+func hasDiagnosticContaining(diagnostics []Diagnostic, path string, message string) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Path == path && strings.Contains(diagnostic.Message, message) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameResolvedPath(t *testing.T, got string, want string) bool {
+	t.Helper()
+	gotResolved, err := filepath.EvalSymlinks(got)
+	if err != nil {
+		t.Fatalf("resolve got path %q: %v", got, err)
+	}
+	wantResolved, err := filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatalf("resolve want path %q: %v", want, err)
+	}
+	return gotResolved == wantResolved
+}
+
+func initTempGitRepoAt(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	runGitCommand(t, dir, "init", "-b", "main")
+}

--- a/internal/config/startup.go
+++ b/internal/config/startup.go
@@ -67,6 +67,23 @@ func ResolveStartupRepository(options StartupRepositoryOptions) (StartupReposito
 
 // CurrentGitRepository resolves owner/repo from the current Git repository's origin remote.
 func CurrentGitRepository(workingDir string) (string, error) {
+	root, err := CurrentGitRepositoryRoot(workingDir)
+	if err != nil {
+		return "", err
+	}
+	remote, err := runGit(root, "remote", "get-url", "origin")
+	if err != nil {
+		return "", fmt.Errorf("origin remote is not configured for %q", root)
+	}
+	repo, err := ParseGitHubRemoteURL(remote)
+	if err != nil {
+		return "", err
+	}
+	return repo, nil
+}
+
+// CurrentGitRepositoryRoot resolves the root path for the current Git checkout.
+func CurrentGitRepositoryRoot(workingDir string) (string, error) {
 	if workingDir == "" {
 		var err error
 		workingDir, err = os.Getwd()
@@ -79,15 +96,7 @@ func CurrentGitRepository(workingDir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("%q is not inside a Git repository", workingDir)
 	}
-	remote, err := runGit(root, "remote", "get-url", "origin")
-	if err != nil {
-		return "", fmt.Errorf("origin remote is not configured for %q", root)
-	}
-	repo, err := ParseGitHubRemoteURL(remote)
-	if err != nil {
-		return "", err
-	}
-	return repo, nil
+	return root, nil
 }
 
 // ParseGitHubRemoteURL converts supported GitHub remote URLs into owner/repo.

--- a/internal/config/startup_test.go
+++ b/internal/config/startup_test.go
@@ -158,6 +158,22 @@ func TestCurrentGitRepository_ResolvesOriginRemote(t *testing.T) {
 	if got != "owner/repo" {
 		t.Fatalf("expected owner/repo, got %q", got)
 	}
+
+	root, err := CurrentGitRepositoryRoot(subdir)
+	if err != nil {
+		t.Fatalf("expected current Git repository root to resolve, got %v", err)
+	}
+	wantRoot, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		t.Fatalf("resolve repo dir symlinks: %v", err)
+	}
+	gotRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve root symlinks: %v", err)
+	}
+	if gotRoot != wantRoot {
+		t.Fatalf("expected root %q, got %q", wantRoot, gotRoot)
+	}
 }
 
 func TestCurrentGitRepository_ReportsActionableErrors(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -38,44 +38,35 @@ func run() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	data := loadStartupWorkbenchData(ctx, startupRepo)
+	data := loadStartupWorkbenchData(ctx, loadResult.Config, startupRepo)
 
 	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
 	return err
 }
 
-func loadStartupWorkbenchData(ctx context.Context, startupRepo config.StartupRepository) app.WorkbenchData {
+func loadStartupWorkbenchData(ctx context.Context, cfg config.Config, startupRepo config.StartupRepository) app.WorkbenchData {
 	repo, ok := repoRefFromFullName(startupRepo.Repo)
 	if !ok {
 		return app.WorkbenchData{}
 	}
 
 	data := app.WorkbenchData{Repos: []workbench.RepoRef{repo}}
-	repoPath, ok := currentCheckoutPathForRepo(startupRepo.Repo)
-	if !ok {
+	resolvedPath := config.ResolveRepositoryPath(config.RepositoryPathOptions{
+		Repo:   startupRepo.Repo,
+		Config: cfg,
+	})
+	if resolvedPath.Path == "" {
 		return data
 	}
 
 	result := (workbench.RuntimeLoader{
 		Repo:     repo,
-		RepoPath: repoPath,
+		RepoPath: resolvedPath.Path,
 		Local:    localrepo.Service{},
 		GitHub:   github.CLIService{},
 	}).Load(ctx)
 	data.WorkItems = result.Items
 	return data
-}
-
-func currentCheckoutPathForRepo(repoName string) (string, bool) {
-	currentRepo, err := config.CurrentGitRepository("")
-	if err != nil || !sameRepoFullName(currentRepo, repoName) {
-		return "", false
-	}
-	repoPath, err := config.CurrentGitRepositoryRoot("")
-	if err != nil {
-		return "", false
-	}
-	return repoPath, true
 }
 
 func repoRefFromFullName(repoName string) (workbench.RepoRef, bool) {

--- a/main.go
+++ b/main.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/0maru/gh-zen/internal/app"
 	"github.com/0maru/gh-zen/internal/config"
+	"github.com/0maru/gh-zen/internal/github"
+	"github.com/0maru/gh-zen/internal/localrepo"
+	"github.com/0maru/gh-zen/internal/workbench"
 )
 
 func main() {
@@ -30,6 +35,50 @@ func run() error {
 		return err
 	}
 
-	_, err = tea.NewProgram(app.NewWithConfig(loadResult.Config, startupRepo.Repo), tea.WithAltScreen()).Run()
+	data := loadStartupWorkbenchData(context.Background(), startupRepo)
+
+	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
 	return err
+}
+
+func loadStartupWorkbenchData(ctx context.Context, startupRepo config.StartupRepository) app.WorkbenchData {
+	repo, ok := repoRefFromFullName(startupRepo.Repo)
+	if !ok {
+		return app.WorkbenchData{}
+	}
+
+	data := app.WorkbenchData{Repos: []workbench.RepoRef{repo}}
+	repoPath, ok := currentCheckoutPathForRepo(startupRepo.Repo)
+	if !ok {
+		return data
+	}
+
+	result := (workbench.RuntimeLoader{
+		Repo:     repo,
+		RepoPath: repoPath,
+		Local:    localrepo.Service{},
+		GitHub:   github.CLIService{},
+	}).Load(ctx)
+	data.WorkItems = result.Items
+	return data
+}
+
+func currentCheckoutPathForRepo(repoName string) (string, bool) {
+	currentRepo, err := config.CurrentGitRepository("")
+	if err != nil || currentRepo != repoName {
+		return "", false
+	}
+	repoPath, err := config.CurrentGitRepositoryRoot("")
+	if err != nil {
+		return "", false
+	}
+	return repoPath, true
+}
+
+func repoRefFromFullName(repoName string) (workbench.RepoRef, bool) {
+	owner, name, ok := strings.Cut(repoName, "/")
+	if !ok || owner == "" || name == "" {
+		return workbench.RepoRef{}, false
+	}
+	return workbench.RepoRef{Owner: owner, Name: name}, true
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -35,7 +36,9 @@ func run() error {
 		return err
 	}
 
-	data := loadStartupWorkbenchData(context.Background(), startupRepo)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data := loadStartupWorkbenchData(ctx, startupRepo)
 
 	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
 	return err
@@ -65,7 +68,7 @@ func loadStartupWorkbenchData(ctx context.Context, startupRepo config.StartupRep
 
 func currentCheckoutPathForRepo(repoName string) (string, bool) {
 	currentRepo, err := config.CurrentGitRepository("")
-	if err != nil || currentRepo != repoName {
+	if err != nil || !sameRepoFullName(currentRepo, repoName) {
 		return "", false
 	}
 	repoPath, err := config.CurrentGitRepositoryRoot("")
@@ -81,4 +84,8 @@ func repoRefFromFullName(repoName string) (workbench.RepoRef, bool) {
 		return workbench.RepoRef{}, false
 	}
 	return workbench.RepoRef{Owner: owner, Name: name}, true
+}
+
+func sameRepoFullName(left string, right string) bool {
+	return strings.EqualFold(left, right)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -19,3 +19,12 @@ func TestRepoRefFromFullName(t *testing.T) {
 		t.Fatalf("expected empty repo name to be rejected")
 	}
 }
+
+func TestSameRepoFullName(t *testing.T) {
+	if !sameRepoFullName("Owner/Repo", "owner/repo") {
+		t.Fatalf("expected repo names to compare case-insensitively")
+	}
+	if sameRepoFullName("owner/other", "owner/repo") {
+		t.Fatalf("expected different repo names not to match")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/0maru/gh-zen/internal/workbench"
+)
+
+func TestRepoRefFromFullName(t *testing.T) {
+	got, ok := repoRefFromFullName("0maru/gh-zen")
+	if !ok {
+		t.Fatalf("expected repo ref to parse")
+	}
+	if want := (workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}); got != want {
+		t.Fatalf("expected %+v, got %+v", want, got)
+	}
+
+	if _, ok := repoRefFromFullName(""); ok {
+		t.Fatalf("expected empty repo name to be rejected")
+	}
+}


### PR DESCRIPTION
Superseded by clean issue-scoped stacked PRs created from `origin/main`.

This draft used the previously merged remote branch state and included more than one issue's diff, so it is closed to avoid reviewing the wrong stack.