### PR TITLE
Clarify installation before first release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,19 @@
 
 ## Installation
 
-Install the latest release with GitHub CLI:
+Install the latest published release with GitHub CLI:
 
 ```sh
 gh extension install 0maru/gh-zen
+```
+
+Until the first release is published, install this repository as a local
+extension:
+
+```sh
+git clone https://github.com/0maru/gh-zen
+cd gh-zen
+make install-extension
 ```
 
 Run it with:


### PR DESCRIPTION
## Summary

- Clarify that  installs a published release.
- Add the local checkout installation path for use before the first release exists.

## Validation

- git diff --check
- pre-commit hook: lint, test-small
- pre-push hook: test-medium