### PR TITLE
Add branch issue detail workflow

### DIFF
--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -1211,6 +1211,55 @@ func TestWorkItemPreviewLines_ShowsReviewPerspective(t *testing.T) {
 	}
 }
 
+func TestWorkItemPreviewLines_ShowsIssueDetails(t *testing.T) {
+	item := workbench.WorkItem{
+		Repo:   workbench.RepoRef{Owner: "0maru", Name: "gh-zen"},
+		Branch: &workbench.BranchRef{Name: "feature/66-issue-detail"},
+		Issue: &workbench.IssueRef{
+			Number:    66,
+			Title:     "Issue detail workflow",
+			State:     "open",
+			Body:      "Show enough issue context inside the preview pane.",
+			Labels:    []string{"enhancement", "ux"},
+			Assignees: []string{"0maru"},
+			Milestone: "v1",
+			UpdatedAt: "2026-05-03T12:00:00Z",
+			Certain:   false,
+		},
+	}
+
+	got := strings.Join(workItemPreviewLines(item, 120), "\n")
+	for _, want := range []string{
+		"Issue: #66 Issue detail workflow (uncertain)",
+		"Issue link: heuristic",
+		"Issue state: open",
+		"Labels: enhancement, ux",
+		"Assignees: 0maru",
+		"Milestone: v1",
+		"Issue updated: 2026-05-03T12:00:00Z",
+		"Issue body: Show enough issue context inside the preview pane.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected preview to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestWorkItemPreviewLines_ShowsNoIssueWithoutError(t *testing.T) {
+	item := workbench.WorkItem{
+		Repo:   workbench.RepoRef{Owner: "0maru", Name: "gh-zen"},
+		Branch: &workbench.BranchRef{Name: "feature/no-issue"},
+	}
+
+	got := strings.Join(workItemPreviewLines(item, 100), "\n")
+	if !strings.Contains(got, "Issue: no issue") {
+		t.Fatalf("expected preview to show no issue state, got:\n%s", got)
+	}
+	if strings.Contains(got, "Preview failed") {
+		t.Fatalf("expected missing issue not to be a preview error, got:\n%s", got)
+	}
+}
+
 func TestNewWithConfig_AppliesStartupRepository(t *testing.T) {
 	cfg := cfgpkg.Defaults()
 	cfg.Startup.Repo = "0maru/dotfiles"

--- a/internal/app/preview.go
+++ b/internal/app/preview.go
@@ -83,6 +83,27 @@ func workItemPreviewLines(item workbench.WorkItem, width int) []string {
 	}
 	lines = append(lines, truncate("Local: "+item.LocalLabel(), width))
 	lines = append(lines, truncate("Issue: "+item.IssueLabel(), width))
+	if item.Issue != nil {
+		lines = append(lines, truncate("Issue link: "+issueCertaintyLabel(*item.Issue), width))
+		if item.Issue.State != "" {
+			lines = append(lines, truncate("Issue state: "+item.Issue.State, width))
+		}
+		if labels := strings.Join(item.Issue.Labels, ", "); labels != "" {
+			lines = append(lines, truncate("Labels: "+labels, width))
+		}
+		if assignees := strings.Join(item.Issue.Assignees, ", "); assignees != "" {
+			lines = append(lines, truncate("Assignees: "+assignees, width))
+		}
+		if item.Issue.Milestone != "" {
+			lines = append(lines, truncate("Milestone: "+item.Issue.Milestone, width))
+		}
+		if item.Issue.UpdatedAt != "" {
+			lines = append(lines, truncate("Issue updated: "+item.Issue.UpdatedAt, width))
+		}
+		if excerpt := issueBodyExcerpt(item.Issue.Body); excerpt != "" {
+			lines = append(lines, truncate("Issue body: "+excerpt, width))
+		}
+	}
 	lines = append(lines, truncate("PR: "+item.PullRequestLabel(), width))
 	if item.PullRequest != nil {
 		if head := item.PullRequest.HeadLabel(); head != "" {

--- a/internal/workbench/issue_link_test.go
+++ b/internal/workbench/issue_link_test.go
@@ -88,11 +88,14 @@ func TestLinkIssues_UsesPRMetadataBeforeBranchHeuristic(t *testing.T) {
 	}}
 
 	got := LinkIssues(items, []IssueRef{
-		{Number: 10, Title: "Config discovery", State: "open", URL: "https://example.test/issues/10", Certain: true},
+		{Number: 10, Title: "Config discovery", State: "open", URL: "https://example.test/issues/10", Body: "Detailed config issue", Labels: []string{"enhancement"}, Certain: true},
 		{Number: 123, Title: "Branch issue", State: "open", URL: "https://example.test/issues/123", Certain: true},
 	})
 	if got[0].Issue == nil || got[0].Issue.Number != 10 || !got[0].Issue.Certain {
 		t.Fatalf("expected PR metadata issue to win, got %+v", got[0].Issue)
+	}
+	if got[0].Issue.Body != "Detailed config issue" || len(got[0].Issue.Labels) != 1 || got[0].Issue.Labels[0] != "enhancement" {
+		t.Fatalf("expected PR issue to be enriched with issue details, got %+v", got[0].Issue)
 	}
 }
 
@@ -105,10 +108,13 @@ func TestLinkIssues_EnrichesBranchHeuristicFromIssueList(t *testing.T) {
 	}}
 
 	got := LinkIssues(items, []IssueRef{
-		{Number: 123, Title: "Config discovery", State: "open", URL: "https://example.test/issues/123", Certain: true},
+		{Number: 123, Title: "Config discovery", State: "open", URL: "https://example.test/issues/123", Body: "Detailed branch issue", Labels: []string{"bug"}, Assignees: []string{"0maru"}, Certain: true},
 	})
 	if got[0].Issue == nil || got[0].Issue.Title != "Config discovery" || got[0].Issue.Certain {
 		t.Fatalf("expected enriched uncertain issue, got %+v", got[0].Issue)
+	}
+	if got[0].Issue.Body != "Detailed branch issue" || len(got[0].Issue.Labels) != 1 || got[0].Issue.Labels[0] != "bug" || len(got[0].Issue.Assignees) != 1 {
+		t.Fatalf("expected enriched issue details to be preserved, got %+v", got[0].Issue)
 	}
 }
 

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -107,7 +107,7 @@ func TestRuntimeLoader_LoadsLocalItemsAndGitHubEnrichment(t *testing.T) {
 	if item.PullRequest == nil || item.PullRequest.Number != 24 || item.PullRequest.ReviewState != "approved" {
 		t.Fatalf("expected linked PR, got %+v", item.PullRequest)
 	}
-	if item.Issue == nil || item.Issue.Number != 123 || item.Issue.Title != "Runtime pipeline" || !item.Issue.Certain {
+	if item.Issue == nil || item.Issue.Number != 123 || item.Issue.Title != "Runtime pipeline" || item.Issue.Body != "Runtime pipeline issue details" || !item.Issue.Certain {
 		t.Fatalf("expected linked issue, got %+v", item.Issue)
 	}
 	if item.Checks.State != CheckPassing || item.Checks.Passing != 2 {


### PR DESCRIPTION
## Summary
- Load richer issue details from GitHub, including body, labels, assignees, milestone, and updated timestamp.
- Preserve certain versus heuristic issue links while enriching linked branch issues.
- Show branch issue context in the preview without treating missing issues as errors.

Closes #66

## Test plan
- make check