### PR TITLE
Add agent hook feedback loop for format, lint, and test gates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/scripts/agent-stop-gate.sh\"",
+            "timeout": 300
+          }
+        ]
+      }
     ]
   }
 }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -12,6 +12,18 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/scripts/agent-stop-gate.sh\"",
+            "timeout": 300,
+            "statusMessage": "Running Go stop gate"
+          }
+        ]
+      }
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,18 @@
 - Use large tests only for real external systems such as GitHub API,
   authenticated `gh`, browser automation, or long-running end-to-end workflows.
 
+## Agent Hooks
+
+- Claude Code hooks live in `.claude/settings.json`; Codex hooks live in
+  `.codex/hooks.json`. Both share the scripts in `scripts/`.
+- After each file edit, `scripts/agent-go-check.sh` formats changed Go files
+  and runs the fast gate (`lint` + `test-small`). Failures are fed back to
+  the agent via exit code 2, so fix them before moving on.
+- When the agent finishes a turn with uncommitted Go changes,
+  `scripts/agent-stop-gate.sh` runs the normal gate (`fmt-check` + `lint` +
+  `test-medium`) and blocks completion until it passes, with a cap of three
+  retries per session to avoid endless loops.
+
 ## GitHub
 
 - Use English for commit messages.

--- a/scripts/agent-go-check.sh
+++ b/scripts/agent-go-check.sh
@@ -4,15 +4,40 @@ set -eu
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$repo_root"
 
+# Exit code 2 feeds stderr back to the agent (Claude Code / Codex) so it can
+# read the failure and self-correct. Any other non-zero exit code is only
+# shown to the user and never reaches the agent.
+fail_with_feedback() {
+	{
+		echo "Go fast gate failed. Fix the issues below before continuing."
+		printf '%s\n' "$1"
+	} >&2
+	exit 2
+}
+
+# Run every check even if an earlier one fails so the agent sees all issues
+# in a single pass. Failure output goes to stdout for capture.
+run_fast_gate() {
+	gate_status=0
+	if command -v lefthook >/dev/null 2>&1; then
+		lefthook run agent-check 2>&1 || gate_status=$?
+	else
+		./scripts/lint.sh 2>&1 || gate_status=$?
+		./scripts/test-small.sh 2>&1 || gate_status=$?
+	fi
+	return "$gate_status"
+}
+
 if ! command -v jq >/dev/null 2>&1; then
 	echo "jq is not installed; running the Go fast gate without targeted formatting." >&2
-	./scripts/lint.sh
-	./scripts/test-small.sh
+	if ! gate_output=$(run_fast_gate); then
+		fail_with_feedback "$gate_output"
+	fi
 	exit 0
 fi
 
-hook_input=$(mktemp)
-changed_paths=$(mktemp)
+hook_input=$(mktemp "${TMPDIR:-/tmp}/agent-go-check.input.XXXXXX")
+changed_paths=$(mktemp "${TMPDIR:-/tmp}/agent-go-check.paths.XXXXXX")
 trap 'rm -f "$hook_input" "$changed_paths"' EXIT
 
 cat > "$hook_input"
@@ -51,7 +76,9 @@ while IFS= read -r path; do
 	case "$clean_path" in
 		*.go)
 			if [ -f "$clean_path" ]; then
-				./scripts/fmt.sh "$clean_path"
+				if ! fmt_output=$(./scripts/fmt.sh "$clean_path" 2>&1); then
+					fail_with_feedback "$fmt_output"
+				fi
 				relevant=1
 			fi
 			;;
@@ -67,9 +94,6 @@ if [ "$relevant" -ne 1 ]; then
 	exit 0
 fi
 
-if command -v lefthook >/dev/null 2>&1; then
-	lefthook run agent-check
-else
-	./scripts/lint.sh
-	./scripts/test-small.sh
+if ! gate_output=$(run_fast_gate); then
+	fail_with_feedback "$gate_output"
 fi

--- a/scripts/agent-stop-gate.sh
+++ b/scripts/agent-stop-gate.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env sh
+set -eu
+
+# Stop-gate hook for coding agents (Claude Code / Codex).
+#
+# When the agent tries to finish a turn while uncommitted Go changes exist,
+# run the normal validation gate (fmt-check + lint + test-medium). On failure,
+# block the stop and feed the output back so the agent keeps fixing until the
+# gate passes. A retry counter caps the loop at max_attempts to avoid running
+# forever when the agent cannot fix the failure.
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$repo_root"
+
+max_attempts=3
+
+hook_input=""
+if [ ! -t 0 ]; then
+	hook_input=$(cat 2>/dev/null || true)
+fi
+
+session_id=""
+if command -v jq >/dev/null 2>&1 && [ -n "$hook_input" ]; then
+	session_id=$(printf '%s' "$hook_input" | jq -r '.session_id // empty' 2>/dev/null || true)
+fi
+session_id=$(printf '%s' "$session_id" | tr -cd 'A-Za-z0-9_-')
+counter_file="${TMPDIR:-/tmp}/gh-zen-stop-gate-${session_id:-default}.count"
+
+clear_counter() {
+	rm -f "$counter_file"
+}
+
+# Only gate uncommitted Go-related changes; lefthook pre-commit and pre-push
+# already gate committed work.
+changed=$(git status --porcelain -- '*.go' 'go.mod' 'go.sum' 2>/dev/null || true)
+if [ -z "$changed" ]; then
+	clear_counter
+	exit 0
+fi
+
+# Run every check even if an earlier one fails so the agent sees all issues
+# in a single pass. Failure output goes to stdout for capture.
+run_gate() {
+	gate_status=0
+	./scripts/fmt-check.sh 2>&1 || gate_status=$?
+	./scripts/lint.sh 2>&1 || gate_status=$?
+	./scripts/test-medium.sh 2>&1 || gate_status=$?
+	return "$gate_status"
+}
+
+if gate_output=$(run_gate); then
+	clear_counter
+	exit 0
+fi
+
+attempts=0
+if [ -f "$counter_file" ]; then
+	attempts=$(cat "$counter_file" 2>/dev/null || echo 0)
+fi
+case "$attempts" in
+	'' | *[!0-9]*) attempts=0 ;;
+esac
+
+if [ "$attempts" -ge "$max_attempts" ]; then
+	clear_counter
+	{
+		echo "Stop gate still failing after ${max_attempts} attempts; allowing stop."
+		echo "Run 'make check' and fix the remaining issues manually."
+	} >&2
+	exit 1
+fi
+
+attempts=$((attempts + 1))
+printf '%s' "$attempts" > "$counter_file"
+
+summary=$(printf '%s\n' "$gate_output" | tail -n 120)
+reason="Stop gate failed (attempt ${attempts}/${max_attempts}): uncommitted Go changes do not pass the normal gate (fmt-check + lint + test-medium). Fix the issues below, then finish again.
+
+${summary}"
+
+if command -v jq >/dev/null 2>&1; then
+	# JSON decision output: blocks the stop and shows the reason to the agent.
+	jq -n --arg reason "$reason" '{decision: "block", reason: $reason}'
+	exit 0
+fi
+
+# Fallback without jq: exit code 2 also blocks and feeds stderr to the agent.
+printf '%s\n' "$reason" >&2
+exit 2

--- a/scripts/test-large.sh
+++ b/scripts/test-large.sh
@@ -6,4 +6,9 @@ if [ "${GH_ZEN_LARGE_TESTS:-}" != "1" ]; then
 	exit 1
 fi
 
+# Git exports repository-specific environment variables to hook processes
+# (e.g. lefthook pre-push). Drop them so tests that create temporary git
+# repositories never operate on this repository instead.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY GIT_PREFIX
+
 go test -tags=large ./...

--- a/scripts/test-medium.sh
+++ b/scripts/test-medium.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env sh
 set -eu
 
+# Git exports repository-specific environment variables to hook processes
+# (e.g. lefthook pre-push). Drop them so tests that create temporary git
+# repositories never operate on this repository instead.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY GIT_PREFIX
+
 go test ./...

--- a/scripts/test-small.sh
+++ b/scripts/test-small.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env sh
 set -eu
 
+# Git exports repository-specific environment variables to hook processes
+# (e.g. lefthook pre-push). Drop them so tests that create temporary git
+# repositories never operate on this repository instead.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY GIT_PREFIX
+
 go test -short ./...


### PR DESCRIPTION
## Summary
- Feed Go fast gate failures back to coding agents: the PostToolUse hook now captures lint/test output and exits with code 2, which is the only exit code Claude Code and Codex surface to the agent, so the agent can read failures and self-correct
- Add `scripts/agent-stop-gate.sh` wired to the Claude Code and Codex Stop hooks: when a turn ends with uncommitted Go changes, it runs fmt-check + lint + test-medium and blocks completion with the failure output until the gate passes, capped at three retries per session
- Drop Git hook environment variables (`GIT_DIR` etc.) in the test scripts so tests that create temporary git repositories never operate on this repository when run from lefthook pre-push, which previously broke pushes from linked worktrees
- Document the agent hook setup in AGENTS.md

## Test plan
- [x] PostToolUse gate passes on a clean Go edit and skips non-Go edits
- [x] PostToolUse gate exits 2 with failure details on test failures and syntax errors
- [x] Stop gate blocks with attempt 1/3..3/3 on a failing tree, then allows stop with a warning on the next attempt
- [x] Stop gate passes a dirty-but-green tree, skips a clean tree, and catches formatting violations
- [x] test-medium passes with leaked `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`, and lefthook pre-push succeeds from a linked worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)