### PR TITLE
Add live-data validation and smoke tests

### DIFF
--- a/docs/validation/live-data-smoke.md
+++ b/docs/validation/live-data-smoke.md
@@ -1,0 +1,38 @@
+# Live Data Smoke Validation
+
+This manual smoke test verifies that normal startup uses live repository data
+instead of fake workbench fixtures. Real GitHub API validation remains opt-in
+because it needs authenticated `gh` state and a suitable repository.
+
+## Prerequisites
+
+- `gh auth status` succeeds for an account that can read the target repository.
+- The target repository is cloned locally and has an `origin` remote on
+  `github.com`.
+- The repository has at least one local branch or worktree.
+- Optional: the repository has an open pull request with checks.
+
+## Local Extension Smoke Test
+
+1. From this repository, run `make build`.
+2. Install the local extension with `gh extension install . --force`.
+3. Change into a real GitHub checkout, for example
+   `cd ~/workspaces/github.com/0maru/gh-zen`.
+4. Run `gh zen`.
+5. Confirm the workbench shows the real checkout repository and local branches
+   or worktrees, not the fake fixture repositories.
+6. If the checkout has an open pull request, confirm the matching branch shows
+   PR, issue, and check data when authenticated GitHub discovery succeeds.
+7. Run `gh auth logout` or use an unauthenticated environment, then run `gh zen`
+   again and confirm local work items remain visible with a non-fatal GitHub
+   discovery error item.
+
+## Opt-In Large Validation
+
+Large tests that touch authenticated GitHub behavior must stay opt-in:
+
+```sh
+GH_ZEN_LARGE_TESTS=1 make test-large
+```
+
+Do not require large tests for normal `make check` or pre-push validation.

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -16,6 +16,11 @@ type fakeRunner struct {
 	args   []string
 }
 
+type fakeRunnerByCommand struct {
+	outputs map[string][]byte
+	calls   [][]string
+}
+
 type fakeExitError struct {
 	code int
 }
@@ -31,6 +36,16 @@ func (e fakeExitError) ExitCode() int {
 func (r *fakeRunner) Run(_ context.Context, args ...string) ([]byte, error) {
 	r.args = append([]string(nil), args...)
 	return r.output, r.err
+}
+
+func (r *fakeRunnerByCommand) Run(_ context.Context, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, append([]string(nil), args...))
+	key := commandKey(args...)
+	output, ok := r.outputs[key]
+	if !ok {
+		return nil, errors.New("unexpected gh command: " + key)
+	}
+	return output, nil
 }
 
 func TestFakeService_ReturnsRepositorySummary(t *testing.T) {
@@ -125,6 +140,51 @@ func TestCLIService_CheckSummaryParsesGHOutput(t *testing.T) {
 	}
 }
 
+func TestCLIService_ProvidesDataForWorkbenchEnrichment(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	prFields := "number,title,state,url,headRefName,headRepositoryOwner,reviewDecision,closingIssuesReferences"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("pr", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", prFields):                    []byte(`[{"number":24,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/pull/24","headRefName":"feature/issue-123-runtime","headRepositoryOwner":{"login":"0maru"},"reviewDecision":"APPROVED","closingIssuesReferences":[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123"}]}]`),
+		commandKey("issue", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", "number,title,state,url"): []byte(`[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123"}]`),
+		commandKey("pr", "checks", "feature/issue-123-runtime", "--repo", repo.FullName(), "--json", "name,state"):                         []byte(`[{"name":"test","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]`),
+	}}
+	service := CLIService{Runner: runner}
+
+	prs, err := service.PullRequests(context.Background(), repo.FullName())
+	if err != nil {
+		t.Fatalf("expected pull requests to parse, got %v", err)
+	}
+	issues, err := service.Issues(context.Background(), repo.FullName())
+	if err != nil {
+		t.Fatalf("expected issues to parse, got %v", err)
+	}
+	checks, err := service.CheckSummary(context.Background(), repo.FullName(), "feature/issue-123-runtime")
+	if err != nil {
+		t.Fatalf("expected checks to parse, got %v", err)
+	}
+
+	items := workbench.LinkPullRequests([]workbench.WorkItem{{
+		ID:     "feature",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "feature/issue-123-runtime"},
+	}}, prs)
+	items = workbench.LinkIssues(items, issues)
+	items[0].Checks = checks
+
+	if items[0].PullRequest == nil || items[0].PullRequest.Number != 24 || items[0].PullRequest.ReviewState != "approved" {
+		t.Fatalf("expected CLI PR data to enrich work item, got %+v", items[0])
+	}
+	if items[0].Issue == nil || items[0].Issue.Number != 123 || items[0].Issue.Title != "Runtime pipeline" {
+		t.Fatalf("expected CLI issue data to enrich work item, got %+v", items[0])
+	}
+	if items[0].Checks.State != workbench.CheckPassing || items[0].Checks.Passing != 2 {
+		t.Fatalf("expected CLI check data to enrich work item, got %+v", items[0])
+	}
+	if len(runner.calls) != 3 {
+		t.Fatalf("expected three gh calls, got %#v", runner.calls)
+	}
+}
+
 func TestClassifyError(t *testing.T) {
 	err := classifyError("gh pr list", []byte("run gh auth login"), errors.New("exit status 1"))
 	if err.Kind != ErrorAuth {
@@ -150,6 +210,10 @@ func TestIsPendingChecksExit(t *testing.T) {
 	if isPendingChecksExit([]string{"pr", "list"}, fakeExitError{code: 8}) {
 		t.Fatal("expected exit 8 from a different gh command to remain an error")
 	}
+}
+
+func commandKey(args ...string) string {
+	return strings.Join(args, "\x00")
 }
 
 func hasArgPair(args []string, key string, value string) bool {

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -3,6 +3,7 @@ package workbench
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -199,6 +200,84 @@ func TestRuntimeLoader_ContinuesWhenSingleCheckFails(t *testing.T) {
 	}
 }
 
+func TestRuntimeLoader_WithTemporaryGitRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoDir := initLocalServiceRepo(t)
+	featureDir := filepath.Join(t.TempDir(), "feature")
+	runLocalServiceGit(t, repoDir, "worktree", "add", "-b", "feature/issue-123-runtime", featureDir)
+	writeLocalServiceFile(t, filepath.Join(featureDir, "dirty.txt"), "dirty\n")
+	runLocalServiceGit(t, repoDir, "update-ref", "refs/remotes/origin/remote-only", "HEAD")
+
+	result := RuntimeLoader{
+		Repo:     repo,
+		RepoPath: repoDir,
+		Local:    localrepo.Service{},
+		GitHub: fakeRuntimeGitHub{
+			prs: []PullRequestRef{{
+				Number:     24,
+				Title:      "Runtime pipeline",
+				State:      "open",
+				URL:        "https://example.test/pull/24",
+				HeadOwner:  "0maru",
+				HeadBranch: "feature/issue-123-runtime",
+				LinkedIssues: []IssueRef{{
+					Number:  123,
+					Certain: true,
+				}},
+			}},
+			issues: []IssueRef{{
+				Number:  123,
+				Title:   "Runtime pipeline",
+				State:   "open",
+				URL:     "https://example.test/issues/123",
+				Certain: true,
+			}},
+			checks: CheckSummary{State: CheckPassing, Passing: 3},
+		},
+	}.Load(context.Background())
+
+	if !hasWorkItem(result.Items, func(item WorkItem) bool {
+		return item.Worktree != nil &&
+			sameRuntimeTestPath(t, item.Worktree.Path, repoDir) &&
+			item.Branch != nil &&
+			item.Branch.Name == "main" &&
+			item.Local != nil &&
+			item.Local.State == LocalClean
+	}) {
+		t.Fatalf("expected clean main worktree item, got %+v", result.Items)
+	}
+	if !hasWorkItem(result.Items, func(item WorkItem) bool {
+		return item.Worktree != nil &&
+			sameRuntimeTestPath(t, item.Worktree.Path, featureDir) &&
+			item.Branch != nil &&
+			item.Branch.Name == "feature/issue-123-runtime" &&
+			item.Local != nil &&
+			item.Local.State == LocalDirty &&
+			item.PullRequest != nil &&
+			item.PullRequest.Number == 24 &&
+			item.Issue != nil &&
+			item.Issue.Number == 123 &&
+			item.Checks.State == CheckPassing &&
+			item.Checks.Passing == 3
+	}) {
+		t.Fatalf("expected dirty feature worktree enriched with PR, issue, and checks, got %+v", result.Items)
+	}
+	if !hasWorkItem(result.Items, func(item WorkItem) bool {
+		return item.Worktree == nil &&
+			item.Branch != nil &&
+			item.Branch.Name == "remote-only" &&
+			item.Branch.RemoteOnly &&
+			item.Local != nil &&
+			item.Local.State == LocalMissing
+	}) {
+		t.Fatalf("expected remote-only branch item, got %+v", result.Items)
+	}
+}
+
 func hasRuntimeErrorItem(items []WorkItem, prefix string, detail string) bool {
 	return hasWorkItem(items, func(item WorkItem) bool {
 		return item.Local != nil &&
@@ -214,4 +293,17 @@ func runtimeWorkItemByBranch(items []WorkItem, branch string) *WorkItem {
 		}
 	}
 	return nil
+}
+
+func sameRuntimeTestPath(t *testing.T, got string, want string) bool {
+	t.Helper()
+	gotResolved, err := filepath.EvalSymlinks(got)
+	if err != nil {
+		t.Fatalf("resolve got path %q: %v", got, err)
+	}
+	wantResolved, err := filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatalf("resolve want path %q: %v", want, err)
+	}
+	return gotResolved == wantResolved
 }


### PR DESCRIPTION
## Summary

- Add medium runtime pipeline coverage with temporary Git worktrees, dirty state, remote-only branches, PRs, issues, and checks.
- Add fake `gh` runner coverage for data used by workbench enrichment.
- Document manual live-data smoke validation for local extension startup.

## Stack

- Stack position: 5 of 5.
- Depends on #55.

## Validation

- `make check`
- `git push` pre-push hook: `test-medium`

Closes #41