### PR TITLE
Resolve local paths for repository loading

### DIFF
--- a/internal/config/repository_path.go
+++ b/internal/config/repository_path.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RepositoryPathOptions configures local checkout path resolution.
+type RepositoryPathOptions struct {
+	Repo       string
+	Config     Config
+	WorkingDir string
+}
+
+// RepositoryPathResult contains a resolved local path and non-fatal diagnostics.
+type RepositoryPathResult struct {
+	Repo        string
+	Path        string
+	Diagnostics []Diagnostic
+}
+
+// ResolveRepositoryPath maps an owner/repo name to a local checkout path.
+func ResolveRepositoryPath(options RepositoryPathOptions) RepositoryPathResult {
+	result := RepositoryPathResult{Repo: options.Repo}
+	if options.Repo == "" {
+		return result
+	}
+
+	currentRepo, currentErr := CurrentGitRepository(options.WorkingDir)
+	if currentErr == nil {
+		if sameRepoName(currentRepo, options.Repo) {
+			if root, err := CurrentGitRepositoryRoot(options.WorkingDir); err == nil {
+				result.Path = root
+				return result
+			}
+		}
+	} else {
+		result.Diagnostics = append(result.Diagnostics, Diagnostic{
+			Path:    "current_git",
+			Message: currentErr.Error(),
+		})
+	}
+
+	for i, root := range options.Config.Repos.Roots {
+		rootPath := expandHomePath(root)
+		matchedPath, diagnostics := findRepositoryInRoot(rootPath, options.Repo, i)
+		result.Diagnostics = append(result.Diagnostics, diagnostics...)
+		if matchedPath != "" {
+			result.Path = matchedPath
+			return result
+		}
+	}
+
+	result.Diagnostics = append(result.Diagnostics, Diagnostic{
+		Path:    "repos",
+		Message: fmt.Sprintf("no local checkout found for %s", options.Repo),
+	})
+	return result
+}
+
+func findRepositoryInRoot(root string, repoName string, rootIndex int) (string, []Diagnostic) {
+	diagnostics := []Diagnostic{}
+	info, err := os.Stat(root)
+	if err != nil {
+		return "", []Diagnostic{repositoryRootDiagnostic(rootIndex, fmt.Sprintf("%q is not accessible: %v", root, err))}
+	}
+	if !info.IsDir() {
+		return "", []Diagnostic{repositoryRootDiagnostic(rootIndex, fmt.Sprintf("%q is not a directory", root))}
+	}
+
+	var matchedPath string
+	err = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			diagnostics = append(diagnostics, repositoryRootDiagnostic(rootIndex, fmt.Sprintf("read %q: %v", path, walkErr)))
+			if entry != nil && entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		if entry.Name() == ".git" {
+			return filepath.SkipDir
+		}
+		if !hasGitMetadata(path) {
+			return nil
+		}
+
+		repo, err := CurrentGitRepository(path)
+		if err != nil {
+			diagnostics = append(diagnostics, Diagnostic{
+				Path:    path,
+				Message: err.Error(),
+			})
+			return nil
+		}
+		if sameRepoName(repo, repoName) {
+			matchedRoot, err := CurrentGitRepositoryRoot(path)
+			if err != nil {
+				diagnostics = append(diagnostics, Diagnostic{
+					Path:    path,
+					Message: err.Error(),
+				})
+				return filepath.SkipDir
+			}
+			matchedPath = matchedRoot
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		diagnostics = append(diagnostics, repositoryRootDiagnostic(rootIndex, fmt.Sprintf("scan %q: %v", root, err)))
+	}
+	return matchedPath, diagnostics
+}
+
+func hasGitMetadata(path string) bool {
+	_, err := os.Stat(filepath.Join(path, ".git"))
+	return err == nil
+}
+
+func repositoryRootDiagnostic(index int, message string) Diagnostic {
+	return Diagnostic{
+		Path:    fmt.Sprintf("repos.roots[%d]", index),
+		Message: message,
+	}
+}
+
+func sameRepoName(left string, right string) bool {
+	return strings.EqualFold(left, right)
+}
+
+func expandHomePath(path string) string {
+	if path == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+	}
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, filepath.FromSlash(strings.TrimPrefix(path, "~/")))
+		}
+	}
+	return path
+}

--- a/internal/config/repository_path_test.go
+++ b/internal/config/repository_path_test.go
@@ -1,0 +1,183 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveRepositoryPath_PrefersMatchingCurrentCheckout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	current := initTempGitRepo(t)
+	runGitCommand(t, current, "remote", "add", "origin", "git@github.com:owner/repo.git")
+	nested := filepath.Join(current, "nested")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+
+	root := t.TempDir()
+	other := filepath.Join(root, "owner", "repo")
+	initTempGitRepoAt(t, other)
+	runGitCommand(t, other, "remote", "add", "origin", "git@github.com:owner/repo.git")
+
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{root}
+	got := ResolveRepositoryPath(RepositoryPathOptions{
+		Repo:       "owner/repo",
+		Config:     cfg,
+		WorkingDir: nested,
+	})
+
+	if !sameResolvedPath(t, got.Path, current) {
+		t.Fatalf("expected current checkout %q to win, got %+v", current, got)
+	}
+}
+
+func TestResolveRepositoryPath_FindsConfiguredRootCheckout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	checkout := filepath.Join(root, "owner", "repo")
+	initTempGitRepoAt(t, checkout)
+	runGitCommand(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{root}
+	got := ResolveRepositoryPath(RepositoryPathOptions{
+		Repo:       "owner/repo",
+		Config:     cfg,
+		WorkingDir: t.TempDir(),
+	})
+
+	if !sameResolvedPath(t, got.Path, checkout) {
+		t.Fatalf("expected checkout %q, got %+v", checkout, got)
+	}
+	if len(got.Diagnostics) == 0 || !strings.Contains(got.Diagnostics[0].Message, "not inside a Git repository") {
+		t.Fatalf("expected current Git diagnostic before root match, got %+v", got.Diagnostics)
+	}
+}
+
+func TestResolveRepositoryPath_DiagnosticsForMissingAndUnsupportedPaths(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	unsupported := filepath.Join(root, "unsupported")
+	initTempGitRepoAt(t, unsupported)
+	runGitCommand(t, unsupported, "remote", "add", "origin", "https://example.com/owner/repo.git")
+
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{filepath.Join(root, "missing"), root}
+	got := ResolveRepositoryPath(RepositoryPathOptions{
+		Repo:       "owner/repo",
+		Config:     cfg,
+		WorkingDir: t.TempDir(),
+	})
+
+	if got.Path != "" {
+		t.Fatalf("expected no checkout to resolve, got %+v", got)
+	}
+	if !hasDiagnosticContaining(got.Diagnostics, "repos.roots[0]", "not accessible") {
+		t.Fatalf("expected missing root diagnostic, got %+v", got.Diagnostics)
+	}
+	if !hasDiagnosticContaining(got.Diagnostics, unsupported, "unsupported GitHub remote host") {
+		t.Fatalf("expected unsupported remote diagnostic, got %+v", got.Diagnostics)
+	}
+	if !hasDiagnosticContaining(got.Diagnostics, "repos", "no local checkout found") {
+		t.Fatalf("expected no checkout diagnostic, got %+v", got.Diagnostics)
+	}
+}
+
+func TestResolveRepositoryPath_FindsNestedCheckoutInsideUnmatchedGitRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	parent := filepath.Join(root, "parent")
+	initTempGitRepoAt(t, parent)
+	runGitCommand(t, parent, "remote", "add", "origin", "https://github.com/owner/parent.git")
+
+	nested := filepath.Join(parent, "nested", "repo")
+	initTempGitRepoAt(t, nested)
+	runGitCommand(t, nested, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{root}
+	got := ResolveRepositoryPath(RepositoryPathOptions{
+		Repo:       "owner/repo",
+		Config:     cfg,
+		WorkingDir: t.TempDir(),
+	})
+
+	if !sameResolvedPath(t, got.Path, nested) {
+		t.Fatalf("expected nested checkout %q, got %+v", nested, got)
+	}
+}
+
+func TestResolveRepositoryPath_FindsNestedCheckoutAfterParentRemoteParseError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	parent := filepath.Join(root, "parent")
+	initTempGitRepoAt(t, parent)
+	runGitCommand(t, parent, "remote", "add", "origin", "https://example.com/owner/parent.git")
+
+	nested := filepath.Join(parent, "nested", "repo")
+	initTempGitRepoAt(t, nested)
+	runGitCommand(t, nested, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{root}
+	got := ResolveRepositoryPath(RepositoryPathOptions{
+		Repo:       "owner/repo",
+		Config:     cfg,
+		WorkingDir: t.TempDir(),
+	})
+
+	if !sameResolvedPath(t, got.Path, nested) {
+		t.Fatalf("expected nested checkout %q, got %+v", nested, got)
+	}
+	if !hasDiagnosticContaining(got.Diagnostics, parent, "unsupported GitHub remote host") {
+		t.Fatalf("expected parent remote parse diagnostic, got %+v", got.Diagnostics)
+	}
+}
+
+func hasDiagnosticContaining(diagnostics []Diagnostic, path string, message string) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Path == path && strings.Contains(diagnostic.Message, message) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameResolvedPath(t *testing.T, got string, want string) bool {
+	t.Helper()
+	gotResolved, err := filepath.EvalSymlinks(got)
+	if err != nil {
+		t.Fatalf("resolve got path %q: %v", got, err)
+	}
+	wantResolved, err := filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatalf("resolve want path %q: %v", want, err)
+	}
+	return gotResolved == wantResolved
+}
+
+func initTempGitRepoAt(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	runGitCommand(t, dir, "init", "-b", "main")
+}

--- a/main.go
+++ b/main.go
@@ -38,44 +38,35 @@ func run() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	data := loadStartupWorkbenchData(ctx, startupRepo)
+	data := loadStartupWorkbenchData(ctx, loadResult.Config, startupRepo)
 
 	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
 	return err
 }
 
-func loadStartupWorkbenchData(ctx context.Context, startupRepo config.StartupRepository) app.WorkbenchData {
+func loadStartupWorkbenchData(ctx context.Context, cfg config.Config, startupRepo config.StartupRepository) app.WorkbenchData {
 	repo, ok := repoRefFromFullName(startupRepo.Repo)
 	if !ok {
 		return app.WorkbenchData{}
 	}
 
 	data := app.WorkbenchData{Repos: []workbench.RepoRef{repo}}
-	repoPath, ok := currentCheckoutPathForRepo(startupRepo.Repo)
-	if !ok {
+	resolvedPath := config.ResolveRepositoryPath(config.RepositoryPathOptions{
+		Repo:   startupRepo.Repo,
+		Config: cfg,
+	})
+	if resolvedPath.Path == "" {
 		return data
 	}
 
 	result := (workbench.RuntimeLoader{
 		Repo:     repo,
-		RepoPath: repoPath,
+		RepoPath: resolvedPath.Path,
 		Local:    localrepo.Service{},
 		GitHub:   github.CLIService{},
 	}).Load(ctx)
 	data.WorkItems = result.Items
 	return data
-}
-
-func currentCheckoutPathForRepo(repoName string) (string, bool) {
-	currentRepo, err := config.CurrentGitRepository("")
-	if err != nil || !sameRepoFullName(currentRepo, repoName) {
-		return "", false
-	}
-	repoPath, err := config.CurrentGitRepositoryRoot("")
-	if err != nil {
-		return "", false
-	}
-	return repoPath, true
 }
 
 func repoRefFromFullName(repoName string) (workbench.RepoRef, bool) {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -36,9 +35,7 @@ func run() error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	data := loadStartupWorkbenchData(ctx, loadResult.Config, startupRepo)
+	data := loadStartupWorkbenchData(context.Background(), loadResult.Config, startupRepo)
 
 	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
 	return err


### PR DESCRIPTION
## Summary

- Add repository path resolution for the current checkout and configured `repos.roots`.
- Match local checkouts to `owner/repo` by parsing their GitHub `origin` remote.
- Return non-fatal diagnostics for missing roots, unsupported remotes, and unresolved local checkouts.

## Stack

- Stack position: 2 of 5.
- Depends on #52.
- Next: refresh reloads the full workbench pipeline.

## Validation

- `make check`
- `git push` pre-push hook: `test-medium`

Closes #39