### PR TITLE
Integrate live workbench reload and validation

### DIFF
--- a/docs/validation/live-data-smoke.md
+++ b/docs/validation/live-data-smoke.md
@@ -1,0 +1,38 @@
+# Live Data Smoke Validation
+
+This manual smoke test verifies that normal startup uses live repository data
+instead of fake workbench fixtures. Real GitHub API validation remains opt-in
+because it needs authenticated `gh` state and a suitable repository.
+
+## Prerequisites
+
+- `gh auth status` succeeds for an account that can read the target repository.
+- The target repository is cloned locally and has an `origin` remote on
+  `github.com`.
+- The repository has at least one local branch or worktree.
+- Optional: the repository has an open pull request with checks.
+
+## Local Extension Smoke Test
+
+1. From this repository, run `make build`.
+2. Install the local extension with `gh extension install . --force`.
+3. Change into a real GitHub checkout, for example
+   `cd ~/workspaces/github.com/0maru/gh-zen`.
+4. Run `gh zen`.
+5. Confirm the workbench shows the real checkout repository and local branches
+   or worktrees, not the fake fixture repositories.
+6. If the checkout has an open pull request, confirm the matching branch shows
+   PR, issue, and check data when authenticated GitHub discovery succeeds.
+7. Run `gh auth logout` or use an unauthenticated environment, then run `gh zen`
+   again and confirm local work items remain visible with a non-fatal GitHub
+   discovery error item.
+
+## Opt-In Large Validation
+
+Large tests that touch authenticated GitHub behavior must stay opt-in:
+
+```sh
+GH_ZEN_LARGE_TESTS=1 make test-large
+```
+
+Do not require large tests for normal `make check` or pre-push validation.

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -75,6 +75,8 @@ type model struct {
 	viewSelected         bool
 	workItems            []workbench.WorkItem
 	selectedItem         int
+	workbenchSource      workbenchDataSource
+	workbenchLoading     bool
 	focusedPane          paneFocus
 	focusedWorkItemID    string
 	preview              previewState
@@ -93,9 +95,11 @@ type model struct {
 
 // WorkbenchData contains resolved repository workbench state for app startup.
 type WorkbenchData struct {
-	Repos     []workbench.RepoRef
-	WorkItems []workbench.WorkItem
-	Reloader  WorkbenchReloader
+	Repos          []workbench.RepoRef
+	WorkItems      []workbench.WorkItem
+	Reloader       WorkbenchReloader
+	InitialLoading bool
+	Demo           bool
 }
 
 // WorkbenchReloader reloads runtime workbench data for one selected repository.
@@ -105,10 +109,17 @@ type WorkbenchReloader interface {
 
 type repoViewFilter int
 
+type workbenchDataSource int
+
 const (
 	repoViewActiveWorktrees repoViewFilter = iota
 	repoViewReviewRequested
 	repoViewFailedChecks
+)
+
+const (
+	workbenchDataLive workbenchDataSource = iota
+	workbenchDataDemo
 )
 
 type repoView struct {
@@ -120,6 +131,13 @@ var repoViews = []repoView{
 	{label: "Active worktrees", filter: repoViewActiveWorktrees},
 	{label: "Review requested", filter: repoViewReviewRequested},
 	{label: "Failed checks", filter: repoViewFailedChecks},
+}
+
+var workbenchErrorIDPrefixes = []string{
+	"local-discovery-error:",
+	"pull-request-discovery-error:",
+	"issue-check-discovery-error:",
+	"repository-path-error:",
 }
 
 func New() tea.Model {
@@ -147,13 +165,19 @@ func newModelWithRuntimeConfig(cfg cfgpkg.Config, startupRepo string, loader pre
 	return newModelWithRuntimeData(cfg, startupRepo, WorkbenchData{
 		Repos:     workbench.FakeRepos(),
 		WorkItems: workbench.FakeWorkItems(),
+		Demo:      true,
 	}, loader)
 }
 
 func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data WorkbenchData, loader previewLoader) model {
+	source := workbenchDataLive
+	if data.Demo {
+		source = workbenchDataDemo
+	}
 	m := model{
 		repos:             cloneRepoRefs(data.Repos),
 		workItems:         cloneWorkItems(data.WorkItems),
+		workbenchSource:   source,
 		previewLoader:     loader,
 		workbenchReloader: data.Reloader,
 		workbenchFilter:   cfg.Workbench.Filter,
@@ -167,6 +191,9 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 		startupRepo = cfg.Startup.Repo
 	}
 	m.applyStartupRepo(startupRepo)
+	if data.InitialLoading {
+		m.beginWorkbenchReload("Loading workbench data...")
+	}
 	_ = m.startPreviewLoadForCurrentItem()
 	return m
 }
@@ -182,18 +209,40 @@ type workbenchReloadMsg struct {
 }
 
 func (m model) Init() tea.Cmd {
+	var cmds []tea.Cmd
+	if m.workbenchLoading && m.activeReloadRequest.requestID != 0 {
+		cmds = append(cmds, m.workbenchReloadCommand(m.activeReloadRequest))
+	}
 	if m.preview.status != previewLoading || m.previewLoader == nil {
-		return nil
+		return batchCommands(cmds...)
 	}
 	item, ok := m.selectedWorkItem()
 	if !ok || item.ID != m.focusedWorkItemID {
-		return nil
+		return batchCommands(cmds...)
 	}
-	return m.previewLoader(previewRequest{
+	cmds = append(cmds, m.previewLoader(previewRequest{
 		requestID:  m.preview.requestID,
 		workItemID: item.ID,
 		item:       item,
-	})
+	}))
+	return batchCommands(cmds...)
+}
+
+func batchCommands(cmds ...tea.Cmd) tea.Cmd {
+	filtered := make([]tea.Cmd, 0, len(cmds))
+	for _, cmd := range cmds {
+		if cmd != nil {
+			filtered = append(filtered, cmd)
+		}
+	}
+	switch len(filtered) {
+	case 0:
+		return nil
+	case 1:
+		return filtered[0]
+	default:
+		return tea.Batch(filtered...)
+	}
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -330,7 +379,6 @@ func (m *model) handleAction(action actionID) tea.Cmd {
 			m.statusMessage = "Refresh unavailable"
 			return nil
 		}
-		m.statusMessage = "Reloading workbench data..."
 		return cmd
 	case actionOpenPullRequest:
 		return m.openPullRequest()
@@ -447,12 +495,23 @@ func bestWorkItemURL(item workbench.WorkItem) (string, string, bool) {
 }
 
 func (m *model) refreshWorkbenchData() tea.Cmd {
-	if m.workbenchReloader == nil {
+	return m.startWorkbenchReload("Reloading workbench data...")
+}
+
+func (m *model) startWorkbenchReload(status string) tea.Cmd {
+	if !m.beginWorkbenchReload(status) {
 		return nil
+	}
+	return m.workbenchReloadCommand(m.activeReloadRequest)
+}
+
+func (m *model) beginWorkbenchReload(status string) bool {
+	if m.workbenchReloader == nil {
+		return false
 	}
 	repo, ok := m.selectedRepoRef()
 	if !ok {
-		return nil
+		return false
 	}
 	m.nextReloadRequestID++
 	request := workbenchReloadRequest{
@@ -460,10 +519,16 @@ func (m *model) refreshWorkbenchData() tea.Cmd {
 		repo:      repo,
 	}
 	m.activeReloadRequest = request
+	m.workbenchLoading = true
+	m.statusMessage = status
+	return true
+}
+
+func (m model) workbenchReloadCommand(request workbenchReloadRequest) tea.Cmd {
 	return func() tea.Msg {
 		return workbenchReloadMsg{
 			request: request,
-			result:  m.workbenchReloader.Load(context.Background(), repo),
+			result:  m.workbenchReloader.Load(context.Background(), request.repo),
 		}
 	}
 }
@@ -474,6 +539,7 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	}
 	repo, ok := m.selectedRepoRef()
 	if !ok || repo != msg.request.repo {
+		m.workbenchLoading = false
 		m.statusMessage = ""
 		return nil
 	}
@@ -486,7 +552,12 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	}
 	m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
 	m.restoreSelectedWorkItem(selectedWorkItemRepo, selectedWorkItemID)
-	m.statusMessage = "Reloaded workbench data"
+	m.workbenchLoading = false
+	if hasWorkbenchErrorItems(msg.result.Items) {
+		m.statusMessage = "Workbench loaded with partial errors"
+	} else {
+		m.statusMessage = ""
+	}
 	return m.startPreviewLoadForCurrentItem()
 }
 
@@ -709,6 +780,17 @@ func replaceRepoWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, re
 	return out
 }
 
+func hasWorkbenchErrorItems(items []workbench.WorkItem) bool {
+	for _, item := range items {
+		for _, prefix := range workbenchErrorIDPrefixes {
+			if strings.HasPrefix(item.ID, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (m *model) restoreSelectedWorkItem(repo workbench.RepoRef, workItemID string) {
 	items := m.visibleWorkItems()
 	if len(items) == 0 {
@@ -915,8 +997,14 @@ func (m model) workItemLines(width int, focused bool) []string {
 }
 
 func (m model) emptyWorkItemLine() string {
+	if m.workbenchLoading {
+		return "  loading workbench data..."
+	}
 	if workbenchFilterActive(m.workbenchFilter) {
 		return "  no work items match filters"
+	}
+	if m.workbenchSource == workbenchDataLive {
+		return "  no live work items"
 	}
 	return "  no work items"
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -14,7 +14,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	cfgpkg "github.com/0maru/gh-zen/internal/config"
-	ghsvc "github.com/0maru/gh-zen/internal/github"
 	"github.com/0maru/gh-zen/internal/workbench"
 )
 
@@ -81,9 +80,9 @@ type model struct {
 	preview              previewState
 	nextPreviewRequestID int
 	previewLoader        previewLoader
-	githubService        ghsvc.Service
-	githubSummary        ghsvc.RepositorySummary
-	githubError          string
+	workbenchReloader    WorkbenchReloader
+	nextReloadRequestID  int
+	activeReloadRequest  workbenchReloadRequest
 	workbenchFilter      cfgpkg.WorkbenchFilter
 	actionRunner         actionRunner
 	statusMessage        string
@@ -96,6 +95,12 @@ type model struct {
 type WorkbenchData struct {
 	Repos     []workbench.RepoRef
 	WorkItems []workbench.WorkItem
+	Reloader  WorkbenchReloader
+}
+
+// WorkbenchReloader reloads runtime workbench data for one selected repository.
+type WorkbenchReloader interface {
+	Load(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult
 }
 
 type repoViewFilter int
@@ -147,14 +152,15 @@ func newModelWithRuntimeConfig(cfg cfgpkg.Config, startupRepo string, loader pre
 
 func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data WorkbenchData, loader previewLoader) model {
 	m := model{
-		repos:           cloneRepoRefs(data.Repos),
-		workItems:       cloneWorkItems(data.WorkItems),
-		previewLoader:   loader,
-		workbenchFilter: cfg.Workbench.Filter,
-		actionRunner:    systemActionRunner{},
-		styles:          DefaultStyles(),
-		keys:            DefaultKeyMap(),
-		help:            newHelpModel(),
+		repos:             cloneRepoRefs(data.Repos),
+		workItems:         cloneWorkItems(data.WorkItems),
+		previewLoader:     loader,
+		workbenchReloader: data.Reloader,
+		workbenchFilter:   cfg.Workbench.Filter,
+		actionRunner:      systemActionRunner{},
+		styles:            DefaultStyles(),
+		keys:              DefaultKeyMap(),
+		help:              newHelpModel(),
 	}
 	m.applyStartupView(cfg.Startup.View)
 	if startupRepo == "" {
@@ -165,15 +171,14 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 	return m
 }
 
-func newModelWithGitHubService(service ghsvc.Service) model {
-	m := newModelWithPreviewLoader(fakeDelayedPreviewLoader(defaultPreviewDelay))
-	m.githubService = service
-	return m
+type workbenchReloadRequest struct {
+	requestID int
+	repo      workbench.RepoRef
 }
 
-type githubSummaryMsg struct {
-	summary ghsvc.RepositorySummary
-	err     error
+type workbenchReloadMsg struct {
+	request workbenchReloadRequest
+	result  workbench.RuntimeLoadResult
 }
 
 func (m model) Init() tea.Cmd {
@@ -203,9 +208,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case actionResultMsg:
 		m.handleActionResult(msg)
 		return m, nil
-	case githubSummaryMsg:
-		m.handleGitHubSummary(msg)
-		return m, nil
+	case workbenchReloadMsg:
+		return m, m.handleWorkbenchReload(msg)
 	case tea.KeyMsg:
 		if action, ok := m.matchedAction(msg); ok {
 			return m, m.handleAction(action)
@@ -321,12 +325,12 @@ func (m *model) handleAction(action actionID) tea.Cmd {
 		m.jumpFocusedSelection(true)
 		return m.startPreviewLoadIfFocusedItemChanged()
 	case actionRefresh:
-		cmd := m.refreshGitHubSummary()
+		cmd := m.refreshWorkbenchData()
 		if cmd == nil {
 			m.statusMessage = "Refresh unavailable"
 			return nil
 		}
-		m.statusMessage = "Refreshing GitHub data..."
+		m.statusMessage = "Reloading workbench data..."
 		return cmd
 	case actionOpenPullRequest:
 		return m.openPullRequest()
@@ -442,30 +446,46 @@ func bestWorkItemURL(item workbench.WorkItem) (string, string, bool) {
 	return "", "", false
 }
 
-func (m model) refreshGitHubSummary() tea.Cmd {
-	if m.githubService == nil {
+func (m *model) refreshWorkbenchData() tea.Cmd {
+	if m.workbenchReloader == nil {
 		return nil
 	}
 	repo, ok := m.selectedRepoRef()
 	if !ok {
 		return nil
 	}
-	repoName := repo.FullName()
+	m.nextReloadRequestID++
+	request := workbenchReloadRequest{
+		requestID: m.nextReloadRequestID,
+		repo:      repo,
+	}
+	m.activeReloadRequest = request
 	return func() tea.Msg {
-		summary, err := m.githubService.RepositorySummary(context.Background(), repoName)
-		return githubSummaryMsg{summary: summary, err: err}
+		return workbenchReloadMsg{
+			request: request,
+			result:  m.workbenchReloader.Load(context.Background(), repo),
+		}
 	}
 }
 
-func (m *model) handleGitHubSummary(msg githubSummaryMsg) {
-	if msg.err != nil {
-		m.githubError = msg.err.Error()
-		m.statusMessage = "Refresh failed: " + msg.err.Error()
-		return
+func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
+	if msg.request != m.activeReloadRequest {
+		return nil
 	}
-	m.githubError = ""
-	m.githubSummary = msg.summary
-	m.statusMessage = "Refreshed GitHub data"
+	repo, ok := m.selectedRepoRef()
+	if !ok || repo != msg.request.repo {
+		m.statusMessage = ""
+		return nil
+	}
+
+	selectedWorkItemID := ""
+	if item, ok := m.selectedWorkItem(); ok {
+		selectedWorkItemID = item.ID
+	}
+	m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
+	m.restoreSelectedWorkItem(selectedWorkItemID)
+	m.statusMessage = "Reloaded workbench data"
+	return m.startPreviewLoadForCurrentItem()
 }
 
 func (m *model) focusNextPane() {
@@ -666,6 +686,42 @@ func filterWorkItems(items []workbench.WorkItem, keep func(workbench.WorkItem) b
 		}
 	}
 	return out
+}
+
+func replaceRepoWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, replacement []workbench.WorkItem) []workbench.WorkItem {
+	out := make([]workbench.WorkItem, 0, len(items)+len(replacement))
+	replaced := false
+	for _, item := range items {
+		if item.Repo == repo {
+			if !replaced {
+				out = append(out, replacement...)
+				replaced = true
+			}
+			continue
+		}
+		out = append(out, item)
+	}
+	if !replaced {
+		out = append(out, replacement...)
+	}
+	return out
+}
+
+func (m *model) restoreSelectedWorkItem(workItemID string) {
+	items := m.visibleWorkItems()
+	if len(items) == 0 {
+		m.selectedItem = 0
+		return
+	}
+	if workItemID != "" {
+		for i, item := range items {
+			if item.ID == workItemID {
+				m.selectedItem = i
+				return
+			}
+		}
+	}
+	m.selectedItem = clamp(m.selectedItem, 0, len(items)-1)
 }
 
 func cloneRepoRefs(repos []workbench.RepoRef) []workbench.RepoRef {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
@@ -33,6 +34,7 @@ const (
 	frameBottomRightGlyph  = "┘"
 	previewPaneMinWidth    = 28
 	fullLayoutMinWidth     = repoPaneWidth + workItemPaneWidth + previewPaneMinWidth + paneBorderWidth*3 + paneGapWidth*2
+	workbenchReloadTimeout = 5 * time.Second
 )
 
 // paneFocus tracks the pane that owns pane-scoped key handling.
@@ -526,9 +528,12 @@ func (m *model) beginWorkbenchReload(status string) bool {
 
 func (m model) workbenchReloadCommand(request workbenchReloadRequest) tea.Cmd {
 	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), workbenchReloadTimeout)
+		defer cancel()
+
 		return workbenchReloadMsg{
 			request: request,
-			result:  m.workbenchReloader.Load(context.Background(), request.repo),
+			result:  m.workbenchReloader.Load(ctx, request.repo),
 		}
 	}
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -174,6 +174,7 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 type workbenchReloadRequest struct {
 	requestID int
 	repo      workbench.RepoRef
+	status    string
 }
 
 type workbenchReloadMsg struct {
@@ -325,12 +326,11 @@ func (m *model) handleAction(action actionID) tea.Cmd {
 		m.jumpFocusedSelection(true)
 		return m.startPreviewLoadIfFocusedItemChanged()
 	case actionRefresh:
-		cmd := m.refreshWorkbenchData()
+		cmd := m.refreshWorkbenchData("Reloading workbench data...")
 		if cmd == nil {
 			m.statusMessage = "Refresh unavailable"
 			return nil
 		}
-		m.statusMessage = "Reloading workbench data..."
 		return cmd
 	case actionOpenPullRequest:
 		return m.openPullRequest()
@@ -446,7 +446,7 @@ func bestWorkItemURL(item workbench.WorkItem) (string, string, bool) {
 	return "", "", false
 }
 
-func (m *model) refreshWorkbenchData() tea.Cmd {
+func (m *model) refreshWorkbenchData(status string) tea.Cmd {
 	if m.workbenchReloader == nil {
 		return nil
 	}
@@ -458,8 +458,10 @@ func (m *model) refreshWorkbenchData() tea.Cmd {
 	request := workbenchReloadRequest{
 		requestID: m.nextReloadRequestID,
 		repo:      repo,
+		status:    status,
 	}
 	m.activeReloadRequest = request
+	m.statusMessage = status
 	return func() tea.Msg {
 		return workbenchReloadMsg{
 			request: request,
@@ -474,7 +476,9 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	}
 	repo, ok := m.selectedRepoRef()
 	if !ok || repo != msg.request.repo {
-		m.statusMessage = ""
+		if m.statusMessage == msg.request.status {
+			m.statusMessage = ""
+		}
 		return nil
 	}
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -478,12 +478,14 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		return nil
 	}
 
+	selectedWorkItemRepo := workbench.RepoRef{}
 	selectedWorkItemID := ""
 	if item, ok := m.selectedWorkItem(); ok {
+		selectedWorkItemRepo = item.Repo
 		selectedWorkItemID = item.ID
 	}
 	m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
-	m.restoreSelectedWorkItem(selectedWorkItemID)
+	m.restoreSelectedWorkItem(selectedWorkItemRepo, selectedWorkItemID)
 	m.statusMessage = "Reloaded workbench data"
 	return m.startPreviewLoadForCurrentItem()
 }
@@ -707,7 +709,7 @@ func replaceRepoWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, re
 	return out
 }
 
-func (m *model) restoreSelectedWorkItem(workItemID string) {
+func (m *model) restoreSelectedWorkItem(repo workbench.RepoRef, workItemID string) {
 	items := m.visibleWorkItems()
 	if len(items) == 0 {
 		m.selectedItem = 0
@@ -715,7 +717,7 @@ func (m *model) restoreSelectedWorkItem(workItemID string) {
 	}
 	if workItemID != "" {
 		for i, item := range items {
-			if item.ID == workItemID {
+			if item.Repo == repo && item.ID == workItemID {
 				m.selectedItem = i
 				return
 			}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
@@ -34,7 +33,6 @@ const (
 	frameBottomRightGlyph  = "┘"
 	previewPaneMinWidth    = 28
 	fullLayoutMinWidth     = repoPaneWidth + workItemPaneWidth + previewPaneMinWidth + paneBorderWidth*3 + paneGapWidth*2
-	workbenchReloadTimeout = 5 * time.Second
 )
 
 // paneFocus tracks the pane that owns pane-scoped key handling.
@@ -530,12 +528,9 @@ func (m *model) beginWorkbenchReload(status string) bool {
 
 func (m model) workbenchReloadCommand(request workbenchReloadRequest) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), workbenchReloadTimeout)
-		defer cancel()
-
 		return workbenchReloadMsg{
 			request: request,
-			result:  m.workbenchReloader.Load(ctx, request.repo),
+			result:  m.workbenchReloader.Load(context.Background(), request.repo),
 		}
 	}
 }

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -158,8 +158,8 @@ func TestUpdate_RefreshReloadsWorkbenchData(t *testing.T) {
 	if mm.selectedItem != 0 || mm.focusedWorkItemID != original.ID {
 		t.Fatalf("expected selection to remain on %q, got item=%d focused=%q", original.ID, mm.selectedItem, mm.focusedWorkItemID)
 	}
-	if status := mm.statusMessage; status != "Reloaded workbench data" {
-		t.Fatalf("expected reloaded status, got %q", status)
+	if status := mm.statusMessage; status != "" {
+		t.Fatalf("expected successful reload to clear transient status, got %q", status)
 	}
 }
 
@@ -310,6 +310,9 @@ func TestUpdate_StaleRefreshResultIsDiscarded(t *testing.T) {
 	if len(mm.workItems) != 1 || mm.workItems[0].ID != original.ID {
 		t.Fatalf("expected stale reload not to replace work items, got %+v", mm.workItems)
 	}
+	if mm.workbenchLoading {
+		t.Fatalf("expected stale reload to clear loading state")
+	}
 	if mm.statusMessage != "" {
 		t.Fatalf("expected stale reload to clear loading status, got %q", mm.statusMessage)
 	}
@@ -354,8 +357,8 @@ func TestUpdate_RefreshAppliesAfterViewSelectionChange(t *testing.T) {
 	if len(items) != 1 || items[0].Local == nil || items[0].Local.State != workbench.LocalDirty {
 		t.Fatalf("expected reload result to apply after view selection, got %+v", items)
 	}
-	if status := mm.statusMessage; status != "Reloaded workbench data" {
-		t.Fatalf("expected reloaded status, got %q", status)
+	if status := mm.statusMessage; status != "" {
+		t.Fatalf("expected successful reload to clear status, got %q", status)
 	}
 }
 
@@ -417,6 +420,113 @@ func TestReplaceRepoWorkItems_PreservesRepositoryOrder(t *testing.T) {
 	wantIDs := []string{"a1", "a2", "b2", "b3", "c1"}
 	if !reflect.DeepEqual(gotIDs, wantIDs) {
 		t.Fatalf("expected replacement to preserve repo order %+v, got %+v", wantIDs, gotIDs)
+	}
+}
+
+func TestInit_StartsInitialWorkbenchLoad(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	loaded := workbench.WorkItem{
+		ID:     "branch:loaded",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "loaded"},
+	}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {Repo: repo, Items: []workbench.WorkItem{loaded}},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:          []workbench.RepoRef{repo},
+		Reloader:       reloader,
+		InitialLoading: true,
+	}, fakeDelayedPreviewLoader(0))
+
+	if !start.workbenchLoading {
+		t.Fatalf("expected initial workbench loading state")
+	}
+	if got := strings.Join(start.workItemLines(80, false), "\n"); !strings.Contains(got, "loading workbench data") {
+		t.Fatalf("expected loading workbench line, got %q", got)
+	}
+
+	msg := requireWorkbenchReloadMsg(t, start.Init())
+	got, _ := start.Update(msg)
+	mm := got.(model)
+	if mm.workbenchLoading {
+		t.Fatalf("expected initial workbench load to finish")
+	}
+	if items := mm.visibleWorkItems(); len(items) != 1 || items[0].ID != loaded.ID {
+		t.Fatalf("expected loaded work item, got %+v", items)
+	}
+}
+
+func TestUpdate_RefreshKeepsPartialDataVisibleWhileLoading(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	item := workbench.WorkItem{
+		ID:     "branch:feature",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "feature"},
+	}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {Repo: repo, Items: []workbench.WorkItem{item}},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{item},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	mm := got.(model)
+	if !mm.workbenchLoading {
+		t.Fatalf("expected refresh loading state")
+	}
+	lines := strings.Join(mm.workItemLines(80, false), "\n")
+	if !strings.Contains(lines, "feature") {
+		t.Fatalf("expected existing partial data to remain visible, got %q", lines)
+	}
+	if !strings.Contains(strings.Join(mm.headerLines("gh-zen", 80), "\n"), "Reloading workbench data") {
+		t.Fatalf("expected refresh status in header")
+	}
+}
+
+func TestUpdate_ReloadPartialErrorsSetStatus(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	errorItem := workbench.WorkItem{
+		ID:     "local-discovery-error:" + repo.FullName(),
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "local discovery error"},
+		Local:  &workbench.LocalStatus{State: workbench.LocalUnknown, Summary: "local discovery failed: git failed"},
+	}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {Repo: repo, Items: []workbench.WorkItem{errorItem}},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:    []workbench.RepoRef{repo},
+		Reloader: reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	mm := got.(model)
+
+	if status := mm.statusMessage; status != "Workbench loaded with partial errors" {
+		t.Fatalf("expected partial error status, got %q", status)
+	}
+	if lines := strings.Join(mm.workItemLines(80, false), "\n"); !strings.Contains(lines, "local discovery error") {
+		t.Fatalf("expected error item to be visible, got %q", lines)
+	}
+}
+
+func TestHasWorkbenchErrorItems_UsesKnownErrorPrefixes(t *testing.T) {
+	if hasWorkbenchErrorItems([]workbench.WorkItem{{ID: "branch:error-handling"}}) {
+		t.Fatalf("expected normal branch IDs containing error not to count as partial errors")
+	}
+	if !hasWorkbenchErrorItems([]workbench.WorkItem{{ID: "repository-path-error:0maru/gh-zen"}}) {
+		t.Fatalf("expected repository path error item to count as a partial error")
 	}
 }
 
@@ -507,6 +617,9 @@ func TestNewWithWorkbenchData_EmptyDataDoesNotFallbackToFakeItems(t *testing.T) 
 	}
 	if got.preview.status != previewEmpty {
 		t.Fatalf("expected empty preview, got %v", got.preview.status)
+	}
+	if lines := strings.Join(got.workItemLines(80, false), "\n"); !strings.Contains(lines, "no live work items") {
+		t.Fatalf("expected live empty state, got %q", lines)
 	}
 }
 

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -443,7 +443,7 @@ func TestUpdate_OlderRefreshResultDoesNotClearNewerStatus(t *testing.T) {
 	}
 }
 
-func TestWorkbenchReloadCommandUsesTimeout(t *testing.T) {
+func TestWorkbenchReloadCommandDoesNotDeadlineFullReload(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	reloader := &fakeWorkbenchReloader{}
 	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
@@ -454,8 +454,8 @@ func TestWorkbenchReloadCommandUsesTimeout(t *testing.T) {
 	_, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	requireWorkbenchReloadMsg(t, cmd)
 
-	if len(reloader.deadlineSet) != 1 || !reloader.deadlineSet[0] {
-		t.Fatalf("expected reload context to have a deadline, got %+v", reloader.deadlineSet)
+	if len(reloader.deadlineSet) != 1 || reloader.deadlineSet[0] {
+		t.Fatalf("expected reload context without a deadline, got %+v", reloader.deadlineSet)
 	}
 }
 

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -227,6 +227,54 @@ func TestUpdate_RefreshPreservesCurrentSelectionAfterMove(t *testing.T) {
 	}
 }
 
+func TestUpdate_RefreshPreservesSelectedWorkItemRepo(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	repoAOriginal := workbench.WorkItem{
+		ID:       "branch:main",
+		Repo:     repoA,
+		Branch:   &workbench.BranchRef{Name: "main"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/gh-zen"},
+		Local:    &workbench.LocalStatus{State: workbench.LocalClean},
+	}
+	repoAReloaded := repoAOriginal
+	repoAReloaded.Local = &workbench.LocalStatus{State: workbench.LocalDirty, Summary: "1 status entry"}
+	repoBItem := workbench.WorkItem{
+		ID:       "branch:main",
+		Repo:     repoB,
+		Branch:   &workbench.BranchRef{Name: "main"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/dotfiles"},
+		Local:    &workbench.LocalStatus{State: workbench.LocalClean},
+	}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repoA.FullName(): {
+				Repo:  repoA,
+				Items: []workbench.WorkItem{repoAReloaded},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{repoAOriginal, repoBItem},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.setRepoPaneIndex(len(start.repos))
+	start.selectedItem = 1
+	start.focusedWorkItemID = repoBItem.ID
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	mm := got.(model)
+
+	if mm.selectedItem != 1 {
+		t.Fatalf("expected selected item to remain on repo B at index 1, got %d", mm.selectedItem)
+	}
+	if item, ok := mm.selectedWorkItem(); !ok || item.Repo != repoB || item.ID != repoBItem.ID {
+		t.Fatalf("expected selected work item %+v, got %+v ok=%v", repoBItem, item, ok)
+	}
+}
+
 func TestUpdate_StaleRefreshResultIsDiscarded(t *testing.T) {
 	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -315,6 +315,44 @@ func TestUpdate_StaleRefreshResultIsDiscarded(t *testing.T) {
 	}
 }
 
+func TestUpdate_StaleRefreshResultPreservesNewerStatus(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repoA.FullName(): {
+				Repo: repoA,
+				Items: []workbench.WorkItem{{
+					ID:     "branch:updated",
+					Repo:   repoA,
+					Branch: &workbench.BranchRef{Name: "updated"},
+				}},
+			},
+		},
+	}
+	original := workbench.WorkItem{ID: "branch:original", Repo: repoA, Branch: &workbench.BranchRef{Name: "original"}}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{original},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+	mm := got.(model)
+	mm.setRepoPaneIndex(1)
+	mm.statusMessage = "Copied PR URL"
+
+	got, cmd = mm.Update(msg)
+	if cmd != nil {
+		t.Fatalf("expected stale reload to skip preview command, got %T", cmd)
+	}
+	mm = got.(model)
+	if mm.statusMessage != "Copied PR URL" {
+		t.Fatalf("expected stale reload to preserve newer status, got %q", mm.statusMessage)
+	}
+}
+
 func TestUpdate_RefreshAppliesAfterViewSelectionChange(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	original := workbench.WorkItem{

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	cfgpkg "github.com/0maru/gh-zen/internal/config"
-	ghsvc "github.com/0maru/gh-zen/internal/github"
 	"github.com/0maru/gh-zen/internal/workbench"
 )
 
@@ -79,15 +78,28 @@ func (r *fakeActionRunner) Copy(_ context.Context, text string) error {
 	return r.err
 }
 
-func requireGitHubSummaryMsg(t *testing.T, cmd tea.Cmd) githubSummaryMsg {
+type fakeWorkbenchReloader struct {
+	results map[string]workbench.RuntimeLoadResult
+	calls   []workbench.RepoRef
+}
+
+func (r *fakeWorkbenchReloader) Load(_ context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
+	r.calls = append(r.calls, repo)
+	if result, ok := r.results[repo.FullName()]; ok {
+		return result
+	}
+	return workbench.RuntimeLoadResult{Repo: repo}
+}
+
+func requireWorkbenchReloadMsg(t *testing.T, cmd tea.Cmd) workbenchReloadMsg {
 	t.Helper()
 	if cmd == nil {
-		t.Fatalf("expected GitHub summary command, got nil")
+		t.Fatalf("expected workbench reload command, got nil")
 	}
 	msg := cmd()
-	result, ok := msg.(githubSummaryMsg)
+	result, ok := msg.(workbenchReloadMsg)
 	if !ok {
-		t.Fatalf("expected githubSummaryMsg, got %T", msg)
+		t.Fatalf("expected workbenchReloadMsg, got %T", msg)
 	}
 	return result
 }
@@ -98,42 +110,265 @@ func TestInit_ReturnsNilCmd(t *testing.T) {
 	}
 }
 
-func TestUpdate_RefreshLoadsGitHubSummary(t *testing.T) {
-	service := ghsvc.FakeService{
-		Summaries: map[string]ghsvc.RepositorySummary{
-			"0maru/gh-zen": {
-				Repo: "0maru/gh-zen",
-				PullRequests: []workbench.PullRequestRef{
-					{Number: 12, Title: "Add PR links", State: "open"},
-				},
-				Issues: []workbench.IssueRef{
-					{Number: 10, Title: "Config discovery", State: "open", Certain: true},
-				},
-				Checks: workbench.CheckSummary{State: workbench.CheckPassing, Passing: 2},
+func TestUpdate_RefreshReloadsWorkbenchData(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	original := workbench.WorkItem{
+		ID:     "branch:feature",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "feature"},
+		Local:  &workbench.LocalStatus{State: workbench.LocalClean},
+	}
+	reloaded := original
+	reloaded.Local = &workbench.LocalStatus{State: workbench.LocalDirty, Summary: "1 status entry"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{reloaded},
 			},
 		},
 	}
-	start := newModelWithGitHubService(service)
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{original},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
 
 	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	if cmd == nil {
 		t.Fatalf("expected refresh command")
 	}
+	if status := got.(model).statusMessage; status != "Reloading workbench data..." {
+		t.Fatalf("expected reload status, got %q", status)
+	}
 
-	msg := requireGitHubSummaryMsg(t, cmd)
+	msg := requireWorkbenchReloadMsg(t, cmd)
 	got, cmd = got.(model).Update(msg)
-	if cmd != nil {
-		t.Fatalf("expected nil command after GitHub summary, got %T", cmd)
+	if cmd == nil {
+		t.Fatalf("expected preview reload command")
 	}
 	mm := got.(model)
-	if mm.githubSummary.Repo != "0maru/gh-zen" {
-		t.Fatalf("expected GitHub summary repo, got %+v", mm.githubSummary)
+	if len(reloader.calls) != 1 || reloader.calls[0] != repo {
+		t.Fatalf("expected selected repo to reload, got %+v", reloader.calls)
 	}
-	if len(mm.githubSummary.PullRequests) != 1 || len(mm.githubSummary.Issues) != 1 {
-		t.Fatalf("expected PR and issue summaries, got %+v", mm.githubSummary)
+	items := mm.visibleWorkItems()
+	if len(items) != 1 || items[0].Local == nil || items[0].Local.State != workbench.LocalDirty {
+		t.Fatalf("expected reloaded work item, got %+v", items)
 	}
-	if mm.githubSummary.Checks.State != workbench.CheckPassing {
-		t.Fatalf("expected check summary, got %+v", mm.githubSummary.Checks)
+	if mm.selectedItem != 0 || mm.focusedWorkItemID != original.ID {
+		t.Fatalf("expected selection to remain on %q, got item=%d focused=%q", original.ID, mm.selectedItem, mm.focusedWorkItemID)
+	}
+	if status := mm.statusMessage; status != "Reloaded workbench data" {
+		t.Fatalf("expected reloaded status, got %q", status)
+	}
+}
+
+func TestUpdate_RefreshPreservesSelectedWorkItemID(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	first := workbench.WorkItem{ID: "branch:first", Repo: repo, Branch: &workbench.BranchRef{Name: "first"}}
+	second := workbench.WorkItem{ID: "branch:second", Repo: repo, Branch: &workbench.BranchRef{Name: "second"}}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{second, first},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{first, second},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.selectedItem = 1
+	start.focusedWorkItemID = second.ID
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	mm := got.(model)
+
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected selected item to follow stable ID to index 0, got %d", mm.selectedItem)
+	}
+	if item, ok := mm.selectedWorkItem(); !ok || item.ID != second.ID {
+		t.Fatalf("expected selected work item %q, got %+v ok=%v", second.ID, item, ok)
+	}
+}
+
+func TestUpdate_RefreshPreservesCurrentSelectionAfterMove(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	first := workbench.WorkItem{ID: "branch:first", Repo: repo, Branch: &workbench.BranchRef{Name: "first"}}
+	second := workbench.WorkItem{ID: "branch:second", Repo: repo, Branch: &workbench.BranchRef{Name: "second"}}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{first, second},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{first, second},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+	got, _ = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	got, _ = got.(model).Update(msg)
+	mm := got.(model)
+
+	if mm.selectedItem != 1 {
+		t.Fatalf("expected reload to keep moved selection at index 1, got %d", mm.selectedItem)
+	}
+	if item, ok := mm.selectedWorkItem(); !ok || item.ID != second.ID {
+		t.Fatalf("expected selected work item %q, got %+v ok=%v", second.ID, item, ok)
+	}
+}
+
+func TestUpdate_StaleRefreshResultIsDiscarded(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repoA.FullName(): {
+				Repo: repoA,
+				Items: []workbench.WorkItem{{
+					ID:     "branch:updated",
+					Repo:   repoA,
+					Branch: &workbench.BranchRef{Name: "updated"},
+				}},
+			},
+		},
+	}
+	original := workbench.WorkItem{ID: "branch:original", Repo: repoA, Branch: &workbench.BranchRef{Name: "original"}}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{original},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+	mm := got.(model)
+	mm.setRepoPaneIndex(1)
+
+	got, cmd = mm.Update(msg)
+	if cmd != nil {
+		t.Fatalf("expected stale reload to skip preview command, got %T", cmd)
+	}
+	mm = got.(model)
+	if len(mm.workItems) != 1 || mm.workItems[0].ID != original.ID {
+		t.Fatalf("expected stale reload not to replace work items, got %+v", mm.workItems)
+	}
+	if mm.statusMessage != "" {
+		t.Fatalf("expected stale reload to clear loading status, got %q", mm.statusMessage)
+	}
+}
+
+func TestUpdate_RefreshAppliesAfterViewSelectionChange(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	original := workbench.WorkItem{
+		ID:       "branch:feature",
+		Repo:     repo,
+		Branch:   &workbench.BranchRef{Name: "feature"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/feature"},
+		Local:    &workbench.LocalStatus{State: workbench.LocalClean},
+	}
+	reloaded := original
+	reloaded.Local = &workbench.LocalStatus{State: workbench.LocalDirty, Summary: "1 status entry"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{reloaded},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{original},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+	mm := got.(model)
+	mm.setRepoPaneIndex(len(mm.repos))
+
+	got, cmd = mm.Update(msg)
+	if cmd == nil {
+		t.Fatalf("expected view reload to start preview command")
+	}
+	mm = got.(model)
+	items := mm.visibleWorkItems()
+	if len(items) != 1 || items[0].Local == nil || items[0].Local.State != workbench.LocalDirty {
+		t.Fatalf("expected reload result to apply after view selection, got %+v", items)
+	}
+	if status := mm.statusMessage; status != "Reloaded workbench data" {
+		t.Fatalf("expected reloaded status, got %q", status)
+	}
+}
+
+func TestUpdate_OlderRefreshResultDoesNotClearNewerStatus(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	original := workbench.WorkItem{ID: "branch:original", Repo: repo, Branch: &workbench.BranchRef{Name: "original"}}
+	updated := workbench.WorkItem{ID: "branch:updated", Repo: repo, Branch: &workbench.BranchRef{Name: "updated"}}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{updated},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{original},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, firstCmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	firstMsg := requireWorkbenchReloadMsg(t, firstCmd)
+	got, secondCmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if secondCmd == nil {
+		t.Fatalf("expected second refresh command")
+	}
+	got, cmd := got.(model).Update(firstMsg)
+	if cmd != nil {
+		t.Fatalf("expected older reload result to skip preview command, got %T", cmd)
+	}
+	mm := got.(model)
+	if status := mm.statusMessage; status != "Reloading workbench data..." {
+		t.Fatalf("expected newer reload status to remain, got %q", status)
+	}
+	if len(mm.workItems) != 1 || mm.workItems[0].ID != original.ID {
+		t.Fatalf("expected older reload result not to replace work items, got %+v", mm.workItems)
+	}
+}
+
+func TestReplaceRepoWorkItems_PreservesRepositoryOrder(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	repoC := workbench.RepoRef{Owner: "0maru", Name: "notes"}
+	got := replaceRepoWorkItems([]workbench.WorkItem{
+		{ID: "a1", Repo: repoA},
+		{ID: "a2", Repo: repoA},
+		{ID: "b1", Repo: repoB},
+		{ID: "c1", Repo: repoC},
+	}, repoB, []workbench.WorkItem{
+		{ID: "b2", Repo: repoB},
+		{ID: "b3", Repo: repoB},
+	})
+
+	gotIDs := []string{}
+	for _, item := range got {
+		gotIDs = append(gotIDs, item.ID)
+	}
+	wantIDs := []string{"a1", "a2", "b2", "b3", "c1"}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Fatalf("expected replacement to preserve repo order %+v, got %+v", wantIDs, gotIDs)
 	}
 }
 

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -79,12 +79,15 @@ func (r *fakeActionRunner) Copy(_ context.Context, text string) error {
 }
 
 type fakeWorkbenchReloader struct {
-	results map[string]workbench.RuntimeLoadResult
-	calls   []workbench.RepoRef
+	results     map[string]workbench.RuntimeLoadResult
+	calls       []workbench.RepoRef
+	deadlineSet []bool
 }
 
-func (r *fakeWorkbenchReloader) Load(_ context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
+func (r *fakeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
 	r.calls = append(r.calls, repo)
+	_, hasDeadline := ctx.Deadline()
+	r.deadlineSet = append(r.deadlineSet, hasDeadline)
 	if result, ok := r.results[repo.FullName()]; ok {
 		return result
 	}
@@ -394,8 +397,27 @@ func TestUpdate_OlderRefreshResultDoesNotClearNewerStatus(t *testing.T) {
 	if status := mm.statusMessage; status != "Reloading workbench data..." {
 		t.Fatalf("expected newer reload status to remain, got %q", status)
 	}
+	if !mm.workbenchLoading {
+		t.Fatalf("expected newer reload loading state to remain")
+	}
 	if len(mm.workItems) != 1 || mm.workItems[0].ID != original.ID {
 		t.Fatalf("expected older reload result not to replace work items, got %+v", mm.workItems)
+	}
+}
+
+func TestWorkbenchReloadCommandUsesTimeout(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	reloader := &fakeWorkbenchReloader{}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:    []workbench.RepoRef{repo},
+		Reloader: reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	_, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	requireWorkbenchReloadMsg(t, cmd)
+
+	if len(reloader.deadlineSet) != 1 || !reloader.deadlineSet[0] {
+		t.Fatalf("expected reload context to have a deadline, got %+v", reloader.deadlineSet)
 	}
 }
 

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -16,6 +16,11 @@ type fakeRunner struct {
 	args   []string
 }
 
+type fakeRunnerByCommand struct {
+	outputs map[string][]byte
+	calls   [][]string
+}
+
 type fakeExitError struct {
 	code int
 }
@@ -31,6 +36,16 @@ func (e fakeExitError) ExitCode() int {
 func (r *fakeRunner) Run(_ context.Context, args ...string) ([]byte, error) {
 	r.args = append([]string(nil), args...)
 	return r.output, r.err
+}
+
+func (r *fakeRunnerByCommand) Run(_ context.Context, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, append([]string(nil), args...))
+	key := commandKey(args...)
+	output, ok := r.outputs[key]
+	if !ok {
+		return nil, errors.New("unexpected gh command: " + key)
+	}
+	return output, nil
 }
 
 func TestFakeService_ReturnsRepositorySummary(t *testing.T) {
@@ -125,6 +140,51 @@ func TestCLIService_CheckSummaryParsesGHOutput(t *testing.T) {
 	}
 }
 
+func TestCLIService_ProvidesDataForWorkbenchEnrichment(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	prFields := "number,title,state,url,headRefName,headRepositoryOwner,reviewDecision,closingIssuesReferences"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("pr", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", prFields):                    []byte(`[{"number":24,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/pull/24","headRefName":"feature/issue-123-runtime","headRepositoryOwner":{"login":"0maru"},"reviewDecision":"APPROVED","closingIssuesReferences":[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123"}]}]`),
+		commandKey("issue", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", "number,title,state,url"): []byte(`[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123"}]`),
+		commandKey("pr", "checks", "feature/issue-123-runtime", "--repo", repo.FullName(), "--json", "name,state"):                         []byte(`[{"name":"test","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]`),
+	}}
+	service := CLIService{Runner: runner}
+
+	prs, err := service.PullRequests(context.Background(), repo.FullName())
+	if err != nil {
+		t.Fatalf("expected pull requests to parse, got %v", err)
+	}
+	issues, err := service.Issues(context.Background(), repo.FullName())
+	if err != nil {
+		t.Fatalf("expected issues to parse, got %v", err)
+	}
+	checks, err := service.CheckSummary(context.Background(), repo.FullName(), "feature/issue-123-runtime")
+	if err != nil {
+		t.Fatalf("expected checks to parse, got %v", err)
+	}
+
+	items := workbench.LinkPullRequests([]workbench.WorkItem{{
+		ID:     "feature",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "feature/issue-123-runtime"},
+	}}, prs)
+	items = workbench.LinkIssues(items, issues)
+	items[0].Checks = checks
+
+	if items[0].PullRequest == nil || items[0].PullRequest.Number != 24 || items[0].PullRequest.ReviewState != "approved" {
+		t.Fatalf("expected CLI PR data to enrich work item, got %+v", items[0])
+	}
+	if items[0].Issue == nil || items[0].Issue.Number != 123 || items[0].Issue.Title != "Runtime pipeline" {
+		t.Fatalf("expected CLI issue data to enrich work item, got %+v", items[0])
+	}
+	if items[0].Checks.State != workbench.CheckPassing || items[0].Checks.Passing != 2 {
+		t.Fatalf("expected CLI check data to enrich work item, got %+v", items[0])
+	}
+	if len(runner.calls) != 3 {
+		t.Fatalf("expected three gh calls, got %#v", runner.calls)
+	}
+}
+
 func TestClassifyError(t *testing.T) {
 	err := classifyError("gh pr list", []byte("run gh auth login"), errors.New("exit status 1"))
 	if err.Kind != ErrorAuth {
@@ -150,6 +210,10 @@ func TestIsPendingChecksExit(t *testing.T) {
 	if isPendingChecksExit([]string{"pr", "list"}, fakeExitError{code: 8}) {
 		t.Fatal("expected exit 8 from a different gh command to remain an error")
 	}
+}
+
+func commandKey(args ...string) string {
+	return strings.Join(args, "\x00")
 }
 
 func hasArgPair(args []string, key string, value string) bool {

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -3,6 +3,7 @@ package workbench
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -199,6 +200,84 @@ func TestRuntimeLoader_ContinuesWhenSingleCheckFails(t *testing.T) {
 	}
 }
 
+func TestRuntimeLoader_WithTemporaryGitRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoDir := initLocalServiceRepo(t)
+	featureDir := filepath.Join(t.TempDir(), "feature")
+	runLocalServiceGit(t, repoDir, "worktree", "add", "-b", "feature/issue-123-runtime", featureDir)
+	writeLocalServiceFile(t, filepath.Join(featureDir, "dirty.txt"), "dirty\n")
+	runLocalServiceGit(t, repoDir, "update-ref", "refs/remotes/origin/remote-only", "HEAD")
+
+	result := RuntimeLoader{
+		Repo:     repo,
+		RepoPath: repoDir,
+		Local:    localrepo.Service{},
+		GitHub: fakeRuntimeGitHub{
+			prs: []PullRequestRef{{
+				Number:     24,
+				Title:      "Runtime pipeline",
+				State:      "open",
+				URL:        "https://example.test/pull/24",
+				HeadOwner:  "0maru",
+				HeadBranch: "feature/issue-123-runtime",
+				LinkedIssues: []IssueRef{{
+					Number:  123,
+					Certain: true,
+				}},
+			}},
+			issues: []IssueRef{{
+				Number:  123,
+				Title:   "Runtime pipeline",
+				State:   "open",
+				URL:     "https://example.test/issues/123",
+				Certain: true,
+			}},
+			checks: CheckSummary{State: CheckPassing, Passing: 3},
+		},
+	}.Load(context.Background())
+
+	if !hasWorkItem(result.Items, func(item WorkItem) bool {
+		return item.Worktree != nil &&
+			sameRuntimeTestPath(t, item.Worktree.Path, repoDir) &&
+			item.Branch != nil &&
+			item.Branch.Name == "main" &&
+			item.Local != nil &&
+			item.Local.State == LocalClean
+	}) {
+		t.Fatalf("expected clean main worktree item, got %+v", result.Items)
+	}
+	if !hasWorkItem(result.Items, func(item WorkItem) bool {
+		return item.Worktree != nil &&
+			sameRuntimeTestPath(t, item.Worktree.Path, featureDir) &&
+			item.Branch != nil &&
+			item.Branch.Name == "feature/issue-123-runtime" &&
+			item.Local != nil &&
+			item.Local.State == LocalDirty &&
+			item.PullRequest != nil &&
+			item.PullRequest.Number == 24 &&
+			item.Issue != nil &&
+			item.Issue.Number == 123 &&
+			item.Checks.State == CheckPassing &&
+			item.Checks.Passing == 3
+	}) {
+		t.Fatalf("expected dirty feature worktree enriched with PR, issue, and checks, got %+v", result.Items)
+	}
+	if !hasWorkItem(result.Items, func(item WorkItem) bool {
+		return item.Worktree == nil &&
+			item.Branch != nil &&
+			item.Branch.Name == "remote-only" &&
+			item.Branch.RemoteOnly &&
+			item.Local != nil &&
+			item.Local.State == LocalMissing
+	}) {
+		t.Fatalf("expected remote-only branch item, got %+v", result.Items)
+	}
+}
+
 func hasRuntimeErrorItem(items []WorkItem, prefix string, detail string) bool {
 	return hasWorkItem(items, func(item WorkItem) bool {
 		return item.Local != nil &&
@@ -214,4 +293,17 @@ func runtimeWorkItemByBranch(items []WorkItem, branch string) *WorkItem {
 		}
 	}
 	return nil
+}
+
+func sameRuntimeTestPath(t *testing.T, got string, want string) bool {
+	t.Helper()
+	gotResolved, err := filepath.EvalSymlinks(got)
+	if err != nil {
+		t.Fatalf("resolve got path %q: %v", got, err)
+	}
+	wantResolved, err := filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatalf("resolve want path %q: %v", want, err)
+	}
+	return gotResolved == wantResolved
 }

--- a/main.go
+++ b/main.go
@@ -38,33 +38,48 @@ func run() error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	data := loadStartupWorkbenchData(ctx, loadResult.Config, startupRepo)
+	reloader := runtimeWorkbenchReloader{config: loadResult.Config}
+	data := loadStartupWorkbenchData(ctx, startupRepo, reloader)
 
 	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
 	return err
 }
 
-func loadStartupWorkbenchData(ctx context.Context, cfg config.Config, startupRepo config.StartupRepository) app.WorkbenchData {
-	repo, ok := repoRefFromFullName(startupRepo.Repo)
-	if !ok {
-		return app.WorkbenchData{}
-	}
+type runtimeWorkbenchReloader struct {
+	config config.Config
+}
 
-	data := app.WorkbenchData{Repos: []workbench.RepoRef{repo}}
+func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
 	resolvedPath := config.ResolveRepositoryPath(config.RepositoryPathOptions{
-		Repo:   startupRepo.Repo,
-		Config: cfg,
+		Repo:   repo.FullName(),
+		Config: r.config,
 	})
 	if resolvedPath.Path == "" {
-		return data
+		return workbench.RuntimeLoadResult{Repo: repo}
 	}
-
-	result := (workbench.RuntimeLoader{
+	return (workbench.RuntimeLoader{
 		Repo:     repo,
 		RepoPath: resolvedPath.Path,
 		Local:    localrepo.Service{},
 		GitHub:   github.CLIService{},
 	}).Load(ctx)
+}
+
+func loadStartupWorkbenchData(ctx context.Context, startupRepo config.StartupRepository, reloader app.WorkbenchReloader) app.WorkbenchData {
+	repo, ok := repoRefFromFullName(startupRepo.Repo)
+	if !ok {
+		return app.WorkbenchData{}
+	}
+
+	data := app.WorkbenchData{
+		Repos:    []workbench.RepoRef{repo},
+		Reloader: reloader,
+	}
+	if reloader == nil {
+		return data
+	}
+
+	result := reloader.Load(ctx, repo)
 	data.WorkItems = result.Items
 	return data
 }

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -36,10 +35,8 @@ func run() error {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	reloader := runtimeWorkbenchReloader{config: loadResult.Config}
-	data := loadStartupWorkbenchData(ctx, startupRepo, reloader)
+	data := loadStartupWorkbenchData(startupRepo, reloader)
 
 	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
 	return err
@@ -55,7 +52,10 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 		Config: r.config,
 	})
 	if resolvedPath.Path == "" {
-		return workbench.RuntimeLoadResult{Repo: repo}
+		return workbench.RuntimeLoadResult{
+			Repo:  repo,
+			Items: []workbench.WorkItem{repositoryPathErrorItem(repo, resolvedPath.Diagnostics)},
+		}
 	}
 	return (workbench.RuntimeLoader{
 		Repo:     repo,
@@ -65,23 +65,47 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 	}).Load(ctx)
 }
 
-func loadStartupWorkbenchData(ctx context.Context, startupRepo config.StartupRepository, reloader app.WorkbenchReloader) app.WorkbenchData {
+func loadStartupWorkbenchData(startupRepo config.StartupRepository, reloader app.WorkbenchReloader) app.WorkbenchData {
 	repo, ok := repoRefFromFullName(startupRepo.Repo)
 	if !ok {
 		return app.WorkbenchData{}
 	}
 
 	data := app.WorkbenchData{
-		Repos:    []workbench.RepoRef{repo},
-		Reloader: reloader,
+		Repos:          []workbench.RepoRef{repo},
+		Reloader:       reloader,
+		InitialLoading: reloader != nil,
 	}
-	if reloader == nil {
-		return data
-	}
-
-	result := reloader.Load(ctx, repo)
-	data.WorkItems = result.Items
 	return data
+}
+
+func repositoryPathErrorItem(repo workbench.RepoRef, diagnostics []config.Diagnostic) workbench.WorkItem {
+	summary := "repository path resolution failed"
+	if len(diagnostics) > 0 {
+		summary += ": " + diagnosticSummary(diagnostics)
+	}
+	return workbench.WorkItem{
+		ID:     "repository-path-error:" + repo.FullName(),
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "repository path error"},
+		Local: &workbench.LocalStatus{
+			State:   workbench.LocalUnknown,
+			Summary: summary,
+		},
+		Checks: workbench.CheckSummary{State: workbench.CheckUnknown},
+	}
+}
+
+func diagnosticSummary(diagnostics []config.Diagnostic) string {
+	parts := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Path == "" {
+			parts = append(parts, diagnostic.Message)
+			continue
+		}
+		parts = append(parts, diagnostic.Path+": "+diagnostic.Message)
+	}
+	return strings.Join(parts, "; ")
 }
 
 func repoRefFromFullName(repoName string) (workbench.RepoRef, bool) {


### PR DESCRIPTION
## Summary

- Integrate the remaining runtime workbench changes into main.
- Reload the full live workbench pipeline on refresh while preserving selection and ignoring stale responses.
- Add explicit loading, empty, and partial-error UI states for live data.
- Add live-data validation coverage and manual smoke documentation.

## Validation

- make check
- pre-push hook: test-medium
- PR #57-#60 CI and claude-review passed before this integration PR.

Closes #41
Closes #42
Closes #43