### PR TITLE
Create PR-backed review work items

### DIFF
--- a/internal/github/fake.go
+++ b/internal/github/fake.go
@@ -12,6 +12,7 @@ type FakeService struct {
 	PullRequestsByRepo map[string][]workbench.PullRequestRef
 	IssuesByRepo       map[string][]workbench.IssueRef
 	Checks             map[string]workbench.CheckSummary
+	ReviewSubjects     workbench.ReviewSubjects
 	Err                error
 }
 
@@ -57,6 +58,13 @@ func (f FakeService) CheckSummary(_ context.Context, repo string, ref string) (w
 		return summary, nil
 	}
 	return workbench.CheckSummary{State: workbench.CheckUnknown}, nil
+}
+
+func (f FakeService) ViewerReviewSubjects(context.Context) (workbench.ReviewSubjects, error) {
+	if f.Err != nil {
+		return workbench.ReviewSubjects{}, f.Err
+	}
+	return f.ReviewSubjects, nil
 }
 
 func (f FakeService) PullRequestsForRepo(repo string) ([]workbench.PullRequestRef, error) {

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/0maru/gh-zen/internal/workbench"
@@ -17,6 +19,7 @@ type Service interface {
 	PullRequests(ctx context.Context, repo string) ([]workbench.PullRequestRef, error)
 	Issues(ctx context.Context, repo string) ([]workbench.IssueRef, error)
 	CheckSummary(ctx context.Context, repo string, ref string) (workbench.CheckSummary, error)
+	ViewerReviewSubjects(ctx context.Context) (workbench.ReviewSubjects, error)
 }
 
 // RepositorySummary contains lightweight GitHub data for a repository refresh.
@@ -48,7 +51,14 @@ const (
 	ErrorNetwork ErrorKind = "network"
 	ErrorCommand ErrorKind = "command"
 
-	listLimit = "1000"
+	issueListFields = "number,title,state,url,body,labels,assignees,milestone,updatedAt"
+	listLimit       = "1000"
+	prListFields    = "number,title,state,url,headRefName,headRepositoryOwner,baseRefName,isDraft,updatedAt,author,reviewRequests,latestReviews,reviewDecision,body"
+)
+
+var (
+	closingIssueTextPattern = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[^\n\r.]*`)
+	issueNumberPattern      = regexp.MustCompile(`#(\d+)`)
 )
 
 // Error describes a gh-backed service failure.
@@ -104,7 +114,7 @@ func (s CLIService) RepositorySummary(ctx context.Context, repo string) (Reposit
 
 // PullRequests loads pull request summaries through gh.
 func (s CLIService) PullRequests(ctx context.Context, repo string) ([]workbench.PullRequestRef, error) {
-	output, err := s.runner().Run(ctx, "pr", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", "number,title,state,url,headRefName,headRepositoryOwner,reviewDecision,closingIssuesReferences")
+	output, err := s.runner().Run(ctx, "pr", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", prListFields)
 	if err != nil {
 		return nil, err
 	}
@@ -114,16 +124,17 @@ func (s CLIService) PullRequests(ctx context.Context, repo string) ([]workbench.
 		State               string `json:"state"`
 		URL                 string `json:"url"`
 		HeadRefName         string `json:"headRefName"`
+		BaseRefName         string `json:"baseRefName"`
+		IsDraft             bool   `json:"isDraft"`
+		UpdatedAt           string `json:"updatedAt"`
+		Body                string `json:"body"`
+		Author              ghUser `json:"author"`
 		HeadRepositoryOwner struct {
 			Login string `json:"login"`
 		} `json:"headRepositoryOwner"`
-		ReviewDecision string `json:"reviewDecision"`
-		ClosingIssues  []struct {
-			Number int    `json:"number"`
-			Title  string `json:"title"`
-			State  string `json:"state"`
-			URL    string `json:"url"`
-		} `json:"closingIssuesReferences"`
+		ReviewDecision string             `json:"reviewDecision"`
+		ReviewRequests []ghReviewRequest  `json:"reviewRequests"`
+		LatestReviews  []ghPullReviewItem `json:"latestReviews"`
 	}
 	if err := json.Unmarshal(output, &payload); err != nil {
 		return nil, fmt.Errorf("parse gh pr list output: %w", err)
@@ -131,14 +142,20 @@ func (s CLIService) PullRequests(ctx context.Context, repo string) ([]workbench.
 	prs := make([]workbench.PullRequestRef, 0, len(payload))
 	for _, pr := range payload {
 		prs = append(prs, workbench.PullRequestRef{
-			Number:       pr.Number,
-			Title:        pr.Title,
-			State:        strings.ToLower(pr.State),
-			URL:          pr.URL,
-			HeadOwner:    pr.HeadRepositoryOwner.Login,
-			HeadBranch:   pr.HeadRefName,
-			LinkedIssues: linkedIssues(pr.ClosingIssues),
-			ReviewState:  reviewState(pr.ReviewDecision),
+			Number:         pr.Number,
+			Title:          pr.Title,
+			State:          strings.ToLower(pr.State),
+			URL:            pr.URL,
+			AuthorLogin:    pr.Author.Login,
+			HeadOwner:      pr.HeadRepositoryOwner.Login,
+			HeadBranch:     pr.HeadRefName,
+			BaseBranch:     pr.BaseRefName,
+			IsDraft:        pr.IsDraft,
+			UpdatedAt:      pr.UpdatedAt,
+			LinkedIssues:   linkedIssuesFromBody(pr.Body),
+			ReviewState:    reviewState(pr.ReviewDecision),
+			ReviewRequests: reviewRequests(pr.ReviewRequests),
+			LatestReviews:  latestReviews(pr.LatestReviews),
 		})
 	}
 	return prs, nil
@@ -146,15 +163,22 @@ func (s CLIService) PullRequests(ctx context.Context, repo string) ([]workbench.
 
 // Issues loads issue summaries through gh.
 func (s CLIService) Issues(ctx context.Context, repo string) ([]workbench.IssueRef, error) {
-	output, err := s.runner().Run(ctx, "issue", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", "number,title,state,url")
+	output, err := s.runner().Run(ctx, "issue", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", issueListFields)
 	if err != nil {
 		return nil, err
 	}
 	var payload []struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		State  string `json:"state"`
-		URL    string `json:"url"`
+		Number    int       `json:"number"`
+		Title     string    `json:"title"`
+		State     string    `json:"state"`
+		URL       string    `json:"url"`
+		Body      string    `json:"body"`
+		Labels    []ghLabel `json:"labels"`
+		Assignees []ghUser  `json:"assignees"`
+		Milestone *struct {
+			Title string `json:"title"`
+		} `json:"milestone"`
+		UpdatedAt string `json:"updatedAt"`
 	}
 	if err := json.Unmarshal(output, &payload); err != nil {
 		return nil, fmt.Errorf("parse gh issue list output: %w", err)
@@ -195,6 +219,22 @@ func (s CLIService) CheckSummary(ctx context.Context, repo string, ref string) (
 	return summarizeCheckStates(states), nil
 }
 
+// ViewerReviewSubjects loads the authenticated viewer and team slugs used for review request matching.
+func (s CLIService) ViewerReviewSubjects(ctx context.Context) (workbench.ReviewSubjects, error) {
+	output, err := s.runner().Run(ctx, "api", "user", "--jq", ".login")
+	if err != nil {
+		return workbench.ReviewSubjects{}, err
+	}
+	subjects := workbench.ReviewSubjects{Login: strings.TrimSpace(string(output))}
+
+	output, err = s.runner().Run(ctx, "api", "user/teams", "--jq", ".[].slug")
+	if err != nil {
+		return subjects, err
+	}
+	subjects.TeamSlugs = nonEmptyLines(string(output))
+	return subjects, nil
+}
+
 func (s CLIService) runner() Runner {
 	if s.Runner != nil {
 		return s.Runner
@@ -202,23 +242,122 @@ func (s CLIService) runner() Runner {
 	return GHRunner{}
 }
 
-func linkedIssues(payload []struct {
-	Number int    `json:"number"`
-	Title  string `json:"title"`
+type ghUser struct {
+	Login string `json:"login"`
+}
+
+type ghLabel struct {
+	Name string `json:"name"`
+}
+
+type ghReviewRequest struct {
+	TypeName string `json:"__typename"`
+	Login    string `json:"login"`
+	Name     string `json:"name"`
+	Slug     string `json:"slug"`
+}
+
+type ghPullReviewItem struct {
+	Author ghUser `json:"author"`
 	State  string `json:"state"`
-	URL    string `json:"url"`
-}) []workbench.IssueRef {
-	issues := make([]workbench.IssueRef, 0, len(payload))
-	for _, issue := range payload {
-		issues = append(issues, workbench.IssueRef{
-			Number:  issue.Number,
-			Title:   issue.Title,
-			State:   strings.ToLower(issue.State),
-			URL:     issue.URL,
-			Certain: true,
-		})
+}
+
+func linkedIssuesFromBody(body string) []workbench.IssueRef {
+	seen := map[int]bool{}
+	issues := []workbench.IssueRef{}
+	for _, text := range closingIssueTextPattern.FindAllString(body, -1) {
+		for _, match := range issueNumberPattern.FindAllStringSubmatch(text, -1) {
+			if len(match) < 2 {
+				continue
+			}
+			number, err := strconv.Atoi(match[1])
+			if err != nil || seen[number] {
+				continue
+			}
+			issues = append(issues, workbench.IssueRef{
+				Number:  number,
+				Certain: true,
+			})
+			seen[number] = true
+		}
 	}
 	return issues
+}
+
+func labelNames(labels []ghLabel) []string {
+	names := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if label.Name != "" {
+			names = append(names, label.Name)
+		}
+	}
+	return names
+}
+
+func userLogins(users []ghUser) []string {
+	logins := make([]string, 0, len(users))
+	for _, user := range users {
+		if user.Login != "" {
+			logins = append(logins, user.Login)
+		}
+	}
+	return logins
+}
+
+func milestoneTitle(milestone *struct {
+	Title string `json:"title"`
+}) string {
+	if milestone == nil {
+		return ""
+	}
+	return milestone.Title
+}
+
+func reviewRequests(payload []ghReviewRequest) []workbench.ReviewRequestRef {
+	requests := make([]workbench.ReviewRequestRef, 0, len(payload))
+	for _, request := range payload {
+		requests = append(requests, workbench.ReviewRequestRef{
+			Kind:  request.TypeName,
+			Login: request.Login,
+			Name:  reviewRequestName(request),
+			Slug:  request.Slug,
+		})
+	}
+	return requests
+}
+
+func reviewRequestName(request ghReviewRequest) string {
+	switch {
+	case request.Name != "":
+		return request.Name
+	case request.Slug != "":
+		return request.Slug
+	default:
+		return request.Login
+	}
+}
+
+func latestReviews(payload []ghPullReviewItem) []workbench.PullRequestReviewRef {
+	reviews := make([]workbench.PullRequestReviewRef, 0, len(payload))
+	for _, review := range payload {
+		reviews = append(reviews, workbench.PullRequestReviewRef{
+			AuthorLogin: review.Author.Login,
+			State:       reviewState(review.State),
+		})
+	}
+	return reviews
+}
+
+func nonEmptyLines(value string) []string {
+	lines := strings.Split(value, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
 }
 
 func isPendingChecksExit(args []string, err error) bool {

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -54,6 +54,29 @@ const (
 	issueListFields = "number,title,state,url,body,labels,assignees,milestone,updatedAt"
 	listLimit       = "1000"
 	prListFields    = "number,title,state,url,headRefName,headRepositoryOwner,baseRefName,isDraft,updatedAt,author,reviewRequests,latestReviews,reviewDecision,body"
+
+	pullRequestClosingIssuesQuery = `
+query($owner:String!, $name:String!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequests(first:100, after:$after, states:[OPEN, CLOSED, MERGED], orderBy:{field:UPDATED_AT, direction:DESC}) {
+      nodes {
+        number
+        closingIssuesReferences(first:20) {
+          nodes {
+            number
+            title
+            state
+            url
+          }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}`
 )
 
 var (
@@ -139,6 +162,8 @@ func (s CLIService) PullRequests(ctx context.Context, repo string) ([]workbench.
 	if err := json.Unmarshal(output, &payload); err != nil {
 		return nil, fmt.Errorf("parse gh pr list output: %w", err)
 	}
+	closingIssuesByPR, _ := s.pullRequestClosingIssues(ctx, repo)
+
 	prs := make([]workbench.PullRequestRef, 0, len(payload))
 	for _, pr := range payload {
 		prs = append(prs, workbench.PullRequestRef{
@@ -152,7 +177,7 @@ func (s CLIService) PullRequests(ctx context.Context, repo string) ([]workbench.
 			BaseBranch:     pr.BaseRefName,
 			IsDraft:        pr.IsDraft,
 			UpdatedAt:      pr.UpdatedAt,
-			LinkedIssues:   linkedIssuesFromBody(pr.Body),
+			LinkedIssues:   linkedIssues(closingIssuesByPR[pr.Number], pr.Body),
 			ReviewState:    reviewState(pr.ReviewDecision),
 			ReviewRequests: reviewRequests(pr.ReviewRequests),
 			LatestReviews:  latestReviews(pr.LatestReviews),
@@ -186,11 +211,16 @@ func (s CLIService) Issues(ctx context.Context, repo string) ([]workbench.IssueR
 	issues := make([]workbench.IssueRef, 0, len(payload))
 	for _, issue := range payload {
 		issues = append(issues, workbench.IssueRef{
-			Number:  issue.Number,
-			Title:   issue.Title,
-			State:   strings.ToLower(issue.State),
-			URL:     issue.URL,
-			Certain: true,
+			Number:    issue.Number,
+			Title:     issue.Title,
+			State:     strings.ToLower(issue.State),
+			URL:       issue.URL,
+			Body:      issue.Body,
+			Labels:    labelNames(issue.Labels),
+			Assignees: userLogins(issue.Assignees),
+			Milestone: milestoneTitle(issue.Milestone),
+			UpdatedAt: issue.UpdatedAt,
+			Certain:   true,
 		})
 	}
 	return issues, nil
@@ -235,6 +265,55 @@ func (s CLIService) ViewerReviewSubjects(ctx context.Context) (workbench.ReviewS
 	return subjects, nil
 }
 
+func (s CLIService) pullRequestClosingIssues(ctx context.Context, repo string) (map[int][]workbench.IssueRef, error) {
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" {
+		return nil, nil
+	}
+
+	issuesByPR := map[int][]workbench.IssueRef{}
+	after := ""
+	for {
+		output, err := s.runner().Run(ctx, "api", "graphql", "-f", "owner="+owner, "-f", "name="+name, "-f", "after="+after, "-f", "query="+pullRequestClosingIssuesQuery)
+		if err != nil {
+			return issuesByPR, err
+		}
+		var payload struct {
+			Data struct {
+				Repository struct {
+					PullRequests struct {
+						Nodes []struct {
+							Number        int `json:"number"`
+							ClosingIssues struct {
+								Nodes []ghIssue `json:"nodes"`
+							} `json:"closingIssuesReferences"`
+						} `json:"nodes"`
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
+					} `json:"pullRequests"`
+				} `json:"repository"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(output, &payload); err != nil {
+			return issuesByPR, fmt.Errorf("parse gh pull request closing issues output: %w", err)
+		}
+		for _, pr := range payload.Data.Repository.PullRequests.Nodes {
+			if pr.Number > 0 {
+				issuesByPR[pr.Number] = issuesFromGraphQL(pr.ClosingIssues.Nodes)
+			}
+		}
+		if !payload.Data.Repository.PullRequests.PageInfo.HasNextPage {
+			return issuesByPR, nil
+		}
+		after = payload.Data.Repository.PullRequests.PageInfo.EndCursor
+		if after == "" {
+			return issuesByPR, nil
+		}
+	}
+}
+
 func (s CLIService) runner() Runner {
 	if s.Runner != nil {
 		return s.Runner
@@ -250,6 +329,13 @@ type ghLabel struct {
 	Name string `json:"name"`
 }
 
+type ghIssue struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+	URL    string `json:"url"`
+}
+
 type ghReviewRequest struct {
 	TypeName string `json:"__typename"`
 	Login    string `json:"login"`
@@ -260,6 +346,38 @@ type ghReviewRequest struct {
 type ghPullReviewItem struct {
 	Author ghUser `json:"author"`
 	State  string `json:"state"`
+}
+
+func linkedIssues(closingIssues []workbench.IssueRef, body string) []workbench.IssueRef {
+	issues := append([]workbench.IssueRef(nil), closingIssues...)
+	seen := map[int]bool{}
+	for _, issue := range issues {
+		if issue.Number > 0 {
+			seen[issue.Number] = true
+		}
+	}
+	for _, issue := range linkedIssuesFromBody(body) {
+		if issue.Number == 0 || seen[issue.Number] {
+			continue
+		}
+		issues = append(issues, issue)
+		seen[issue.Number] = true
+	}
+	return issues
+}
+
+func issuesFromGraphQL(payload []ghIssue) []workbench.IssueRef {
+	issues := make([]workbench.IssueRef, 0, len(payload))
+	for _, issue := range payload {
+		issues = append(issues, workbench.IssueRef{
+			Number:  issue.Number,
+			Title:   issue.Title,
+			State:   strings.ToLower(issue.State),
+			URL:     issue.URL,
+			Certain: true,
+		})
+	}
+	return issues
 }
 
 func linkedIssuesFromBody(body string) []workbench.IssueRef {

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -71,7 +71,7 @@ func TestFakeService_ReturnsRepositorySummary(t *testing.T) {
 }
 
 func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
-	runner := &fakeRunner{output: []byte(`[{"number":12,"title":"Add feature","state":"OPEN","url":"https://example.test/pr/12","headRefName":"feature","headRepositoryOwner":{"login":"0maru"},"reviewDecision":"REVIEW_REQUIRED","closingIssuesReferences":[{"number":9,"title":"Issue","state":"OPEN","url":"https://example.test/issues/9"}]}]`)}
+	runner := &fakeRunner{output: []byte(`[{"number":12,"title":"Add feature","state":"OPEN","url":"https://example.test/pr/12","author":{"login":"0maru"},"headRefName":"feature","headRepositoryOwner":{"login":"0maru"},"baseRefName":"main","isDraft":false,"updatedAt":"2026-05-03T12:00:00Z","reviewDecision":"REVIEW_REQUIRED","reviewRequests":[{"__typename":"User","login":"alice","name":"Alice"},{"__typename":"Team","slug":"core","name":"Core"}],"latestReviews":[{"author":{"login":"bob"},"state":"APPROVED"}],"body":"Fixes #9"}]`)}
 	service := CLIService{Runner: runner}
 
 	got, err := service.PullRequests(context.Background(), "0maru/gh-zen")
@@ -79,16 +79,26 @@ func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
 		t.Fatalf("expected pull requests to parse, got %v", err)
 	}
 	want := []workbench.PullRequestRef{{
-		Number:     12,
-		Title:      "Add feature",
-		State:      "open",
-		URL:        "https://example.test/pr/12",
-		HeadOwner:  "0maru",
-		HeadBranch: "feature",
+		Number:      12,
+		Title:       "Add feature",
+		State:       "open",
+		URL:         "https://example.test/pr/12",
+		AuthorLogin: "0maru",
+		HeadOwner:   "0maru",
+		HeadBranch:  "feature",
+		BaseBranch:  "main",
+		UpdatedAt:   "2026-05-03T12:00:00Z",
 		LinkedIssues: []workbench.IssueRef{
-			{Number: 9, Title: "Issue", State: "open", URL: "https://example.test/issues/9", Certain: true},
+			{Number: 9, Certain: true},
 		},
 		ReviewState: "review required",
+		ReviewRequests: []workbench.ReviewRequestRef{
+			{Kind: "User", Login: "alice", Name: "Alice"},
+			{Kind: "Team", Name: "Core", Slug: "core"},
+		},
+		LatestReviews: []workbench.PullRequestReviewRef{
+			{AuthorLogin: "bob", State: "approved"},
+		},
 	}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected %+v, got %+v", want, got)
@@ -99,13 +109,13 @@ func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
 	if !hasArgPair(runner.args, "--limit", listLimit) {
 		t.Fatalf("expected gh pr list limit, got %#v", runner.args)
 	}
-	if !hasArgValue(runner.args, "number,title,state,url,headRefName,headRepositoryOwner,reviewDecision,closingIssuesReferences") {
+	if !hasArgValue(runner.args, prListFields) {
 		t.Fatalf("expected gh pr list to request head repository owner, got %#v", runner.args)
 	}
 }
 
 func TestCLIService_IssuesParsesGHOutput(t *testing.T) {
-	runner := &fakeRunner{output: []byte(`[{"number":9,"title":"Config","state":"OPEN","url":"https://example.test/issues/9"}]`)}
+	runner := &fakeRunner{output: []byte(`[{"number":9,"title":"Config","state":"OPEN","url":"https://example.test/issues/9","body":"Issue details","labels":[{"name":"enhancement"}],"assignees":[{"login":"0maru"}],"milestone":{"title":"v1"},"updatedAt":"2026-05-03T12:00:00Z"}]`)}
 	service := CLIService{Runner: runner}
 
 	got, err := service.Issues(context.Background(), "0maru/gh-zen")
@@ -140,13 +150,29 @@ func TestCLIService_CheckSummaryParsesGHOutput(t *testing.T) {
 	}
 }
 
+func TestCLIService_ViewerReviewSubjectsParsesGHOutput(t *testing.T) {
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("api", "user", "--jq", ".login"):         []byte("0maru\n"),
+		commandKey("api", "user/teams", "--jq", ".[].slug"): []byte("frontend\nplatform\n"),
+	}}
+	service := CLIService{Runner: runner}
+
+	got, err := service.ViewerReviewSubjects(context.Background())
+	if err != nil {
+		t.Fatalf("expected viewer subjects to parse, got %v", err)
+	}
+	want := workbench.ReviewSubjects{Login: "0maru", TeamSlugs: []string{"frontend", "platform"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %+v, got %+v", want, got)
+	}
+}
+
 func TestCLIService_ProvidesDataForWorkbenchEnrichment(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
-	prFields := "number,title,state,url,headRefName,headRepositoryOwner,reviewDecision,closingIssuesReferences"
 	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
-		commandKey("pr", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", prFields):                    []byte(`[{"number":24,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/pull/24","headRefName":"feature/issue-123-runtime","headRepositoryOwner":{"login":"0maru"},"reviewDecision":"APPROVED","closingIssuesReferences":[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123"}]}]`),
-		commandKey("issue", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", "number,title,state,url"): []byte(`[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123"}]`),
-		commandKey("pr", "checks", "feature/issue-123-runtime", "--repo", repo.FullName(), "--json", "name,state"):                         []byte(`[{"name":"test","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]`),
+		commandKey("pr", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", prListFields):       []byte(`[{"number":24,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/pull/24","author":{"login":"0maru"},"headRefName":"feature/issue-123-runtime","headRepositoryOwner":{"login":"0maru"},"baseRefName":"main","isDraft":false,"updatedAt":"2026-05-03T12:00:00Z","reviewDecision":"APPROVED","reviewRequests":[],"latestReviews":[],"body":"Closes #123"}]`),
+		commandKey("issue", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", issueListFields): []byte(`[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123","body":"Runtime issue","labels":[],"assignees":[],"milestone":null,"updatedAt":"2026-05-03T12:00:00Z"}]`),
+		commandKey("pr", "checks", "feature/issue-123-runtime", "--repo", repo.FullName(), "--json", "name,state"):                []byte(`[{"name":"test","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]`),
 	}}
 	service := CLIService{Runner: runner}
 

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -71,10 +71,14 @@ func TestFakeService_ReturnsRepositorySummary(t *testing.T) {
 }
 
 func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
-	runner := &fakeRunner{output: []byte(`[{"number":12,"title":"Add feature","state":"OPEN","url":"https://example.test/pr/12","author":{"login":"0maru"},"headRefName":"feature","headRepositoryOwner":{"login":"0maru"},"baseRefName":"main","isDraft":false,"updatedAt":"2026-05-03T12:00:00Z","reviewDecision":"REVIEW_REQUIRED","reviewRequests":[{"__typename":"User","login":"alice","name":"Alice"},{"__typename":"Team","slug":"core","name":"Core"}],"latestReviews":[{"author":{"login":"bob"},"state":"APPROVED"}],"body":"Fixes #9"}]`)}
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("pr", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", prListFields):                             []byte(`[{"number":12,"title":"Add feature","state":"OPEN","url":"https://example.test/pr/12","author":{"login":"0maru"},"headRefName":"feature","headRepositoryOwner":{"login":"0maru"},"baseRefName":"main","isDraft":false,"updatedAt":"2026-05-03T12:00:00Z","reviewDecision":"REVIEW_REQUIRED","reviewRequests":[{"__typename":"User","login":"alice","name":"Alice"},{"__typename":"Team","slug":"core","name":"Core"}],"latestReviews":[{"author":{"login":"bob"},"state":"APPROVED"}],"body":"No closing keyword"}]`),
+		commandKey("api", "graphql", "-f", "owner=0maru", "-f", "name=gh-zen", "-f", "after=", "-f", "query="+pullRequestClosingIssuesQuery): []byte(`{"data":{"repository":{"pullRequests":{"nodes":[{"number":12,"closingIssuesReferences":{"nodes":[{"number":9,"title":"Issue","state":"OPEN","url":"https://example.test/issues/9"}]}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`),
+	}}
 	service := CLIService{Runner: runner}
 
-	got, err := service.PullRequests(context.Background(), "0maru/gh-zen")
+	got, err := service.PullRequests(context.Background(), repo)
 	if err != nil {
 		t.Fatalf("expected pull requests to parse, got %v", err)
 	}
@@ -89,7 +93,7 @@ func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
 		BaseBranch:  "main",
 		UpdatedAt:   "2026-05-03T12:00:00Z",
 		LinkedIssues: []workbench.IssueRef{
-			{Number: 9, Certain: true},
+			{Number: 9, Title: "Issue", State: "open", URL: "https://example.test/issues/9", Certain: true},
 		},
 		ReviewState: "review required",
 		ReviewRequests: []workbench.ReviewRequestRef{
@@ -103,14 +107,14 @@ func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected %+v, got %+v", want, got)
 	}
-	if !reflect.DeepEqual(runner.args[:4], []string{"pr", "list", "--repo", "0maru/gh-zen"}) {
-		t.Fatalf("expected gh pr list args, got %#v", runner.args)
+	if !reflect.DeepEqual(runner.calls[0][:4], []string{"pr", "list", "--repo", repo}) {
+		t.Fatalf("expected gh pr list args, got %#v", runner.calls)
 	}
-	if !hasArgPair(runner.args, "--limit", listLimit) {
-		t.Fatalf("expected gh pr list limit, got %#v", runner.args)
+	if !hasArgPair(runner.calls[0], "--limit", listLimit) {
+		t.Fatalf("expected gh pr list limit, got %#v", runner.calls)
 	}
-	if !hasArgValue(runner.args, prListFields) {
-		t.Fatalf("expected gh pr list to request head repository owner, got %#v", runner.args)
+	if !hasArgValue(runner.calls[0], prListFields) {
+		t.Fatalf("expected gh pr list to request head repository owner, got %#v", runner.calls)
 	}
 }
 
@@ -123,17 +127,25 @@ func TestCLIService_IssuesParsesGHOutput(t *testing.T) {
 		t.Fatalf("expected issues to parse, got %v", err)
 	}
 	want := []workbench.IssueRef{{
-		Number:  9,
-		Title:   "Config",
-		State:   "open",
-		URL:     "https://example.test/issues/9",
-		Certain: true,
+		Number:    9,
+		Title:     "Config",
+		State:     "open",
+		URL:       "https://example.test/issues/9",
+		Body:      "Issue details",
+		Labels:    []string{"enhancement"},
+		Assignees: []string{"0maru"},
+		Milestone: "v1",
+		UpdatedAt: "2026-05-03T12:00:00Z",
+		Certain:   true,
 	}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected %+v, got %+v", want, got)
 	}
 	if !hasArgPair(runner.args, "--limit", listLimit) {
 		t.Fatalf("expected gh issue list limit, got %#v", runner.args)
+	}
+	if !hasArgValue(runner.args, issueListFields) {
+		t.Fatalf("expected gh issue list to request issue detail fields, got %#v", runner.args)
 	}
 }
 
@@ -170,9 +182,10 @@ func TestCLIService_ViewerReviewSubjectsParsesGHOutput(t *testing.T) {
 func TestCLIService_ProvidesDataForWorkbenchEnrichment(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
-		commandKey("pr", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", prListFields):       []byte(`[{"number":24,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/pull/24","author":{"login":"0maru"},"headRefName":"feature/issue-123-runtime","headRepositoryOwner":{"login":"0maru"},"baseRefName":"main","isDraft":false,"updatedAt":"2026-05-03T12:00:00Z","reviewDecision":"APPROVED","reviewRequests":[],"latestReviews":[],"body":"Closes #123"}]`),
-		commandKey("issue", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", issueListFields): []byte(`[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123","body":"Runtime issue","labels":[],"assignees":[],"milestone":null,"updatedAt":"2026-05-03T12:00:00Z"}]`),
-		commandKey("pr", "checks", "feature/issue-123-runtime", "--repo", repo.FullName(), "--json", "name,state"):                []byte(`[{"name":"test","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]`),
+		commandKey("pr", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", prListFields):                  []byte(`[{"number":24,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/pull/24","author":{"login":"0maru"},"headRefName":"feature/issue-123-runtime","headRepositoryOwner":{"login":"0maru"},"baseRefName":"main","isDraft":false,"updatedAt":"2026-05-03T12:00:00Z","reviewDecision":"APPROVED","reviewRequests":[],"latestReviews":[],"body":"Closes #123"}]`),
+		commandKey("api", "graphql", "-f", "owner=0maru", "-f", "name=gh-zen", "-f", "after=", "-f", "query="+pullRequestClosingIssuesQuery): []byte(`{"data":{"repository":{"pullRequests":{"nodes":[{"number":24,"closingIssuesReferences":{"nodes":[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123"}]}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`),
+		commandKey("issue", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", issueListFields):            []byte(`[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123","body":"Runtime issue","labels":[],"assignees":[],"milestone":null,"updatedAt":"2026-05-03T12:00:00Z"}]`),
+		commandKey("pr", "checks", "feature/issue-123-runtime", "--repo", repo.FullName(), "--json", "name,state"):                           []byte(`[{"name":"test","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]`),
 	}}
 	service := CLIService{Runner: runner}
 
@@ -206,8 +219,8 @@ func TestCLIService_ProvidesDataForWorkbenchEnrichment(t *testing.T) {
 	if items[0].Checks.State != workbench.CheckPassing || items[0].Checks.Passing != 2 {
 		t.Fatalf("expected CLI check data to enrich work item, got %+v", items[0])
 	}
-	if len(runner.calls) != 3 {
-		t.Fatalf("expected three gh calls, got %#v", runner.calls)
+	if len(runner.calls) != 4 {
+		t.Fatalf("expected four gh calls, got %#v", runner.calls)
 	}
 }
 

--- a/internal/workbench/issue_link.go
+++ b/internal/workbench/issue_link.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 var (
@@ -37,10 +38,14 @@ func (s IssueCheckLinkService) LinkForRepo(ctx context.Context, repo RepoRef, it
 
 	out := LinkIssues(items, issues)
 	for i := range out {
-		if out[i].PullRequest == nil || out[i].PullRequest.HeadBranch == "" {
+		if out[i].PullRequest == nil {
 			continue
 		}
-		checks, err := s.GitHub.CheckSummary(ctx, repo.FullName(), out[i].PullRequest.HeadBranch)
+		ref := pullRequestCheckRef(out[i])
+		if ref == "" {
+			continue
+		}
+		checks, err := s.GitHub.CheckSummary(ctx, repo.FullName(), ref)
 		if err != nil {
 			discoveryErrors = append(discoveryErrors, err)
 			if out[i].Checks.State == "" {
@@ -140,6 +145,16 @@ func enrichIssue(issue IssueRef, byNumber map[int]IssueRef) *IssueRef {
 		return &known
 	}
 	return &issue
+}
+
+func pullRequestCheckRef(item WorkItem) string {
+	if item.PullRequest == nil {
+		return ""
+	}
+	if strings.HasPrefix(item.ID, "pull-request:") && item.PullRequest.Number > 0 {
+		return strconv.Itoa(item.PullRequest.Number)
+	}
+	return item.PullRequest.HeadBranch
 }
 
 func issueCheckDiscoveryErrorItem(repo RepoRef, err error) WorkItem {

--- a/internal/workbench/pr_link.go
+++ b/internal/workbench/pr_link.go
@@ -2,6 +2,7 @@ package workbench
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -9,6 +10,11 @@ import (
 // PullRequestDiscovery provides pull request data for linking work items.
 type PullRequestDiscovery interface {
 	PullRequests(ctx context.Context, repo string) ([]PullRequestRef, error)
+}
+
+// ReviewSubjectDiscovery provides the authenticated viewer and review team subjects.
+type ReviewSubjectDiscovery interface {
+	ViewerReviewSubjects(ctx context.Context) (ReviewSubjects, error)
 }
 
 // PullRequestLinkService links GitHub pull requests onto local workbench items.
@@ -25,11 +31,45 @@ func (s PullRequestLinkService) LinkForRepo(ctx context.Context, repo RepoRef, i
 	if err != nil {
 		return append(cloneWorkItems(items), pullRequestDiscoveryErrorItem(repo, err))
 	}
-	return LinkPullRequests(items, prs)
+	var discoveryErrors []error
+	subjects, err := reviewSubjects(ctx, s.GitHub)
+	if err != nil {
+		discoveryErrors = append(discoveryErrors, err)
+	}
+	if !subjects.Empty() {
+		prs = ApplyReviewPerspective(prs, subjects)
+	}
+
+	out := LinkPullRequestsForRepo(repo, items, prs)
+	if len(discoveryErrors) > 0 {
+		return append(out, pullRequestDiscoveryErrorItem(repo, errors.Join(discoveryErrors...)))
+	}
+	return out
 }
 
 // LinkPullRequests matches pull requests to work items by branch head.
 func LinkPullRequests(items []WorkItem, prs []PullRequestRef) []WorkItem {
+	repo := RepoRef{}
+	for _, item := range items {
+		if item.Repo != (RepoRef{}) {
+			repo = item.Repo
+			break
+		}
+	}
+	return LinkPullRequestsForRepo(repo, items, prs)
+}
+
+// ApplyReviewPerspective marks PRs that are relevant to the authenticated viewer.
+func ApplyReviewPerspective(prs []PullRequestRef, subjects ReviewSubjects) []PullRequestRef {
+	out := append([]PullRequestRef(nil), prs...)
+	for i := range out {
+		out[i] = out[i].WithReviewPerspective(subjects)
+	}
+	return out
+}
+
+// LinkPullRequestsForRepo matches pull requests to local work items and appends PR-backed items.
+func LinkPullRequestsForRepo(repo RepoRef, items []WorkItem, prs []PullRequestRef) []WorkItem {
 	byBranch := map[pullRequestBranchKey]PullRequestRef{}
 	for _, pr := range prs {
 		if pr.HeadBranch == "" {
@@ -42,6 +82,7 @@ func LinkPullRequests(items []WorkItem, prs []PullRequestRef) []WorkItem {
 	}
 
 	out := cloneWorkItems(items)
+	linkedPullRequests := map[string]bool{}
 	for i := range out {
 		if out[i].Branch == nil || out[i].Branch.Name == "" {
 			continue
@@ -55,11 +96,33 @@ func LinkPullRequests(items []WorkItem, prs []PullRequestRef) []WorkItem {
 			continue
 		}
 		out[i].PullRequest = &pr
+		linkedPullRequests[pullRequestIdentity(pr)] = true
 		if out[i].Checks.State == "" {
 			out[i].Checks = CheckSummary{State: CheckUnknown}
 		}
 	}
+	appendedPullRequests := map[string]bool{}
+	for _, pr := range prs {
+		identity := pullRequestIdentity(pr)
+		if linkedPullRequests[identity] || appendedPullRequests[identity] || !shouldCreatePullRequestWorkItem(pr) {
+			continue
+		}
+		out = append(out, pullRequestWorkItem(repo, pr))
+		appendedPullRequests[identity] = true
+	}
 	return out
+}
+
+func reviewSubjects(ctx context.Context, discovery PullRequestDiscovery) (ReviewSubjects, error) {
+	subjectDiscovery, ok := discovery.(ReviewSubjectDiscovery)
+	if !ok {
+		return ReviewSubjects{}, nil
+	}
+	subjects, err := subjectDiscovery.ViewerReviewSubjects(ctx)
+	if err != nil {
+		return subjects, fmt.Errorf("viewer review subject discovery failed: %w", err)
+	}
+	return subjects, nil
 }
 
 type pullRequestBranchKey struct {
@@ -73,6 +136,52 @@ func normalizedOwner(owner string) string {
 
 func preferredPullRequest(candidate PullRequestRef, existing PullRequestRef) bool {
 	return strings.EqualFold(candidate.State, "open") && !strings.EqualFold(existing.State, "open")
+}
+
+func shouldCreatePullRequestWorkItem(pr PullRequestRef) bool {
+	return strings.EqualFold(pr.State, "open") && (pr.Number > 0 || pr.HeadBranch != "")
+}
+
+func pullRequestWorkItem(repo RepoRef, pr PullRequestRef) WorkItem {
+	item := WorkItem{
+		ID:          "pull-request:" + repo.FullName() + ":" + pullRequestIdentity(pr),
+		Repo:        repo,
+		PullRequest: &pr,
+		Checks:      CheckSummary{State: CheckUnknown},
+		Local: &LocalStatus{
+			State:   LocalMissing,
+			Summary: pullRequestOnlyLocalSummary(repo, pr),
+		},
+	}
+	if pr.HeadBranch != "" {
+		item.Branch = &BranchRef{
+			Name:       pr.HeadBranch,
+			Base:       pr.BaseBranch,
+			RemoteOnly: true,
+		}
+	}
+	return item
+}
+
+func pullRequestIdentity(pr PullRequestRef) string {
+	if pr.Number > 0 {
+		return fmt.Sprintf("#%d", pr.Number)
+	}
+	if pr.HeadBranch == "" {
+		return "unknown"
+	}
+	owner := normalizedOwner(pr.HeadOwner)
+	if owner == "" {
+		return pr.HeadBranch
+	}
+	return owner + ":" + pr.HeadBranch
+}
+
+func pullRequestOnlyLocalSummary(repo RepoRef, pr PullRequestRef) string {
+	if pr.HeadOwner != "" && repo.Owner != "" && !strings.EqualFold(pr.HeadOwner, repo.Owner) {
+		return "no local worktree; fork head " + pr.HeadOwner
+	}
+	return "no local worktree"
 }
 
 func cloneWorkItems(items []WorkItem) []WorkItem {

--- a/internal/workbench/pr_link_test.go
+++ b/internal/workbench/pr_link_test.go
@@ -101,6 +101,135 @@ func TestLinkPullRequests_PrefersOpenPullRequestForSameHead(t *testing.T) {
 	}
 }
 
+func TestLinkPullRequestsForRepo_AppendsOpenPRBackedItems(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	items := []WorkItem{
+		{ID: "main", Repo: repo, Branch: &BranchRef{Name: "main"}},
+	}
+	prs := []PullRequestRef{{
+		Number:     12,
+		Title:      "Review fork work",
+		State:      "open",
+		URL:        "https://example.test/pr/12",
+		HeadOwner:  "contributor",
+		HeadBranch: "feature",
+		BaseBranch: "main",
+	}}
+
+	got := LinkPullRequestsForRepo(repo, items, prs)
+	if len(got) != 2 {
+		t.Fatalf("expected local item plus PR-backed item, got %+v", got)
+	}
+	item := got[1]
+	if item.ID != "pull-request:0maru/gh-zen:#12" {
+		t.Fatalf("expected stable PR-backed ID, got %q", item.ID)
+	}
+	if item.Repo != repo {
+		t.Fatalf("expected repo context to be preserved, got %+v", item.Repo)
+	}
+	if item.PullRequest == nil || item.PullRequest.Number != 12 {
+		t.Fatalf("expected PR metadata, got %+v", item.PullRequest)
+	}
+	if item.Branch == nil || item.Branch.Name != "feature" || item.Branch.Base != "main" || !item.Branch.RemoteOnly {
+		t.Fatalf("expected remote PR branch context, got %+v", item.Branch)
+	}
+	if item.Local == nil || item.Local.State != LocalMissing || !strings.Contains(item.Local.Summary, "fork head contributor") {
+		t.Fatalf("expected missing local fork summary, got %+v", item.Local)
+	}
+	if item.Checks.State != CheckUnknown {
+		t.Fatalf("expected unknown checks placeholder, got %+v", item.Checks)
+	}
+}
+
+func TestLinkPullRequestsForRepo_DeduplicatesLocalBackedPullRequests(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	items := []WorkItem{
+		{ID: "feature", Repo: repo, Branch: &BranchRef{Name: "feature"}},
+	}
+	prs := []PullRequestRef{{
+		Number:     12,
+		State:      "open",
+		HeadOwner:  "0maru",
+		HeadBranch: "feature",
+	}}
+
+	got := LinkPullRequestsForRepo(repo, items, prs)
+	if len(got) != 1 {
+		t.Fatalf("expected linked PR not to be duplicated, got %+v", got)
+	}
+	if got[0].PullRequest == nil || got[0].PullRequest.Number != 12 {
+		t.Fatalf("expected local item to keep linked PR, got %+v", got[0])
+	}
+}
+
+func TestLinkPullRequestsForRepo_SkipsClosedPRBackedItems(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	items := []WorkItem{
+		{ID: "main", Repo: repo, Branch: &BranchRef{Name: "main"}},
+	}
+	prs := []PullRequestRef{{
+		Number:     12,
+		State:      "closed",
+		HeadOwner:  "0maru",
+		HeadBranch: "closed-feature",
+	}}
+
+	got := LinkPullRequestsForRepo(repo, items, prs)
+	if len(got) != 1 {
+		t.Fatalf("expected closed unmatched PR to stay hidden, got %+v", got)
+	}
+}
+
+func TestApplyReviewPerspective_MarksViewerReviewRequestsAndWaitingPRs(t *testing.T) {
+	subjects := ReviewSubjects{Login: "0maru", TeamSlugs: []string{"frontend"}}
+	prs := []PullRequestRef{
+		{
+			Number: 1,
+			State:  "open",
+			ReviewRequests: []ReviewRequestRef{
+				{Kind: "User", Login: "0maru"},
+			},
+		},
+		{
+			Number:      2,
+			State:       "open",
+			AuthorLogin: "0maru",
+			ReviewRequests: []ReviewRequestRef{
+				{Kind: "User", Login: "alice"},
+			},
+		},
+		{
+			Number: 3,
+			State:  "open",
+			ReviewRequests: []ReviewRequestRef{
+				{Kind: "Team", Slug: "frontend"},
+			},
+		},
+		{
+			Number:  4,
+			State:   "open",
+			IsDraft: true,
+			ReviewRequests: []ReviewRequestRef{
+				{Kind: "User", Login: "0maru"},
+			},
+		},
+	}
+
+	got := ApplyReviewPerspective(prs, subjects)
+	if !got[0].ViewerReviewRequested {
+		t.Fatalf("expected direct viewer review request to be marked: %+v", got[0])
+	}
+	if !got[1].ViewerAuthored || !got[1].WaitingOnReview {
+		t.Fatalf("expected viewer-authored pending request to be marked waiting: %+v", got[1])
+	}
+	if !got[2].ViewerReviewRequested {
+		t.Fatalf("expected viewer team review request to be marked: %+v", got[2])
+	}
+	if got[3].ViewerReviewRequested {
+		t.Fatalf("expected draft PR to be excluded from actionable review requests: %+v", got[3])
+	}
+}
+
 func TestPullRequestLinkService_LoadsPullRequestsForRepo(t *testing.T) {
 	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
 	service := PullRequestLinkService{

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -13,6 +13,8 @@ import (
 type fakeRuntimeGitHub struct {
 	prs         []PullRequestRef
 	prErr       error
+	subjects    ReviewSubjects
+	subjectErr  error
 	issues      []IssueRef
 	issueErr    error
 	checks      CheckSummary
@@ -26,6 +28,13 @@ func (f fakeRuntimeGitHub) PullRequests(context.Context, string) ([]PullRequestR
 		return nil, f.prErr
 	}
 	return f.prs, nil
+}
+
+func (f fakeRuntimeGitHub) ViewerReviewSubjects(context.Context) (ReviewSubjects, error) {
+	if f.subjectErr != nil {
+		return f.subjects, f.subjectErr
+	}
+	return f.subjects, nil
 }
 
 func (f fakeRuntimeGitHub) Issues(context.Context, string) ([]IssueRef, error) {
@@ -78,6 +87,8 @@ func TestRuntimeLoader_LoadsLocalItemsAndGitHubEnrichment(t *testing.T) {
 				Title:   "Runtime pipeline",
 				State:   "open",
 				URL:     "https://example.test/issues/123",
+				Body:    "Runtime pipeline issue details",
+				Labels:  []string{"enhancement"},
 				Certain: true,
 			}},
 			checks: CheckSummary{State: CheckPassing, Passing: 2},
@@ -101,6 +112,64 @@ func TestRuntimeLoader_LoadsLocalItemsAndGitHubEnrichment(t *testing.T) {
 	}
 	if item.Checks.State != CheckPassing || item.Checks.Passing != 2 {
 		t.Fatalf("expected passing checks, got %+v", item.Checks)
+	}
+}
+
+func TestRuntimeLoader_AddsPullRequestBackedItems(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	loader := RuntimeLoader{
+		Repo:     repo,
+		RepoPath: "/repo",
+		Local: fakeLocalDiscovery{
+			branches: []localrepo.Branch{{Name: "main"}},
+		},
+		GitHub: fakeRuntimeGitHub{
+			prs: []PullRequestRef{{
+				Number:     31,
+				Title:      "Review fork work",
+				State:      "open",
+				URL:        "https://example.test/pull/31",
+				HeadOwner:  "contributor",
+				HeadBranch: "feature/issue-77-review",
+				BaseBranch: "main",
+				LinkedIssues: []IssueRef{{
+					Number:  77,
+					Certain: true,
+				}},
+			}},
+			issues: []IssueRef{{
+				Number:  77,
+				Title:   "Review queue",
+				State:   "open",
+				URL:     "https://example.test/issues/77",
+				Certain: true,
+			}},
+			checksByRef: map[string]CheckSummary{
+				"31": {State: CheckPassing, Passing: 2},
+			},
+		},
+	}
+
+	result := loader.Load(context.Background())
+
+	item := runtimeWorkItemByPullRequest(result.Items, 31)
+	if item == nil {
+		t.Fatalf("expected PR-backed item, got %+v", result.Items)
+	}
+	if item.Worktree != nil {
+		t.Fatalf("expected PR-backed item without local worktree, got %+v", item.Worktree)
+	}
+	if item.Branch == nil || item.Branch.Name != "feature/issue-77-review" || item.Branch.Base != "main" || !item.Branch.RemoteOnly {
+		t.Fatalf("expected remote PR branch context, got %+v", item.Branch)
+	}
+	if item.Location() != "contributor/feature/issue-77-review" {
+		t.Fatalf("expected fork head location, got %q", item.Location())
+	}
+	if item.Issue == nil || item.Issue.Number != 77 || item.Issue.Title != "Review queue" || !item.Issue.Certain {
+		t.Fatalf("expected linked issue enrichment, got %+v", item.Issue)
+	}
+	if item.Checks.State != CheckPassing || item.Checks.Passing != 2 {
+		t.Fatalf("expected checks to use PR number for PR-only item, got %+v", item.Checks)
 	}
 }
 
@@ -289,6 +358,15 @@ func hasRuntimeErrorItem(items []WorkItem, prefix string, detail string) bool {
 func runtimeWorkItemByBranch(items []WorkItem, branch string) *WorkItem {
 	for i := range items {
 		if items[i].Branch != nil && items[i].Branch.Name == branch {
+			return &items[i]
+		}
+	}
+	return nil
+}
+
+func runtimeWorkItemByPullRequest(items []WorkItem, number int) *WorkItem {
+	for i := range items {
+		if items[i].PullRequest != nil && items[i].PullRequest.Number == number {
 			return &items[i]
 		}
 	}

--- a/internal/workbench/types.go
+++ b/internal/workbench/types.go
@@ -1,6 +1,9 @@
 package workbench
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type RepoRef struct {
 	Owner string
@@ -29,11 +32,16 @@ type WorktreeRef struct {
 }
 
 type IssueRef struct {
-	Number  int
-	Title   string
-	State   string
-	URL     string
-	Certain bool
+	Number    int
+	Title     string
+	State     string
+	URL       string
+	Body      string
+	Labels    []string
+	Assignees []string
+	Milestone string
+	UpdatedAt string
+	Certain   bool
 }
 
 func (i IssueRef) Label() string {
@@ -47,14 +55,24 @@ func (i IssueRef) Label() string {
 }
 
 type PullRequestRef struct {
-	Number       int
-	Title        string
-	State        string
-	URL          string
-	HeadOwner    string
-	HeadBranch   string
-	LinkedIssues []IssueRef
-	ReviewState  string
+	Number         int
+	Title          string
+	State          string
+	URL            string
+	AuthorLogin    string
+	HeadOwner      string
+	HeadBranch     string
+	BaseBranch     string
+	IsDraft        bool
+	UpdatedAt      string
+	LinkedIssues   []IssueRef
+	ReviewState    string
+	ReviewRequests []ReviewRequestRef
+	LatestReviews  []PullRequestReviewRef
+
+	ViewerReviewRequested bool
+	ViewerAuthored        bool
+	WaitingOnReview       bool
 }
 
 func (p PullRequestRef) Label() string {
@@ -70,6 +88,89 @@ func (p PullRequestRef) NumberLabel() string {
 		return "PR"
 	}
 	return fmt.Sprintf("PR #%d", p.Number)
+}
+
+func (p PullRequestRef) HeadLabel() string {
+	switch {
+	case p.HeadOwner != "" && p.HeadBranch != "":
+		return p.HeadOwner + "/" + p.HeadBranch
+	case p.HeadBranch != "":
+		return p.HeadBranch
+	case p.HeadOwner != "":
+		return p.HeadOwner
+	default:
+		return ""
+	}
+}
+
+type ReviewRequestRef struct {
+	Kind  string
+	Login string
+	Name  string
+	Slug  string
+}
+
+type PullRequestReviewRef struct {
+	AuthorLogin string
+	State       string
+}
+
+type ReviewSubjects struct {
+	Login     string
+	TeamSlugs []string
+}
+
+func (s ReviewSubjects) Empty() bool {
+	return s.Login == "" && len(s.TeamSlugs) == 0
+}
+
+func (p PullRequestRef) WithReviewPerspective(subjects ReviewSubjects) PullRequestRef {
+	p.ViewerAuthored = sameLogin(p.AuthorLogin, subjects.Login)
+	p.ViewerReviewRequested = p.needsReviewFrom(subjects)
+	p.WaitingOnReview = p.waitingOnReviewFromOthers(subjects)
+	return p
+}
+
+func (p PullRequestRef) needsReviewFrom(subjects ReviewSubjects) bool {
+	if !p.openForReview() {
+		return false
+	}
+	for _, request := range p.ReviewRequests {
+		if reviewRequestMatches(subjects, request) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p PullRequestRef) waitingOnReviewFromOthers(subjects ReviewSubjects) bool {
+	if !p.openForReview() || !sameLogin(p.AuthorLogin, subjects.Login) {
+		return false
+	}
+	return len(p.ReviewRequests) > 0 || p.ReviewState == "review required"
+}
+
+func (p PullRequestRef) openForReview() bool {
+	return strings.EqualFold(p.State, "open") && !p.IsDraft
+}
+
+func reviewRequestMatches(subjects ReviewSubjects, request ReviewRequestRef) bool {
+	if request.Login != "" && sameLogin(request.Login, subjects.Login) {
+		return true
+	}
+	if request.Slug == "" {
+		return false
+	}
+	for _, team := range subjects.TeamSlugs {
+		if strings.EqualFold(team, request.Slug) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameLogin(left string, right string) bool {
+	return left != "" && right != "" && strings.EqualFold(left, right)
 }
 
 type CheckState string
@@ -170,6 +271,11 @@ func (w WorkItem) Location() string {
 	switch {
 	case w.Worktree != nil && w.Worktree.Path != "":
 		return w.Worktree.Path
+	case w.PullRequest != nil && w.Worktree == nil && w.Branch != nil && w.Branch.RemoteOnly:
+		if head := w.PullRequest.HeadLabel(); head != "" {
+			return head
+		}
+		return "remote only"
 	case w.Branch != nil && w.Branch.RemoteOnly:
 		return "remote only"
 	case w.Issue != nil && w.Branch == nil && w.PullRequest == nil:

--- a/internal/workbench/types_test.go
+++ b/internal/workbench/types_test.go
@@ -54,6 +54,24 @@ func TestWorkItem_IssueLabel_MarksUncertainIssue(t *testing.T) {
 	}
 }
 
+func TestPullRequestRef_HeadLabel(t *testing.T) {
+	pr := PullRequestRef{HeadOwner: "contributor", HeadBranch: "feature"}
+	if got := pr.HeadLabel(); got != "contributor/feature" {
+		t.Fatalf("expected owner-qualified head label, got %q", got)
+	}
+}
+
+func TestWorkItem_LocationShowsPullRequestHeadForRemotePRBranch(t *testing.T) {
+	item := WorkItem{
+		Repo:        RepoRef{Owner: "0maru", Name: "gh-zen"},
+		Branch:      &BranchRef{Name: "feature", RemoteOnly: true},
+		PullRequest: &PullRequestRef{HeadOwner: "contributor", HeadBranch: "feature"},
+	}
+	if got := item.Location(); got != "contributor/feature" {
+		t.Fatalf("expected PR head location, got %q", got)
+	}
+}
+
 func TestFakeWorkItems_CoverRequiredShapes(t *testing.T) {
 	items := FakeWorkItems()
 	if len(items) < 5 {


### PR DESCRIPTION
## Summary
- Create PR-backed work items for open pull requests that do not match local branches or worktrees.
- Preserve PR branch ownership, base branch, review metadata, linked issues, and checks for PR-only items.
- Add viewer/review metadata needed to classify review-relevant PRs.

Closes #64

## Test plan
- make check