### PR TITLE
Add runtime loading and partial-error UI states

### DIFF
--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -75,6 +75,8 @@ type model struct {
 	viewSelected         bool
 	workItems            []workbench.WorkItem
 	selectedItem         int
+	workbenchSource      workbenchDataSource
+	workbenchLoading     bool
 	focusedPane          paneFocus
 	focusedWorkItemID    string
 	preview              previewState
@@ -93,9 +95,11 @@ type model struct {
 
 // WorkbenchData contains resolved repository workbench state for app startup.
 type WorkbenchData struct {
-	Repos     []workbench.RepoRef
-	WorkItems []workbench.WorkItem
-	Reloader  WorkbenchReloader
+	Repos          []workbench.RepoRef
+	WorkItems      []workbench.WorkItem
+	Reloader       WorkbenchReloader
+	InitialLoading bool
+	Demo           bool
 }
 
 // WorkbenchReloader reloads runtime workbench data for one selected repository.
@@ -105,10 +109,17 @@ type WorkbenchReloader interface {
 
 type repoViewFilter int
 
+type workbenchDataSource int
+
 const (
 	repoViewActiveWorktrees repoViewFilter = iota
 	repoViewReviewRequested
 	repoViewFailedChecks
+)
+
+const (
+	workbenchDataLive workbenchDataSource = iota
+	workbenchDataDemo
 )
 
 type repoView struct {
@@ -120,6 +131,13 @@ var repoViews = []repoView{
 	{label: "Active worktrees", filter: repoViewActiveWorktrees},
 	{label: "Review requested", filter: repoViewReviewRequested},
 	{label: "Failed checks", filter: repoViewFailedChecks},
+}
+
+var workbenchErrorIDPrefixes = []string{
+	"local-discovery-error:",
+	"pull-request-discovery-error:",
+	"issue-check-discovery-error:",
+	"repository-path-error:",
 }
 
 func New() tea.Model {
@@ -147,13 +165,19 @@ func newModelWithRuntimeConfig(cfg cfgpkg.Config, startupRepo string, loader pre
 	return newModelWithRuntimeData(cfg, startupRepo, WorkbenchData{
 		Repos:     workbench.FakeRepos(),
 		WorkItems: workbench.FakeWorkItems(),
+		Demo:      true,
 	}, loader)
 }
 
 func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data WorkbenchData, loader previewLoader) model {
+	source := workbenchDataLive
+	if data.Demo {
+		source = workbenchDataDemo
+	}
 	m := model{
 		repos:             cloneRepoRefs(data.Repos),
 		workItems:         cloneWorkItems(data.WorkItems),
+		workbenchSource:   source,
 		previewLoader:     loader,
 		workbenchReloader: data.Reloader,
 		workbenchFilter:   cfg.Workbench.Filter,
@@ -167,6 +191,9 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 		startupRepo = cfg.Startup.Repo
 	}
 	m.applyStartupRepo(startupRepo)
+	if data.InitialLoading {
+		m.beginWorkbenchReload("Loading workbench data...")
+	}
 	_ = m.startPreviewLoadForCurrentItem()
 	return m
 }
@@ -182,18 +209,40 @@ type workbenchReloadMsg struct {
 }
 
 func (m model) Init() tea.Cmd {
+	var cmds []tea.Cmd
+	if m.workbenchLoading && m.activeReloadRequest.requestID != 0 {
+		cmds = append(cmds, m.workbenchReloadCommand(m.activeReloadRequest))
+	}
 	if m.preview.status != previewLoading || m.previewLoader == nil {
-		return nil
+		return batchCommands(cmds...)
 	}
 	item, ok := m.selectedWorkItem()
 	if !ok || item.ID != m.focusedWorkItemID {
-		return nil
+		return batchCommands(cmds...)
 	}
-	return m.previewLoader(previewRequest{
+	cmds = append(cmds, m.previewLoader(previewRequest{
 		requestID:  m.preview.requestID,
 		workItemID: item.ID,
 		item:       item,
-	})
+	}))
+	return batchCommands(cmds...)
+}
+
+func batchCommands(cmds ...tea.Cmd) tea.Cmd {
+	filtered := make([]tea.Cmd, 0, len(cmds))
+	for _, cmd := range cmds {
+		if cmd != nil {
+			filtered = append(filtered, cmd)
+		}
+	}
+	switch len(filtered) {
+	case 0:
+		return nil
+	case 1:
+		return filtered[0]
+	default:
+		return tea.Batch(filtered...)
+	}
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -330,7 +379,6 @@ func (m *model) handleAction(action actionID) tea.Cmd {
 			m.statusMessage = "Refresh unavailable"
 			return nil
 		}
-		m.statusMessage = "Reloading workbench data..."
 		return cmd
 	case actionOpenPullRequest:
 		return m.openPullRequest()
@@ -447,12 +495,23 @@ func bestWorkItemURL(item workbench.WorkItem) (string, string, bool) {
 }
 
 func (m *model) refreshWorkbenchData() tea.Cmd {
-	if m.workbenchReloader == nil {
+	return m.startWorkbenchReload("Reloading workbench data...")
+}
+
+func (m *model) startWorkbenchReload(status string) tea.Cmd {
+	if !m.beginWorkbenchReload(status) {
 		return nil
+	}
+	return m.workbenchReloadCommand(m.activeReloadRequest)
+}
+
+func (m *model) beginWorkbenchReload(status string) bool {
+	if m.workbenchReloader == nil {
+		return false
 	}
 	repo, ok := m.selectedRepoRef()
 	if !ok {
-		return nil
+		return false
 	}
 	m.nextReloadRequestID++
 	request := workbenchReloadRequest{
@@ -460,10 +519,16 @@ func (m *model) refreshWorkbenchData() tea.Cmd {
 		repo:      repo,
 	}
 	m.activeReloadRequest = request
+	m.workbenchLoading = true
+	m.statusMessage = status
+	return true
+}
+
+func (m model) workbenchReloadCommand(request workbenchReloadRequest) tea.Cmd {
 	return func() tea.Msg {
 		return workbenchReloadMsg{
 			request: request,
-			result:  m.workbenchReloader.Load(context.Background(), repo),
+			result:  m.workbenchReloader.Load(context.Background(), request.repo),
 		}
 	}
 }
@@ -474,6 +539,7 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	}
 	repo, ok := m.selectedRepoRef()
 	if !ok || repo != msg.request.repo {
+		m.workbenchLoading = false
 		m.statusMessage = ""
 		return nil
 	}
@@ -486,7 +552,12 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	}
 	m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
 	m.restoreSelectedWorkItem(selectedWorkItemRepo, selectedWorkItemID)
-	m.statusMessage = "Reloaded workbench data"
+	m.workbenchLoading = false
+	if hasWorkbenchErrorItems(msg.result.Items) {
+		m.statusMessage = "Workbench loaded with partial errors"
+	} else {
+		m.statusMessage = ""
+	}
 	return m.startPreviewLoadForCurrentItem()
 }
 
@@ -709,6 +780,17 @@ func replaceRepoWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, re
 	return out
 }
 
+func hasWorkbenchErrorItems(items []workbench.WorkItem) bool {
+	for _, item := range items {
+		for _, prefix := range workbenchErrorIDPrefixes {
+			if strings.HasPrefix(item.ID, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (m *model) restoreSelectedWorkItem(repo workbench.RepoRef, workItemID string) {
 	items := m.visibleWorkItems()
 	if len(items) == 0 {
@@ -915,8 +997,14 @@ func (m model) workItemLines(width int, focused bool) []string {
 }
 
 func (m model) emptyWorkItemLine() string {
+	if m.workbenchLoading {
+		return "  loading workbench data..."
+	}
 	if workbenchFilterActive(m.workbenchFilter) {
 		return "  no work items match filters"
+	}
+	if m.workbenchSource == workbenchDataLive {
+		return "  no live work items"
 	}
 	return "  no work items"
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
@@ -33,6 +34,7 @@ const (
 	frameBottomRightGlyph  = "┘"
 	previewPaneMinWidth    = 28
 	fullLayoutMinWidth     = repoPaneWidth + workItemPaneWidth + previewPaneMinWidth + paneBorderWidth*3 + paneGapWidth*2
+	workbenchReloadTimeout = 5 * time.Second
 )
 
 // paneFocus tracks the pane that owns pane-scoped key handling.
@@ -526,9 +528,12 @@ func (m *model) beginWorkbenchReload(status string) bool {
 
 func (m model) workbenchReloadCommand(request workbenchReloadRequest) tea.Cmd {
 	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), workbenchReloadTimeout)
+		defer cancel()
+
 		return workbenchReloadMsg{
 			request: request,
-			result:  m.workbenchReloader.Load(context.Background(), request.repo),
+			result:  m.workbenchReloader.Load(ctx, request.repo),
 		}
 	}
 }

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -158,8 +158,8 @@ func TestUpdate_RefreshReloadsWorkbenchData(t *testing.T) {
 	if mm.selectedItem != 0 || mm.focusedWorkItemID != original.ID {
 		t.Fatalf("expected selection to remain on %q, got item=%d focused=%q", original.ID, mm.selectedItem, mm.focusedWorkItemID)
 	}
-	if status := mm.statusMessage; status != "Reloaded workbench data" {
-		t.Fatalf("expected reloaded status, got %q", status)
+	if status := mm.statusMessage; status != "" {
+		t.Fatalf("expected successful reload to clear transient status, got %q", status)
 	}
 }
 
@@ -310,6 +310,9 @@ func TestUpdate_StaleRefreshResultIsDiscarded(t *testing.T) {
 	if len(mm.workItems) != 1 || mm.workItems[0].ID != original.ID {
 		t.Fatalf("expected stale reload not to replace work items, got %+v", mm.workItems)
 	}
+	if mm.workbenchLoading {
+		t.Fatalf("expected stale reload to clear loading state")
+	}
 	if mm.statusMessage != "" {
 		t.Fatalf("expected stale reload to clear loading status, got %q", mm.statusMessage)
 	}
@@ -354,8 +357,8 @@ func TestUpdate_RefreshAppliesAfterViewSelectionChange(t *testing.T) {
 	if len(items) != 1 || items[0].Local == nil || items[0].Local.State != workbench.LocalDirty {
 		t.Fatalf("expected reload result to apply after view selection, got %+v", items)
 	}
-	if status := mm.statusMessage; status != "Reloaded workbench data" {
-		t.Fatalf("expected reloaded status, got %q", status)
+	if status := mm.statusMessage; status != "" {
+		t.Fatalf("expected successful reload to clear status, got %q", status)
 	}
 }
 
@@ -417,6 +420,113 @@ func TestReplaceRepoWorkItems_PreservesRepositoryOrder(t *testing.T) {
 	wantIDs := []string{"a1", "a2", "b2", "b3", "c1"}
 	if !reflect.DeepEqual(gotIDs, wantIDs) {
 		t.Fatalf("expected replacement to preserve repo order %+v, got %+v", wantIDs, gotIDs)
+	}
+}
+
+func TestInit_StartsInitialWorkbenchLoad(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	loaded := workbench.WorkItem{
+		ID:     "branch:loaded",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "loaded"},
+	}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {Repo: repo, Items: []workbench.WorkItem{loaded}},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:          []workbench.RepoRef{repo},
+		Reloader:       reloader,
+		InitialLoading: true,
+	}, fakeDelayedPreviewLoader(0))
+
+	if !start.workbenchLoading {
+		t.Fatalf("expected initial workbench loading state")
+	}
+	if got := strings.Join(start.workItemLines(80, false), "\n"); !strings.Contains(got, "loading workbench data") {
+		t.Fatalf("expected loading workbench line, got %q", got)
+	}
+
+	msg := requireWorkbenchReloadMsg(t, start.Init())
+	got, _ := start.Update(msg)
+	mm := got.(model)
+	if mm.workbenchLoading {
+		t.Fatalf("expected initial workbench load to finish")
+	}
+	if items := mm.visibleWorkItems(); len(items) != 1 || items[0].ID != loaded.ID {
+		t.Fatalf("expected loaded work item, got %+v", items)
+	}
+}
+
+func TestUpdate_RefreshKeepsPartialDataVisibleWhileLoading(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	item := workbench.WorkItem{
+		ID:     "branch:feature",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "feature"},
+	}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {Repo: repo, Items: []workbench.WorkItem{item}},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{item},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	mm := got.(model)
+	if !mm.workbenchLoading {
+		t.Fatalf("expected refresh loading state")
+	}
+	lines := strings.Join(mm.workItemLines(80, false), "\n")
+	if !strings.Contains(lines, "feature") {
+		t.Fatalf("expected existing partial data to remain visible, got %q", lines)
+	}
+	if !strings.Contains(strings.Join(mm.headerLines("gh-zen", 80), "\n"), "Reloading workbench data") {
+		t.Fatalf("expected refresh status in header")
+	}
+}
+
+func TestUpdate_ReloadPartialErrorsSetStatus(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	errorItem := workbench.WorkItem{
+		ID:     "local-discovery-error:" + repo.FullName(),
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "local discovery error"},
+		Local:  &workbench.LocalStatus{State: workbench.LocalUnknown, Summary: "local discovery failed: git failed"},
+	}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {Repo: repo, Items: []workbench.WorkItem{errorItem}},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:    []workbench.RepoRef{repo},
+		Reloader: reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	mm := got.(model)
+
+	if status := mm.statusMessage; status != "Workbench loaded with partial errors" {
+		t.Fatalf("expected partial error status, got %q", status)
+	}
+	if lines := strings.Join(mm.workItemLines(80, false), "\n"); !strings.Contains(lines, "local discovery error") {
+		t.Fatalf("expected error item to be visible, got %q", lines)
+	}
+}
+
+func TestHasWorkbenchErrorItems_UsesKnownErrorPrefixes(t *testing.T) {
+	if hasWorkbenchErrorItems([]workbench.WorkItem{{ID: "branch:error-handling"}}) {
+		t.Fatalf("expected normal branch IDs containing error not to count as partial errors")
+	}
+	if !hasWorkbenchErrorItems([]workbench.WorkItem{{ID: "repository-path-error:0maru/gh-zen"}}) {
+		t.Fatalf("expected repository path error item to count as a partial error")
 	}
 }
 
@@ -507,6 +617,9 @@ func TestNewWithWorkbenchData_EmptyDataDoesNotFallbackToFakeItems(t *testing.T) 
 	}
 	if got.preview.status != previewEmpty {
 		t.Fatalf("expected empty preview, got %v", got.preview.status)
+	}
+	if lines := strings.Join(got.workItemLines(80, false), "\n"); !strings.Contains(lines, "no live work items") {
+		t.Fatalf("expected live empty state, got %q", lines)
 	}
 }
 

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -79,12 +79,15 @@ func (r *fakeActionRunner) Copy(_ context.Context, text string) error {
 }
 
 type fakeWorkbenchReloader struct {
-	results map[string]workbench.RuntimeLoadResult
-	calls   []workbench.RepoRef
+	results     map[string]workbench.RuntimeLoadResult
+	calls       []workbench.RepoRef
+	deadlineSet []bool
 }
 
-func (r *fakeWorkbenchReloader) Load(_ context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
+func (r *fakeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
 	r.calls = append(r.calls, repo)
+	_, hasDeadline := ctx.Deadline()
+	r.deadlineSet = append(r.deadlineSet, hasDeadline)
 	if result, ok := r.results[repo.FullName()]; ok {
 		return result
 	}
@@ -394,8 +397,27 @@ func TestUpdate_OlderRefreshResultDoesNotClearNewerStatus(t *testing.T) {
 	if status := mm.statusMessage; status != "Reloading workbench data..." {
 		t.Fatalf("expected newer reload status to remain, got %q", status)
 	}
+	if !mm.workbenchLoading {
+		t.Fatalf("expected newer reload loading state to remain")
+	}
 	if len(mm.workItems) != 1 || mm.workItems[0].ID != original.ID {
 		t.Fatalf("expected older reload result not to replace work items, got %+v", mm.workItems)
+	}
+}
+
+func TestWorkbenchReloadCommandUsesTimeout(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	reloader := &fakeWorkbenchReloader{}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:    []workbench.RepoRef{repo},
+		Reloader: reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	_, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	requireWorkbenchReloadMsg(t, cmd)
+
+	if len(reloader.deadlineSet) != 1 || !reloader.deadlineSet[0] {
+		t.Fatalf("expected reload context to have a deadline, got %+v", reloader.deadlineSet)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -36,10 +35,8 @@ func run() error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	reloader := runtimeWorkbenchReloader{config: loadResult.Config}
-	data := loadStartupWorkbenchData(ctx, startupRepo, reloader)
+	data := loadStartupWorkbenchData(startupRepo, reloader)
 
 	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
 	return err
@@ -55,7 +52,10 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 		Config: r.config,
 	})
 	if resolvedPath.Path == "" {
-		return workbench.RuntimeLoadResult{Repo: repo}
+		return workbench.RuntimeLoadResult{
+			Repo:  repo,
+			Items: []workbench.WorkItem{repositoryPathErrorItem(repo, resolvedPath.Diagnostics)},
+		}
 	}
 	return (workbench.RuntimeLoader{
 		Repo:     repo,
@@ -65,23 +65,47 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 	}).Load(ctx)
 }
 
-func loadStartupWorkbenchData(ctx context.Context, startupRepo config.StartupRepository, reloader app.WorkbenchReloader) app.WorkbenchData {
+func loadStartupWorkbenchData(startupRepo config.StartupRepository, reloader app.WorkbenchReloader) app.WorkbenchData {
 	repo, ok := repoRefFromFullName(startupRepo.Repo)
 	if !ok {
 		return app.WorkbenchData{}
 	}
 
 	data := app.WorkbenchData{
-		Repos:    []workbench.RepoRef{repo},
-		Reloader: reloader,
+		Repos:          []workbench.RepoRef{repo},
+		Reloader:       reloader,
+		InitialLoading: reloader != nil,
 	}
-	if reloader == nil {
-		return data
-	}
-
-	result := reloader.Load(ctx, repo)
-	data.WorkItems = result.Items
 	return data
+}
+
+func repositoryPathErrorItem(repo workbench.RepoRef, diagnostics []config.Diagnostic) workbench.WorkItem {
+	summary := "repository path resolution failed"
+	if len(diagnostics) > 0 {
+		summary += ": " + diagnosticSummary(diagnostics)
+	}
+	return workbench.WorkItem{
+		ID:     "repository-path-error:" + repo.FullName(),
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "repository path error"},
+		Local: &workbench.LocalStatus{
+			State:   workbench.LocalUnknown,
+			Summary: summary,
+		},
+		Checks: workbench.CheckSummary{State: workbench.CheckUnknown},
+	}
+}
+
+func diagnosticSummary(diagnostics []config.Diagnostic) string {
+	parts := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Path == "" {
+			parts = append(parts, diagnostic.Message)
+			continue
+		}
+		parts = append(parts, diagnostic.Path+": "+diagnostic.Message)
+	}
+	return strings.Join(parts, "; ")
 }
 
 func repoRefFromFullName(repoName string) (workbench.RepoRef, bool) {


### PR DESCRIPTION
## Summary

- Add explicit live workbench loading and empty-state rendering.
- Keep existing partial data visible during refresh while showing loading status.
- Surface local, GitHub, and repository path failures as visible partial-error states.
- Add a bounded reload context so refresh commands do not hang indefinitely.

## Stack

- Stack position: 4 of 5.
- Depends on #54.
- Next: live-data validation and smoke tests.

## Validation

- `make check`
- `git push` pre-push hook: `test-medium`

Closes #43