### PR TITLE
[gh-zen] Discover and browse repositories from configured roots

### DIFF
--- a/docs/validation/repository-root-discovery.md
+++ b/docs/validation/repository-root-discovery.md
@@ -1,0 +1,29 @@
+# Repository Root Discovery Validation
+
+This manual smoke test verifies that configured repository roots populate the
+Repository Workbench with multiple local GitHub checkouts.
+
+## Prerequisites
+
+- `gh auth status` succeeds for an account that can read the repositories.
+- At least two GitHub repositories are cloned below one configured root.
+- Each checkout has an `origin` remote on `github.com`.
+
+## Plan
+
+1. Run `make build`.
+2. Create or update a local gh-zen config so `repos.roots` includes the parent
+   directory that contains at least two checkouts.
+3. Optionally add one missing path to `repos.roots` to verify non-fatal
+   diagnostics.
+4. Run `./gh-zen`.
+5. Confirm the repository pane lists both repositories discovered from the
+   configured root.
+6. Focus the repository pane and move between repositories. Confirm the preview
+   pane shows the local path, default branch, remotes, active worktree count,
+   open PR count, open issue count, and failing check count for the selected
+   repository.
+7. Confirm local work items remain visible even when the missing root produces a
+   `repository discovery error` work item.
+8. Press `r` to refresh and confirm the selected repository and selected work
+   item are preserved when they still exist.

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -79,6 +79,7 @@ type model struct {
 	workbenchSource      workbenchDataSource
 	workbenchLoading     bool
 	focusedPane          paneFocus
+	focusedWorkItemRepo  workbench.RepoRef
 	focusedWorkItemID    string
 	preview              previewState
 	nextPreviewRequestID int
@@ -225,13 +226,14 @@ func (m model) Init() tea.Cmd {
 		return batchCommands(cmds...)
 	}
 	item, ok := m.selectedWorkItem()
-	if !ok || item.ID != m.focusedWorkItemID {
+	if !ok || !m.focusedWorkItemMatches(item) {
 		return batchCommands(cmds...)
 	}
 	cmds = append(cmds, m.previewLoader(previewRequest{
-		requestID:  m.preview.requestID,
-		workItemID: item.ID,
-		item:       item,
+		requestID:    m.preview.requestID,
+		workItemRepo: item.Repo,
+		workItemID:   item.ID,
+		item:         item,
 	}))
 	return batchCommands(cmds...)
 }
@@ -278,16 +280,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *model) startPreviewLoadIfFocusedItemChanged() tea.Cmd {
 	item, ok := m.selectedWorkItem()
 	if !ok {
-		m.focusedWorkItemID = ""
+		m.clearFocusedWorkItem()
 		m.preview = previewState{status: previewEmpty}
 		return nil
 	}
 	if item.ID == "" {
-		m.focusedWorkItemID = ""
+		m.clearFocusedWorkItem()
 		m.preview = previewState{status: previewEmpty}
 		return nil
 	}
-	if item.ID == m.focusedWorkItemID {
+	if m.focusedWorkItemMatches(item) {
 		return nil
 	}
 	return m.startPreviewLoadForCurrentItem()
@@ -296,37 +298,41 @@ func (m *model) startPreviewLoadIfFocusedItemChanged() tea.Cmd {
 func (m *model) startPreviewLoadForCurrentItem() tea.Cmd {
 	item, ok := m.selectedWorkItem()
 	if !ok || item.ID == "" {
-		m.focusedWorkItemID = ""
+		m.clearFocusedWorkItem()
 		m.preview = previewState{status: previewEmpty}
 		return nil
 	}
 
 	m.nextPreviewRequestID++
 	requestID := m.nextPreviewRequestID
+	m.focusedWorkItemRepo = item.Repo
 	m.focusedWorkItemID = item.ID
 	m.preview = previewState{
-		status:            previewLoading,
-		requestID:         requestID,
-		focusedWorkItemID: item.ID,
+		status:              previewLoading,
+		requestID:           requestID,
+		focusedWorkItemRepo: item.Repo,
+		focusedWorkItemID:   item.ID,
 	}
 	if m.previewLoader == nil {
 		return nil
 	}
 	return m.previewLoader(previewRequest{
-		requestID:  requestID,
-		workItemID: item.ID,
-		item:       item,
+		requestID:    requestID,
+		workItemRepo: item.Repo,
+		workItemID:   item.ID,
+		item:         item,
 	})
 }
 
 func (m *model) handlePreviewResult(msg previewResultMsg) {
-	if msg.requestID != m.preview.requestID || msg.workItemID != m.focusedWorkItemID {
+	if msg.requestID != m.preview.requestID || msg.workItemID != m.focusedWorkItemID || msg.workItemRepo != m.focusedWorkItemRepo {
 		return
 	}
 
 	next := previewState{
-		requestID:         msg.requestID,
-		focusedWorkItemID: msg.workItemID,
+		requestID:           msg.requestID,
+		focusedWorkItemRepo: msg.workItemRepo,
+		focusedWorkItemID:   msg.workItemID,
 	}
 	switch {
 	case msg.err != nil:
@@ -339,6 +345,9 @@ func (m *model) handlePreviewResult(msg previewResultMsg) {
 		next.loaded = msg.data
 		if next.loaded.workItemID == "" {
 			next.loaded.workItemID = msg.workItemID
+		}
+		if next.loaded.workItemRepo == (workbench.RepoRef{}) {
+			next.loaded.workItemRepo = msg.workItemRepo
 		}
 	}
 	m.preview = next
@@ -1119,7 +1128,7 @@ func (m model) previewLines(width int) []string {
 	case previewLoading:
 		return m.previewStatusLines(width, "Loading preview...")
 	case previewLoaded:
-		if m.preview.loaded.workItemID != m.focusedWorkItemID {
+		if m.preview.loaded.workItemID != m.focusedWorkItemID || m.preview.loaded.workItemRepo != m.focusedWorkItemRepo {
 			return m.previewStatusLines(width, "Loading preview...")
 		}
 		return workItemPreviewLines(m.preview.loaded.item, width)
@@ -1338,6 +1347,15 @@ func (m model) selectedWorkItem() (workbench.WorkItem, bool) {
 		return workbench.WorkItem{}, false
 	}
 	return items[m.selectedItem], true
+}
+
+func (m model) focusedWorkItemMatches(item workbench.WorkItem) bool {
+	return item.Repo == m.focusedWorkItemRepo && item.ID == m.focusedWorkItemID
+}
+
+func (m *model) clearFocusedWorkItem() {
+	m.focusedWorkItemRepo = workbench.RepoRef{}
+	m.focusedWorkItemID = ""
 }
 
 func shortRemoteLabel(item workbench.WorkItem) string {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -70,6 +70,7 @@ type model struct {
 	width                int
 	height               int
 	repos                []workbench.RepoRef
+	repoSummaries        []workbench.RepositorySummary
 	selectedRepo         int
 	selectedView         int
 	viewSelected         bool
@@ -95,14 +96,16 @@ type model struct {
 
 // WorkbenchData contains resolved repository workbench state for app startup.
 type WorkbenchData struct {
-	Repos          []workbench.RepoRef
-	WorkItems      []workbench.WorkItem
-	Reloader       WorkbenchReloader
-	InitialLoading bool
-	Demo           bool
+	Repos               []workbench.RepoRef
+	RepositorySummaries []workbench.RepositorySummary
+	WorkItems           []workbench.WorkItem
+	Reloader            WorkbenchReloader
+	InitialLoading      bool
+	Demo                bool
 }
 
-// WorkbenchReloader reloads runtime workbench data for one selected repository.
+// WorkbenchReloader reloads runtime workbench data using the selected repository
+// as the selection anchor.
 type WorkbenchReloader interface {
 	Load(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult
 }
@@ -176,8 +179,10 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 	if data.Demo {
 		source = workbenchDataDemo
 	}
+	repoSummaries := normalizeRepositorySummaries(data.RepositorySummaries, data.Repos)
 	m := model{
-		repos:             cloneRepoRefs(data.Repos),
+		repos:             repoRefsFromSummaries(repoSummaries),
+		repoSummaries:     cloneRepositorySummaries(repoSummaries),
 		workItems:         cloneWorkItems(data.WorkItems),
 		workbenchSource:   source,
 		previewLoader:     loader,
@@ -512,10 +517,7 @@ func (m *model) beginWorkbenchReload(status string) bool {
 	if m.workbenchReloader == nil {
 		return false
 	}
-	repo, ok := m.selectedRepoRef()
-	if !ok {
-		return false
-	}
+	repo, _ := m.selectedRepoRef()
 	m.nextReloadRequestID++
 	request := workbenchReloadRequest{
 		requestID: m.nextReloadRequestID,
@@ -542,7 +544,7 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		return nil
 	}
 	repo, ok := m.selectedRepoRef()
-	if !ok || repo != msg.request.repo {
+	if msg.request.repo != (workbench.RepoRef{}) && (!ok || repo != msg.request.repo) {
 		m.workbenchLoading = false
 		if m.statusMessage == msg.request.status {
 			m.statusMessage = ""
@@ -556,7 +558,11 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		selectedWorkItemRepo = item.Repo
 		selectedWorkItemID = item.ID
 	}
-	m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
+	if len(msg.result.Repositories) > 0 {
+		m.replaceWorkbenchData(msg.result, msg.request.repo)
+	} else {
+		m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
+	}
 	m.restoreSelectedWorkItem(selectedWorkItemRepo, selectedWorkItemID)
 	m.workbenchLoading = false
 	if hasWorkbenchErrorItems(msg.result.Items) {
@@ -750,6 +756,23 @@ func (m model) selectedRepoRef() (workbench.RepoRef, bool) {
 	return m.repos[m.selectedRepo], true
 }
 
+func (m model) selectedRepoSummary() (workbench.RepositorySummary, bool) {
+	repo, ok := m.selectedRepoRef()
+	if !ok {
+		return workbench.RepositorySummary{}, false
+	}
+	return m.repoSummary(repo)
+}
+
+func (m model) repoSummary(repo workbench.RepoRef) (workbench.RepositorySummary, bool) {
+	for _, summary := range m.repoSummaries {
+		if summary.Repo == repo {
+			return summary, true
+		}
+	}
+	return workbench.RepositorySummary{}, false
+}
+
 func (m model) selectedRepoView() (repoView, bool) {
 	if m.selectedView < 0 || m.selectedView >= len(repoViews) {
 		return repoView{}, false
@@ -786,6 +809,33 @@ func replaceRepoWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, re
 	return out
 }
 
+func (m *model) replaceWorkbenchData(result workbench.RuntimeLoadResult, selectedRepo workbench.RepoRef) {
+	m.repoSummaries = cloneRepositorySummaries(result.Repositories)
+	m.repos = repoRefsFromSummaries(m.repoSummaries)
+	m.workItems = cloneWorkItems(result.Items)
+	m.restoreSelectedRepo(selectedRepo)
+}
+
+func (m *model) restoreSelectedRepo(repo workbench.RepoRef) {
+	if repo != (workbench.RepoRef{}) {
+		for i, candidate := range m.repos {
+			if candidate == repo {
+				m.selectedRepo = i
+				return
+			}
+		}
+	}
+	if len(m.repos) == 0 {
+		m.selectedRepo = 0
+		m.viewSelected = false
+		return
+	}
+	m.selectedRepo = clamp(m.selectedRepo, 0, len(m.repos)-1)
+	if m.viewSelected {
+		m.selectedView = clamp(m.selectedView, 0, max(len(repoViews)-1, 0))
+	}
+}
+
 func hasWorkbenchErrorItems(items []workbench.WorkItem) bool {
 	for _, item := range items {
 		for _, prefix := range workbenchErrorIDPrefixes {
@@ -816,6 +866,33 @@ func (m *model) restoreSelectedWorkItem(repo workbench.RepoRef, workItemID strin
 
 func cloneRepoRefs(repos []workbench.RepoRef) []workbench.RepoRef {
 	return append([]workbench.RepoRef(nil), repos...)
+}
+
+func normalizeRepositorySummaries(summaries []workbench.RepositorySummary, repos []workbench.RepoRef) []workbench.RepositorySummary {
+	if len(summaries) > 0 {
+		return cloneRepositorySummaries(summaries)
+	}
+	out := make([]workbench.RepositorySummary, 0, len(repos))
+	for _, repo := range repos {
+		out = append(out, workbench.RepositorySummary{Repo: repo})
+	}
+	return out
+}
+
+func repoRefsFromSummaries(summaries []workbench.RepositorySummary) []workbench.RepoRef {
+	repos := make([]workbench.RepoRef, 0, len(summaries))
+	for _, summary := range summaries {
+		repos = append(repos, summary.Repo)
+	}
+	return repos
+}
+
+func cloneRepositorySummaries(summaries []workbench.RepositorySummary) []workbench.RepositorySummary {
+	out := append([]workbench.RepositorySummary(nil), summaries...)
+	for i := range out {
+		out[i].Remotes = append([]string(nil), summaries[i].Remotes...)
+	}
+	return out
 }
 
 func cloneWorkItems(items []workbench.WorkItem) []workbench.WorkItem {
@@ -854,13 +931,24 @@ func (m *model) applyStartupRepo(repoName string) {
 			m.selectedRepo = i
 			m.viewSelected = false
 			m.selectedItem = 0
+			m.ensureRepositorySummary(repo)
 			return
 		}
 	}
 	m.repos = append(m.repos, repo)
+	m.repoSummaries = append(m.repoSummaries, workbench.RepositorySummary{Repo: repo})
 	m.selectedRepo = len(m.repos) - 1
 	m.viewSelected = false
 	m.selectedItem = 0
+}
+
+func (m *model) ensureRepositorySummary(repo workbench.RepoRef) {
+	for _, summary := range m.repoSummaries {
+		if summary.Repo == repo {
+			return
+		}
+	}
+	m.repoSummaries = append(m.repoSummaries, workbench.RepositorySummary{Repo: repo})
 }
 
 func matchesWorkbenchFilter(item workbench.WorkItem, filter cfgpkg.WorkbenchFilter) bool {
@@ -979,7 +1067,11 @@ func (m model) repoLines(width int, focused bool) []string {
 	} else {
 		for i, repo := range m.repos {
 			marker := selectionMarker(!m.viewSelected && i == m.selectedRepo, focused)
-			lines = append(lines, truncate(fmt.Sprintf("%s %s", marker, repo.FullName()), width))
+			label := repo.FullName()
+			if counts := m.repositoryCountLabel(repo); counts != "" {
+				label += " " + counts
+			}
+			lines = append(lines, truncate(fmt.Sprintf("%s %s", marker, label), width))
 		}
 	}
 	lines = append(lines, "", "Views")
@@ -1018,6 +1110,11 @@ func (m model) emptyWorkItemLine() string {
 }
 
 func (m model) previewLines(width int) []string {
+	if m.activePane() == paneRepositories && !m.viewSelected {
+		if summary, ok := m.selectedRepoSummary(); ok {
+			return repositoryPreviewLines(summary, width)
+		}
+	}
 	switch m.preview.status {
 	case previewLoading:
 		return m.previewStatusLines(width, "Loading preview...")
@@ -1043,6 +1140,49 @@ func (m model) previewLines(width int) []string {
 		}
 		return m.previewStatusLines(width, "Preview idle")
 	}
+}
+
+func repositoryPreviewLines(summary workbench.RepositorySummary, width int) []string {
+	path := summary.Path
+	if path == "" {
+		path = "unknown"
+	}
+	defaultBranch := summary.DefaultBranch
+	if defaultBranch == "" {
+		defaultBranch = "unknown"
+	}
+	remotes := strings.Join(summary.Remotes, ", ")
+	if remotes == "" {
+		remotes = "none"
+	}
+	return []string{
+		truncate("Repo: "+summary.Repo.FullName(), width),
+		truncate("Path: "+path, width),
+		truncate("Default branch: "+defaultBranch, width),
+		truncate("Remotes: "+remotes, width),
+		truncate(fmt.Sprintf("Active worktrees: %d", summary.ActiveWorktreeCount), width),
+		truncate(fmt.Sprintf("Open PRs: %d", summary.OpenPullRequestCount), width),
+		truncate(fmt.Sprintf("Open issues: %d", summary.OpenIssueCount), width),
+		truncate(fmt.Sprintf("Failing checks: %d", summary.FailingCheckCount), width),
+	}
+}
+
+func (m model) repositoryCountLabel(repo workbench.RepoRef) string {
+	summary, ok := m.repoSummary(repo)
+	if !ok || emptyRepositorySummary(summary) {
+		return ""
+	}
+	return fmt.Sprintf("wt%d pr%d issue%d fail%d", summary.ActiveWorktreeCount, summary.OpenPullRequestCount, summary.OpenIssueCount, summary.FailingCheckCount)
+}
+
+func emptyRepositorySummary(summary workbench.RepositorySummary) bool {
+	return summary.Path == "" &&
+		summary.DefaultBranch == "" &&
+		len(summary.Remotes) == 0 &&
+		summary.ActiveWorktreeCount == 0 &&
+		summary.OpenPullRequestCount == 0 &&
+		summary.OpenIssueCount == 0 &&
+		summary.FailingCheckCount == 0
 }
 
 func (m model) previewStatusLines(width int, status string) []string {

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -43,9 +43,10 @@ func requireModelEqualIgnoringPreviewLoader(t *testing.T, got tea.Model, want mo
 func emptyPreviewLoader(req previewRequest) tea.Cmd {
 	return func() tea.Msg {
 		return previewResultMsg{
-			requestID:  req.requestID,
-			workItemID: req.workItemID,
-			empty:      true,
+			requestID:    req.requestID,
+			workItemRepo: req.workItemRepo,
+			workItemID:   req.workItemID,
+			empty:        true,
 		}
 	}
 }
@@ -54,9 +55,10 @@ func errorPreviewLoader(err error) previewLoader {
 	return func(req previewRequest) tea.Cmd {
 		return func() tea.Msg {
 			return previewResultMsg{
-				requestID:  req.requestID,
-				workItemID: req.workItemID,
-				err:        err,
+				requestID:    req.requestID,
+				workItemRepo: req.workItemRepo,
+				workItemID:   req.workItemID,
+				err:          err,
 			}
 		}
 	}
@@ -184,6 +186,7 @@ func TestUpdate_RefreshPreservesSelectedWorkItemID(t *testing.T) {
 		Reloader:  reloader,
 	}, fakeDelayedPreviewLoader(0))
 	start.selectedItem = 1
+	start.focusedWorkItemRepo = second.Repo
 	start.focusedWorkItemID = second.ID
 
 	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
@@ -264,6 +267,7 @@ func TestUpdate_RefreshPreservesSelectedWorkItemRepo(t *testing.T) {
 	}, fakeDelayedPreviewLoader(0))
 	start.setRepoPaneIndex(len(start.repos))
 	start.selectedItem = 1
+	start.focusedWorkItemRepo = repoBItem.Repo
 	start.focusedWorkItemID = repoBItem.ID
 
 	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
@@ -303,6 +307,7 @@ func TestUpdate_FullRefreshPreservesSelectedRepositoryAndWorkItem(t *testing.T) 
 	}, fakeDelayedPreviewLoader(0))
 	start.selectedRepo = 1
 	start.selectedItem = 1
+	start.focusedWorkItemRepo = repoBSecond.Repo
 	start.focusedWorkItemID = repoBSecond.ID
 
 	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
@@ -341,6 +346,7 @@ func TestUpdate_FullRefreshFallsBackWhenSelectedRepositoryDisappears(t *testing.
 	}, fakeDelayedPreviewLoader(0))
 	start.selectedRepo = 1
 	start.selectedItem = 0
+	start.focusedWorkItemRepo = repoBItem.Repo
 	start.focusedWorkItemID = repoBItem.ID
 
 	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
@@ -906,8 +912,9 @@ func TestUpdate_MoveSelection_ClampsAtEdges(t *testing.T) {
 
 	items := mm.visibleWorkItems()
 	mm.selectedItem = len(items) - 1
+	mm.focusedWorkItemRepo = items[len(items)-1].Repo
 	mm.focusedWorkItemID = items[len(items)-1].ID
-	mm.preview = previewState{status: previewLoading, focusedWorkItemID: mm.focusedWorkItemID}
+	mm.preview = previewState{status: previewLoading, focusedWorkItemRepo: mm.focusedWorkItemRepo, focusedWorkItemID: mm.focusedWorkItemID}
 	got, cmd = mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if cmd != nil {
 		t.Fatalf("expected nil cmd when clamped at end, got %T", cmd)
@@ -1515,6 +1522,41 @@ func TestUpdate_FocusChangeStartsPreviewLoad(t *testing.T) {
 	}
 	if mm.preview.requestID != initialRequestID+1 {
 		t.Fatalf("expected request ID to increment to %d, got %d", initialRequestID+1, mm.preview.requestID)
+	}
+}
+
+func TestUpdate_FocusChangeStartsPreviewLoadForSameIDInDifferentRepo(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	itemA := workbench.WorkItem{ID: "branch:feature", Repo: repoA, Branch: &workbench.BranchRef{Name: "feature"}, Checks: workbench.CheckSummary{State: workbench.CheckFailing}}
+	itemB := workbench.WorkItem{ID: "branch:feature", Repo: repoB, Branch: &workbench.BranchRef{Name: "feature"}, Checks: workbench.CheckSummary{State: workbench.CheckFailing}}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{itemA, itemB},
+	}, fakeDelayedPreviewLoader(0))
+	start.viewSelected = true
+	for i, view := range repoViews {
+		if view.filter == repoViewFailedChecks {
+			start.selectedView = i
+			break
+		}
+	}
+	initialRequestID := start.preview.requestID
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if cmd == nil {
+		t.Fatalf("expected preview load command")
+	}
+	mm := got.(model)
+	if mm.focusedWorkItemRepo != repoB || mm.focusedWorkItemID != itemB.ID {
+		t.Fatalf("expected focused item %+v/%q, got %+v/%q", repoB, itemB.ID, mm.focusedWorkItemRepo, mm.focusedWorkItemID)
+	}
+	if mm.preview.requestID != initialRequestID+1 {
+		t.Fatalf("expected request ID to increment to %d, got %d", initialRequestID+1, mm.preview.requestID)
+	}
+	msg := requirePreviewResultMsg(t, cmd)
+	if msg.workItemRepo != repoB || msg.workItemID != itemB.ID {
+		t.Fatalf("expected preview request for repo B item, got %+v/%q", msg.workItemRepo, msg.workItemID)
 	}
 }
 

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -278,6 +278,83 @@ func TestUpdate_RefreshPreservesSelectedWorkItemRepo(t *testing.T) {
 	}
 }
 
+func TestUpdate_FullRefreshPreservesSelectedRepositoryAndWorkItem(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	repoAItem := workbench.WorkItem{ID: "branch:main", Repo: repoA, Branch: &workbench.BranchRef{Name: "main"}}
+	repoBFirst := workbench.WorkItem{ID: "branch:first", Repo: repoB, Branch: &workbench.BranchRef{Name: "first"}}
+	repoBSecond := workbench.WorkItem{ID: "branch:second", Repo: repoB, Branch: &workbench.BranchRef{Name: "second"}}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repoB.FullName(): {
+				Repo: repoB,
+				Repositories: []workbench.RepositorySummary{
+					{Repo: repoA, Path: "/repos/gh-zen"},
+					{Repo: repoB, Path: "/repos/dotfiles"},
+				},
+				Items: []workbench.WorkItem{repoAItem, repoBSecond, repoBFirst},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{repoAItem, repoBFirst, repoBSecond},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.selectedRepo = 1
+	start.selectedItem = 1
+	start.focusedWorkItemID = repoBSecond.ID
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	mm := got.(model)
+
+	if mm.selectedRepo != 1 {
+		t.Fatalf("expected selected repository to remain repo B, got %d", mm.selectedRepo)
+	}
+	if item, ok := mm.selectedWorkItem(); !ok || item.Repo != repoB || item.ID != repoBSecond.ID {
+		t.Fatalf("expected selected work item to follow repo B second item, got %+v ok=%v", item, ok)
+	}
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected selected item to follow stable ID to index 0, got %d", mm.selectedItem)
+	}
+}
+
+func TestUpdate_FullRefreshFallsBackWhenSelectedRepositoryDisappears(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	repoAItem := workbench.WorkItem{ID: "branch:main", Repo: repoA, Branch: &workbench.BranchRef{Name: "main"}}
+	repoBItem := workbench.WorkItem{ID: "branch:old", Repo: repoB, Branch: &workbench.BranchRef{Name: "old"}}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repoB.FullName(): {
+				Repo:         repoB,
+				Repositories: []workbench.RepositorySummary{{Repo: repoA, Path: "/repos/gh-zen"}},
+				Items:        []workbench.WorkItem{repoAItem},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{repoAItem, repoBItem},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.selectedRepo = 1
+	start.selectedItem = 0
+	start.focusedWorkItemID = repoBItem.ID
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	mm := got.(model)
+
+	if mm.selectedRepo != 0 || len(mm.repos) != 1 || mm.repos[0] != repoA {
+		t.Fatalf("expected fallback to first remaining repo, got selected=%d repos=%+v", mm.selectedRepo, mm.repos)
+	}
+	if item, ok := mm.selectedWorkItem(); !ok || item.Repo != repoA || item.ID != repoAItem.ID {
+		t.Fatalf("expected fallback selected item from repo A, got %+v ok=%v", item, ok)
+	}
+}
+
 func TestUpdate_StaleRefreshResultIsDiscarded(t *testing.T) {
 	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
@@ -516,6 +593,41 @@ func TestInit_StartsInitialWorkbenchLoad(t *testing.T) {
 	}
 	if items := mm.visibleWorkItems(); len(items) != 1 || items[0].ID != loaded.ID {
 		t.Fatalf("expected loaded work item, got %+v", items)
+	}
+}
+
+func TestInit_StartsInitialWorkbenchLoadWithoutSelectedRepository(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	loaded := workbench.WorkItem{
+		ID:     "branch:loaded",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "loaded"},
+	}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			(workbench.RepoRef{}).FullName(): {
+				Repositories: []workbench.RepositorySummary{{Repo: repo, Path: "/repos/gh-zen"}},
+				Items:        []workbench.WorkItem{loaded},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), "", WorkbenchData{
+		Reloader:       reloader,
+		InitialLoading: true,
+	}, fakeDelayedPreviewLoader(0))
+
+	msg := requireWorkbenchReloadMsg(t, start.Init())
+	got, _ := start.Update(msg)
+	mm := got.(model)
+
+	if len(reloader.calls) != 1 || reloader.calls[0] != (workbench.RepoRef{}) {
+		t.Fatalf("expected reload without selected repository, got %+v", reloader.calls)
+	}
+	if len(mm.repos) != 1 || mm.repos[0] != repo {
+		t.Fatalf("expected discovered repository to populate model, got %+v", mm.repos)
+	}
+	if item, ok := mm.selectedWorkItem(); !ok || item.ID != loaded.ID {
+		t.Fatalf("expected loaded item to be selected, got %+v ok=%v", item, ok)
 	}
 }
 

--- a/internal/app/preview.go
+++ b/internal/app/preview.go
@@ -22,30 +22,34 @@ const (
 )
 
 type previewState struct {
-	status            previewStatus
-	requestID         int
-	focusedWorkItemID string
-	loaded            previewData
-	errorMessage      string
+	status              previewStatus
+	requestID           int
+	focusedWorkItemRepo workbench.RepoRef
+	focusedWorkItemID   string
+	loaded              previewData
+	errorMessage        string
 }
 
 type previewRequest struct {
-	requestID  int
-	workItemID string
-	item       workbench.WorkItem
+	requestID    int
+	workItemRepo workbench.RepoRef
+	workItemID   string
+	item         workbench.WorkItem
 }
 
 type previewData struct {
-	workItemID string
-	item       workbench.WorkItem
+	workItemRepo workbench.RepoRef
+	workItemID   string
+	item         workbench.WorkItem
 }
 
 type previewResultMsg struct {
-	requestID  int
-	workItemID string
-	data       previewData
-	empty      bool
-	err        error
+	requestID    int
+	workItemRepo workbench.RepoRef
+	workItemID   string
+	data         previewData
+	empty        bool
+	err          error
 }
 
 type previewLoader func(previewRequest) tea.Cmd
@@ -57,11 +61,13 @@ func fakeDelayedPreviewLoader(delay time.Duration) previewLoader {
 				time.Sleep(delay)
 			}
 			return previewResultMsg{
-				requestID:  req.requestID,
-				workItemID: req.workItemID,
+				requestID:    req.requestID,
+				workItemRepo: req.workItemRepo,
+				workItemID:   req.workItemID,
 				data: previewData{
-					workItemID: req.workItemID,
-					item:       req.item,
+					workItemRepo: req.workItemRepo,
+					workItemID:   req.workItemID,
+					item:         req.item,
 				},
 			}
 		}

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/muesli/termenv"
+
+	cfgpkg "github.com/0maru/gh-zen/internal/config"
+	"github.com/0maru/gh-zen/internal/workbench"
 )
 
 var update = flag.Bool("update", false, "update golden files")
@@ -146,6 +149,62 @@ func TestView_FullLayoutSeparatesPanes(t *testing.T) {
 	body := ansi.Strip(lines[3])
 	if strings.Count(body, paneBorderGlyph) != 6 {
 		t.Fatalf("expected each pane row to have left and right borders, got %q", body)
+	}
+}
+
+func TestView_RepositoryPaneRendersRepositorySummaries(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	start := NewWithWorkbenchData(cfgpkg.Defaults(), repoB.FullName(), WorkbenchData{
+		RepositorySummaries: []workbench.RepositorySummary{
+			{
+				Repo:                 repoA,
+				Path:                 "/repos/gh-zen",
+				DefaultBranch:        "main",
+				Remotes:              []string{"origin", "upstream"},
+				ActiveWorktreeCount:  2,
+				OpenPullRequestCount: 1,
+				OpenIssueCount:       3,
+				FailingCheckCount:    4,
+			},
+			{
+				Repo:                 repoB,
+				Path:                 "/repos/dotfiles",
+				DefaultBranch:        "trunk",
+				Remotes:              []string{"origin"},
+				ActiveWorktreeCount:  1,
+				OpenPullRequestCount: 0,
+				OpenIssueCount:       1,
+				FailingCheckCount:    0,
+			},
+		},
+	}).(model)
+
+	lines := strings.Join(start.repoLines(120, true), "\n")
+	for _, want := range []string{
+		"0maru/gh-zen wt2 pr1 issue3 fail4",
+		"> 0maru/dotfiles wt1 pr0 issue1 fail0",
+	} {
+		if !strings.Contains(lines, want) {
+			t.Fatalf("expected repository pane to contain %q, got:\n%s", want, lines)
+		}
+	}
+
+	start.focusedPane = paneRepositories
+	preview := strings.Join(start.previewLines(120), "\n")
+	for _, want := range []string{
+		"Repo: 0maru/dotfiles",
+		"Path: /repos/dotfiles",
+		"Default branch: trunk",
+		"Remotes: origin",
+		"Active worktrees: 1",
+		"Open PRs: 0",
+		"Open issues: 1",
+		"Failing checks: 0",
+	} {
+		if !strings.Contains(preview, want) {
+			t.Fatalf("expected repository preview to contain %q, got:\n%s", want, preview)
+		}
 	}
 }
 

--- a/internal/config/repository_path.go
+++ b/internal/config/repository_path.go
@@ -22,6 +22,41 @@ type RepositoryPathResult struct {
 	Diagnostics []Diagnostic
 }
 
+// RepositoryRoot is one configured repository discovery root after expansion.
+type RepositoryRoot struct {
+	ConfigPath string
+	Path       string
+}
+
+// ResolveRepositoryRoots expands configured repository roots and reports
+// non-fatal diagnostics for roots that cannot be scanned.
+func ResolveRepositoryRoots(cfg Config) ([]RepositoryRoot, []Diagnostic) {
+	roots := make([]RepositoryRoot, 0, len(cfg.Repos.Roots))
+	diagnostics := []Diagnostic{}
+	for i, root := range cfg.Repos.Roots {
+		rootPath := expandHomePath(root)
+		info, err := os.Stat(rootPath)
+		if err != nil {
+			diagnostics = append(diagnostics, repositoryRootDiagnostic(i, fmt.Sprintf("%q is not accessible: %v", rootPath, err)))
+			continue
+		}
+		if !info.IsDir() {
+			diagnostics = append(diagnostics, repositoryRootDiagnostic(i, fmt.Sprintf("%q is not a directory", rootPath)))
+			continue
+		}
+		walkRoot, err := filepath.EvalSymlinks(rootPath)
+		if err != nil {
+			diagnostics = append(diagnostics, repositoryRootDiagnostic(i, fmt.Sprintf("resolve %q: %v", rootPath, err)))
+			continue
+		}
+		roots = append(roots, RepositoryRoot{
+			ConfigPath: fmt.Sprintf("repos.roots[%d]", i),
+			Path:       walkRoot,
+		})
+	}
+	return roots, diagnostics
+}
+
 // ResolveRepositoryPath maps an owner/repo name to a local checkout path.
 func ResolveRepositoryPath(options RepositoryPathOptions) RepositoryPathResult {
 	result := RepositoryPathResult{Repo: options.Repo}

--- a/internal/config/repository_path_test.go
+++ b/internal/config/repository_path_test.go
@@ -3,9 +3,52 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestResolveRepositoryRoots_ExpandsAccessibleRootsAndDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{root, filepath.Join(root, "missing")}
+
+	roots, diagnostics := ResolveRepositoryRoots(cfg)
+
+	if len(roots) != 1 {
+		t.Fatalf("expected one accessible root, got %+v", roots)
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve temp root: %v", err)
+	}
+	if roots[0].Path != resolvedRoot || roots[0].ConfigPath != "repos.roots[0]" {
+		t.Fatalf("expected resolved root path, got %+v", roots[0])
+	}
+	if !hasDiagnosticContaining(diagnostics, "repos.roots[1]", "not accessible") {
+		t.Fatalf("expected missing root diagnostic, got %+v", diagnostics)
+	}
+}
+
+func TestResolveRepositoryRoots_RejectsFiles(t *testing.T) {
+	root := t.TempDir()
+	filePath := filepath.Join(root, "not-a-directory")
+	if err := os.WriteFile(filePath, []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatalf("write file root: %v", err)
+	}
+	cfg := Defaults()
+	cfg.Repos.Roots = []string{filePath}
+
+	roots, diagnostics := ResolveRepositoryRoots(cfg)
+
+	if len(roots) != 0 {
+		t.Fatalf("expected no roots, got %+v", roots)
+	}
+	want := []Diagnostic{{Path: "repos.roots[0]", Message: "\"" + filePath + "\" is not a directory"}}
+	if !reflect.DeepEqual(diagnostics, want) {
+		t.Fatalf("expected diagnostics %+v, got %+v", want, diagnostics)
+	}
+}
 
 func TestResolveRepositoryPath_PrefersMatchingCurrentCheckout(t *testing.T) {
 	if testing.Short() {

--- a/internal/localrepo/service.go
+++ b/internal/localrepo/service.go
@@ -132,17 +132,17 @@ func (s Service) discoverRepositoriesInRoot(ctx context.Context, displayRoot str
 		repository, err := s.RepositoryMetadata(ctx, path)
 		if err != nil {
 			*diagnostics = append(*diagnostics, RepositoryDiagnostic{Path: diagnosticPath, Message: fmt.Sprintf("read repository metadata: %v", err)})
-			return nil
+			return filepath.SkipDir
 		}
 		if repository.Path == "" {
 			repository.Path = path
 		}
 		if _, ok := seen[repository.Path]; ok {
-			return nil
+			return filepath.SkipDir
 		}
 		seen[repository.Path] = struct{}{}
 		*repositories = append(*repositories, repository)
-		return nil
+		return filepath.SkipDir
 	})
 	if err != nil {
 		*diagnostics = append(*diagnostics, RepositoryDiagnostic{Path: displayRoot, Message: fmt.Sprintf("scan: %v", err)})

--- a/internal/localrepo/service.go
+++ b/internal/localrepo/service.go
@@ -3,8 +3,10 @@ package localrepo
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -29,6 +31,20 @@ type Branch struct {
 	RemoteOnly bool
 }
 
+// Repository describes one local Git checkout discovered below configured roots.
+type Repository struct {
+	Path          string
+	OriginURL     string
+	DefaultBranch string
+	Remotes       []string
+}
+
+// RepositoryDiagnostic describes a non-fatal repository discovery warning.
+type RepositoryDiagnostic struct {
+	Path    string
+	Message string
+}
+
 // Runner executes Git commands for the local repository service.
 type Runner interface {
 	Run(ctx context.Context, dir string, args ...string) (string, error)
@@ -50,6 +66,123 @@ func (GitRunner) Run(ctx context.Context, dir string, args ...string) (string, e
 // Service discovers local repository state behind a Git command boundary.
 type Service struct {
 	Runner Runner
+}
+
+// DiscoverRepositories finds Git repositories below the configured roots.
+func (s Service) DiscoverRepositories(ctx context.Context, roots []string) ([]Repository, []RepositoryDiagnostic) {
+	repositories := []Repository{}
+	diagnostics := []RepositoryDiagnostic{}
+	seen := map[string]struct{}{}
+	visited := map[string]struct{}{}
+	for _, root := range roots {
+		walkRoot, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			diagnostics = append(diagnostics, RepositoryDiagnostic{Path: root, Message: fmt.Sprintf("resolve root: %v", err)})
+			continue
+		}
+		if _, ok := visited[walkRoot]; ok {
+			continue
+		}
+		visited[walkRoot] = struct{}{}
+		s.discoverRepositoriesInRoot(ctx, root, walkRoot, visited, seen, &repositories, &diagnostics)
+	}
+	sort.SliceStable(repositories, func(i, j int) bool {
+		if repositories[i].Path == repositories[j].Path {
+			return repositories[i].OriginURL < repositories[j].OriginURL
+		}
+		return repositories[i].Path < repositories[j].Path
+	})
+	return repositories, diagnostics
+}
+
+func (s Service) discoverRepositoriesInRoot(ctx context.Context, displayRoot string, walkRoot string, visited map[string]struct{}, seen map[string]struct{}, repositories *[]Repository, diagnostics *[]RepositoryDiagnostic) {
+	err := filepath.WalkDir(walkRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		diagnosticPath := repositoryDiagnosticPath(displayRoot, walkRoot, path)
+		if walkErr != nil {
+			*diagnostics = append(*diagnostics, RepositoryDiagnostic{Path: diagnosticPath, Message: fmt.Sprintf("read: %v", walkErr)})
+			if entry != nil && entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Name() == ".git" {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !entry.IsDir() {
+			if entry.Type()&fs.ModeSymlink == 0 {
+				return nil
+			}
+			linkedRoot, ok := repositorySymlinkDir(path, diagnosticPath, diagnostics)
+			if !ok {
+				return nil
+			}
+			if _, ok := visited[linkedRoot]; ok {
+				return nil
+			}
+			visited[linkedRoot] = struct{}{}
+			s.discoverRepositoriesInRoot(ctx, diagnosticPath, linkedRoot, visited, seen, repositories, diagnostics)
+			return nil
+		}
+		if !hasGitMetadata(path) {
+			return nil
+		}
+		repository, err := s.RepositoryMetadata(ctx, path)
+		if err != nil {
+			*diagnostics = append(*diagnostics, RepositoryDiagnostic{Path: diagnosticPath, Message: fmt.Sprintf("read repository metadata: %v", err)})
+			return nil
+		}
+		if repository.Path == "" {
+			repository.Path = path
+		}
+		if _, ok := seen[repository.Path]; ok {
+			return nil
+		}
+		seen[repository.Path] = struct{}{}
+		*repositories = append(*repositories, repository)
+		return nil
+	})
+	if err != nil {
+		*diagnostics = append(*diagnostics, RepositoryDiagnostic{Path: displayRoot, Message: fmt.Sprintf("scan: %v", err)})
+	}
+}
+
+// RepositoryMetadata reads repository-level metadata through Git.
+func (s Service) RepositoryMetadata(ctx context.Context, repoPath string) (Repository, error) {
+	runner := s.runner()
+	root, err := runner.Run(ctx, repoPath, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return Repository{}, fmt.Errorf("resolve repository root: %w", err)
+	}
+	originURL, err := runner.Run(ctx, root, "remote", "get-url", "origin")
+	if err != nil {
+		return Repository{}, fmt.Errorf("read origin remote: %w", err)
+	}
+	remoteOutput, err := runner.Run(ctx, root, "remote")
+	if err != nil {
+		return Repository{}, fmt.Errorf("list remotes: %w", err)
+	}
+	return Repository{
+		Path:          root,
+		OriginURL:     originURL,
+		DefaultBranch: s.defaultBranch(ctx, root),
+		Remotes:       parseRemoteNames(remoteOutput),
+	}, nil
+}
+
+func (s Service) defaultBranch(ctx context.Context, repoPath string) string {
+	runner := s.runner()
+	branch, err := runner.Run(ctx, repoPath, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+	if err == nil && branch != "" {
+		return strings.TrimPrefix(branch, "origin/")
+	}
+	branch, err = runner.Run(ctx, repoPath, "symbolic-ref", "--quiet", "--short", "HEAD")
+	if err == nil {
+		return branch
+	}
+	return ""
 }
 
 // DiscoverWorktrees lists local worktrees and reads their dirty status.
@@ -218,4 +351,40 @@ func trimGitOutput(output []byte) string {
 func missingPath(path string) bool {
 	_, err := os.Stat(path)
 	return os.IsNotExist(err)
+}
+
+func repositoryDiagnosticPath(root string, walkRoot string, path string) string {
+	if root == walkRoot {
+		return path
+	}
+	rel, err := filepath.Rel(walkRoot, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return path
+	}
+	if rel == "." {
+		return root
+	}
+	return filepath.Join(root, rel)
+}
+
+func repositorySymlinkDir(path string, diagnosticPath string, diagnostics *[]RepositoryDiagnostic) (string, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		*diagnostics = append(*diagnostics, RepositoryDiagnostic{Path: diagnosticPath, Message: err.Error()})
+		return "", false
+	}
+	if !info.IsDir() {
+		return "", false
+	}
+	linkedRoot, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		*diagnostics = append(*diagnostics, RepositoryDiagnostic{Path: diagnosticPath, Message: fmt.Sprintf("resolve symlink: %v", err)})
+		return "", false
+	}
+	return linkedRoot, true
+}
+
+func hasGitMetadata(path string) bool {
+	_, err := os.Stat(filepath.Join(path, ".git"))
+	return err == nil
 }

--- a/internal/localrepo/service_test.go
+++ b/internal/localrepo/service_test.go
@@ -266,6 +266,60 @@ func TestService_DiscoverBranchesUsesRemoteNames(t *testing.T) {
 	}
 }
 
+func TestService_DiscoverRepositories(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	ghZen := filepath.Join(root, "0maru", "gh-zen")
+	dotfiles := filepath.Join(root, "0maru", "dotfiles")
+	initTempGitRepoAt(t, ghZen)
+	initTempGitRepoAt(t, dotfiles)
+	runGit(t, ghZen, "remote", "add", "origin", "https://github.com/0maru/gh-zen.git")
+	runGit(t, ghZen, "remote", "add", "upstream", "https://github.com/example/gh-zen.git")
+	runGit(t, dotfiles, "remote", "add", "origin", "https://github.com/0maru/dotfiles.git")
+
+	repositories, diagnostics := (Service{}).DiscoverRepositories(context.Background(), []string{root})
+
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %+v", diagnostics)
+	}
+	ghZenRepo := requireRepository(t, repositories, ghZen)
+	if ghZenRepo.OriginURL != "https://github.com/0maru/gh-zen.git" {
+		t.Fatalf("expected gh-zen origin URL, got %+v", ghZenRepo)
+	}
+	if ghZenRepo.DefaultBranch != "main" {
+		t.Fatalf("expected default branch main, got %+v", ghZenRepo)
+	}
+	if !reflect.DeepEqual(ghZenRepo.Remotes, []string{"origin", "upstream"}) {
+		t.Fatalf("expected remotes origin/upstream, got %+v", ghZenRepo.Remotes)
+	}
+	dotfilesRepo := requireRepository(t, repositories, dotfiles)
+	if dotfilesRepo.OriginURL != "https://github.com/0maru/dotfiles.git" {
+		t.Fatalf("expected dotfiles origin URL, got %+v", dotfilesRepo)
+	}
+}
+
+func TestService_DiscoverRepositoriesReportsMetadataDiagnostics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	noOrigin := filepath.Join(root, "no-origin")
+	initTempGitRepoAt(t, noOrigin)
+
+	repositories, diagnostics := (Service{}).DiscoverRepositories(context.Background(), []string{root})
+
+	if len(repositories) != 0 {
+		t.Fatalf("expected repository without origin to be skipped, got %+v", repositories)
+	}
+	if len(diagnostics) != 1 || diagnostics[0].Path != noOrigin || !strings.Contains(diagnostics[0].Message, "read origin remote") {
+		t.Fatalf("expected origin diagnostic, got %+v", diagnostics)
+	}
+}
+
 func TestService_DiscoverWorktreesMarksMissingWorktrees(t *testing.T) {
 	if testing.Short() {
 		t.Skip("uses temporary Git repositories and worktrees")
@@ -313,6 +367,18 @@ func hasBranch(branches []Branch, want Branch) bool {
 	return false
 }
 
+func requireRepository(t *testing.T, repositories []Repository, path string) Repository {
+	t.Helper()
+	wantPath := canonicalPath(t, path)
+	for _, repository := range repositories {
+		if canonicalPath(t, repository.Path) == wantPath {
+			return repository
+		}
+	}
+	t.Fatalf("repository %q not found in %+v", path, repositories)
+	return Repository{}
+}
+
 func canonicalPath(t *testing.T, path string) string {
 	t.Helper()
 	canonical, err := filepath.EvalSymlinks(path)
@@ -329,10 +395,19 @@ func canonicalPath(t *testing.T, path string) string {
 func initTempGitRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
+	initTempGitRepoAt(t, dir)
+	return dir
+}
+
+func initTempGitRepoAt(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
 	runGit(t, dir, "init", "-b", "main")
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	runGit(t, dir, "config", "user.name", "Test User")
-	return dir
+	runGit(t, dir, "config", "commit.gpgsign", "false")
 }
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/internal/localrepo/service_test.go
+++ b/internal/localrepo/service_test.go
@@ -274,11 +274,14 @@ func TestService_DiscoverRepositories(t *testing.T) {
 	root := t.TempDir()
 	ghZen := filepath.Join(root, "0maru", "gh-zen")
 	dotfiles := filepath.Join(root, "0maru", "dotfiles")
+	nested := filepath.Join(ghZen, "node_modules", "nested")
 	initTempGitRepoAt(t, ghZen)
 	initTempGitRepoAt(t, dotfiles)
+	initTempGitRepoAt(t, nested)
 	runGit(t, ghZen, "remote", "add", "origin", "https://github.com/0maru/gh-zen.git")
 	runGit(t, ghZen, "remote", "add", "upstream", "https://github.com/example/gh-zen.git")
 	runGit(t, dotfiles, "remote", "add", "origin", "https://github.com/0maru/dotfiles.git")
+	runGit(t, nested, "remote", "add", "origin", "https://github.com/example/nested.git")
 
 	repositories, diagnostics := (Service{}).DiscoverRepositories(context.Background(), []string{root})
 
@@ -298,6 +301,12 @@ func TestService_DiscoverRepositories(t *testing.T) {
 	dotfilesRepo := requireRepository(t, repositories, dotfiles)
 	if dotfilesRepo.OriginURL != "https://github.com/0maru/dotfiles.git" {
 		t.Fatalf("expected dotfiles origin URL, got %+v", dotfilesRepo)
+	}
+	nestedPath := canonicalPath(t, nested)
+	for _, repository := range repositories {
+		if canonicalPath(t, repository.Path) == nestedPath {
+			t.Fatalf("expected nested repository to be skipped, got %+v", repositories)
+		}
 	}
 }
 

--- a/internal/workbench/local_service_test.go
+++ b/internal/workbench/local_service_test.go
@@ -152,6 +152,7 @@ func initLocalServiceRepo(t *testing.T) string {
 	runLocalServiceGit(t, dir, "init", "-b", "main")
 	runLocalServiceGit(t, dir, "config", "user.email", "test@example.com")
 	runLocalServiceGit(t, dir, "config", "user.name", "Test User")
+	runLocalServiceGit(t, dir, "config", "commit.gpgsign", "false")
 	writeLocalServiceFile(t, filepath.Join(dir, "README.md"), "initial\n")
 	runLocalServiceGit(t, dir, "add", "README.md")
 	runLocalServiceGit(t, dir, "commit", "-m", "initial")

--- a/internal/workbench/repository_summary.go
+++ b/internal/workbench/repository_summary.go
@@ -1,0 +1,114 @@
+package workbench
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// RepositorySummary contains the repository-level preview shown by the TUI.
+type RepositorySummary struct {
+	Repo                 RepoRef
+	Path                 string
+	DefaultBranch        string
+	Remotes              []string
+	ActiveWorktreeCount  int
+	OpenPullRequestCount int
+	OpenIssueCount       int
+	FailingCheckCount    int
+}
+
+// RepositoryDiagnostic describes a non-fatal repository discovery warning.
+type RepositoryDiagnostic struct {
+	Path    string
+	Message string
+}
+
+// SummarizeRepository derives preview counts from loaded workbench items.
+func SummarizeRepository(repo RepoRef, path string, defaultBranch string, remotes []string, items []WorkItem) RepositorySummary {
+	summary := RepositorySummary{
+		Repo:          repo,
+		Path:          path,
+		DefaultBranch: defaultBranch,
+		Remotes:       append([]string(nil), remotes...),
+	}
+	openPullRequests := map[string]struct{}{}
+	openIssues := map[string]struct{}{}
+	for _, item := range items {
+		if item.Repo != repo {
+			continue
+		}
+		if item.Worktree != nil && item.Local != nil && item.Local.State != LocalMissing {
+			summary.ActiveWorktreeCount++
+		}
+		if item.PullRequest != nil && strings.EqualFold(item.PullRequest.State, "open") {
+			openPullRequests[pullRequestSummaryKey(*item.PullRequest)] = struct{}{}
+		}
+		if item.Issue != nil && strings.EqualFold(item.Issue.State, "open") {
+			openIssues[issueSummaryKey(*item.Issue)] = struct{}{}
+		}
+		if item.Checks.State == CheckFailing {
+			if item.Checks.Failing > 0 {
+				summary.FailingCheckCount += item.Checks.Failing
+			} else {
+				summary.FailingCheckCount++
+			}
+		}
+	}
+	summary.OpenPullRequestCount = len(openPullRequests)
+	summary.OpenIssueCount = len(openIssues)
+	return summary
+}
+
+// RepositoryPathErrorItem exposes path and root diagnostics without hiding
+// repository work that loaded successfully.
+func RepositoryPathErrorItem(repo RepoRef, diagnostics []RepositoryDiagnostic) WorkItem {
+	summary := "repository path resolution failed"
+	if len(diagnostics) > 0 {
+		summary += ": " + DiagnosticSummary(diagnostics)
+	}
+	return WorkItem{
+		ID:     "repository-path-error:" + repo.FullName() + ":" + repositoryDiagnosticID(diagnostics),
+		Repo:   repo,
+		Branch: &BranchRef{Name: "repository discovery error"},
+		Local: &LocalStatus{
+			State:   LocalUnknown,
+			Summary: summary,
+		},
+		Checks: CheckSummary{State: CheckUnknown},
+	}
+}
+
+// DiagnosticSummary formats discovery diagnostics for compact UI display.
+func DiagnosticSummary(diagnostics []RepositoryDiagnostic) string {
+	parts := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Path == "" {
+			parts = append(parts, diagnostic.Message)
+			continue
+		}
+		parts = append(parts, diagnostic.Path+": "+diagnostic.Message)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func pullRequestSummaryKey(pr PullRequestRef) string {
+	if pr.Number > 0 {
+		return strconv.Itoa(pr.Number)
+	}
+	return pr.HeadOwner + ":" + pr.HeadBranch
+}
+
+func issueSummaryKey(issue IssueRef) string {
+	if issue.Number > 0 {
+		return strconv.Itoa(issue.Number)
+	}
+	return issue.Title
+}
+
+func repositoryDiagnosticID(diagnostics []RepositoryDiagnostic) string {
+	if len(diagnostics) == 0 {
+		return "unknown"
+	}
+	return fmt.Sprintf("%d", len(diagnostics))
+}

--- a/internal/workbench/repository_summary_test.go
+++ b/internal/workbench/repository_summary_test.go
@@ -1,0 +1,82 @@
+package workbench
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSummarizeRepositoryCountsPreviewFields(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	other := RepoRef{Owner: "0maru", Name: "dotfiles"}
+	items := []WorkItem{
+		{
+			ID:          "worktree:feature",
+			Repo:        repo,
+			Worktree:    &WorktreeRef{Path: "/repo-feature"},
+			PullRequest: &PullRequestRef{Number: 24, State: "open"},
+			Issue:       &IssueRef{Number: 74, State: "open"},
+			Checks:      CheckSummary{State: CheckFailing, Failing: 2},
+			Local:       &LocalStatus{State: LocalDirty},
+		},
+		{
+			ID:          "pull-request:duplicate",
+			Repo:        repo,
+			PullRequest: &PullRequestRef{Number: 24, State: "open"},
+			Issue:       &IssueRef{Number: 74, State: "open"},
+			Checks:      CheckSummary{State: CheckPassing, Passing: 1},
+			Local:       &LocalStatus{State: LocalMissing},
+		},
+		{
+			ID:          "pull-request:closed",
+			Repo:        repo,
+			PullRequest: &PullRequestRef{Number: 25, State: "closed"},
+			Issue:       &IssueRef{Number: 75, State: "closed"},
+			Checks:      CheckSummary{State: CheckFailing},
+			Local:       &LocalStatus{State: LocalMissing},
+		},
+		{
+			ID:          "worktree:other",
+			Repo:        other,
+			Worktree:    &WorktreeRef{Path: "/dotfiles"},
+			PullRequest: &PullRequestRef{Number: 1, State: "open"},
+			Issue:       &IssueRef{Number: 1, State: "open"},
+			Local:       &LocalStatus{State: LocalClean},
+		},
+	}
+
+	got := SummarizeRepository(repo, "/repo", "main", []string{"origin"}, items)
+
+	if got.Repo != repo || got.Path != "/repo" || got.DefaultBranch != "main" {
+		t.Fatalf("expected repository identity fields, got %+v", got)
+	}
+	if len(got.Remotes) != 1 || got.Remotes[0] != "origin" {
+		t.Fatalf("expected remotes to be copied, got %+v", got.Remotes)
+	}
+	if got.ActiveWorktreeCount != 1 {
+		t.Fatalf("expected one active worktree, got %d", got.ActiveWorktreeCount)
+	}
+	if got.OpenPullRequestCount != 1 || got.OpenIssueCount != 1 {
+		t.Fatalf("expected unique open PR/issue counts, got prs=%d issues=%d", got.OpenPullRequestCount, got.OpenIssueCount)
+	}
+	if got.FailingCheckCount != 3 {
+		t.Fatalf("expected failing check count to include explicit and implicit failures, got %d", got.FailingCheckCount)
+	}
+}
+
+func TestRepositoryPathErrorItemFormatsDiagnostics(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	item := RepositoryPathErrorItem(repo, []RepositoryDiagnostic{{
+		Path:    "repos.roots[0]",
+		Message: "\"/missing\" is not accessible",
+	}})
+
+	if !strings.HasPrefix(item.ID, "repository-path-error:0maru/gh-zen:") {
+		t.Fatalf("expected repository path error ID, got %q", item.ID)
+	}
+	if item.Title() != "repository discovery error" {
+		t.Fatalf("expected repository discovery error title, got %q", item.Title())
+	}
+	if item.Local == nil || !strings.Contains(item.Local.Summary, "repos.roots[0]") || !strings.Contains(item.Local.Summary, "not accessible") {
+		t.Fatalf("expected diagnostic summary, got %+v", item.Local)
+	}
+}

--- a/internal/workbench/runtime_loader.go
+++ b/internal/workbench/runtime_loader.go
@@ -8,10 +8,11 @@ type GitHubWorkbenchDiscovery interface {
 	IssueCheckDiscovery
 }
 
-// RuntimeLoadResult contains workbench data loaded for one repository.
+// RuntimeLoadResult contains refreshed workbench data.
 type RuntimeLoadResult struct {
-	Repo  RepoRef
-	Items []WorkItem
+	Repo         RepoRef
+	Repositories []RepositorySummary
+	Items        []WorkItem
 }
 
 // RuntimeLoader composes local Git discovery with GitHub workbench enrichment.

--- a/main.go
+++ b/main.go
@@ -35,7 +35,10 @@ func run() error {
 		return err
 	}
 
-	reloader := runtimeWorkbenchReloader{config: loadResult.Config}
+	reloader := runtimeWorkbenchReloader{
+		config:      loadResult.Config,
+		startupRepo: startupRepo.Repo,
+	}
 	data := loadStartupWorkbenchData(startupRepo, reloader)
 
 	_, err = tea.NewProgram(app.NewWithWorkbenchData(loadResult.Config, startupRepo.Repo, data), tea.WithAltScreen()).Run()
@@ -43,69 +46,209 @@ func run() error {
 }
 
 type runtimeWorkbenchReloader struct {
-	config config.Config
+	config      config.Config
+	startupRepo string
+	local       localrepo.Service
+	github      workbench.GitHubWorkbenchDiscovery
 }
 
 func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
+	local := r.local
+	rootPaths, rootDiagnostics := resolvedRepositoryRootPaths(r.config)
+	discovered, discoveryDiagnostics := local.DiscoverRepositories(ctx, rootPaths)
+
+	checkouts, diagnostics := r.repositoryCheckouts(ctx, repo, discovered)
+	diagnostics = append(diagnostics, repositoryDiagnosticsFromConfig(rootDiagnostics)...)
+	diagnostics = append(diagnostics, repositoryDiagnosticsFromLocal(discoveryDiagnostics)...)
+
+	items := []workbench.WorkItem{}
+	summaries := make([]workbench.RepositorySummary, 0, len(checkouts))
+	for _, checkout := range checkouts {
+		if checkout.path == "" {
+			items = append(items, workbench.RepositoryPathErrorItem(checkout.repo, checkout.diagnostics))
+			summaries = append(summaries, workbench.RepositorySummary{Repo: checkout.repo})
+			continue
+		}
+		result := (workbench.RuntimeLoader{
+			Repo:     checkout.repo,
+			RepoPath: checkout.path,
+			Local:    local,
+			GitHub:   r.githubDiscovery(),
+		}).Load(ctx)
+		items = append(items, result.Items...)
+		if len(checkout.diagnostics) > 0 {
+			items = append(items, workbench.RepositoryPathErrorItem(checkout.repo, checkout.diagnostics))
+		}
+		summaries = append(summaries, workbench.SummarizeRepository(
+			checkout.repo,
+			checkout.path,
+			checkout.defaultBranch,
+			checkout.remotes,
+			result.Items,
+		))
+	}
+	if len(diagnostics) > 0 {
+		diagnosticRepo := repositoryDiagnosticRepo(repo, summaries, r.startupRepo)
+		if len(summaries) == 0 {
+			summaries = append(summaries, workbench.RepositorySummary{Repo: diagnosticRepo})
+		}
+		items = append(items, workbench.RepositoryPathErrorItem(diagnosticRepo, diagnostics))
+	}
+
+	return workbench.RuntimeLoadResult{
+		Repo:         repo,
+		Repositories: summaries,
+		Items:        items,
+	}
+}
+
+func loadStartupWorkbenchData(startupRepo config.StartupRepository, reloader app.WorkbenchReloader) app.WorkbenchData {
+	data := app.WorkbenchData{
+		Reloader:       reloader,
+		InitialLoading: reloader != nil,
+	}
+	repo, ok := repoRefFromFullName(startupRepo.Repo)
+	if !ok {
+		return data
+	}
+
+	data.Repos = []workbench.RepoRef{repo}
+	return data
+}
+
+type repositoryCheckout struct {
+	repo          workbench.RepoRef
+	path          string
+	defaultBranch string
+	remotes       []string
+	diagnostics   []workbench.RepositoryDiagnostic
+}
+
+func (r runtimeWorkbenchReloader) repositoryCheckouts(ctx context.Context, selected workbench.RepoRef, discovered []localrepo.Repository) ([]repositoryCheckout, []workbench.RepositoryDiagnostic) {
+	checkouts := make([]repositoryCheckout, 0, len(discovered)+1)
+	diagnostics := []workbench.RepositoryDiagnostic{}
+	seen := map[workbench.RepoRef]struct{}{}
+	for _, repository := range discovered {
+		repoName, err := config.ParseGitHubRemoteURL(repository.OriginURL)
+		if err != nil {
+			diagnostics = append(diagnostics, workbench.RepositoryDiagnostic{
+				Path:    repository.Path,
+				Message: err.Error(),
+			})
+			continue
+		}
+		repo, ok := repoRefFromFullName(repoName)
+		if !ok {
+			continue
+		}
+		if _, ok := seen[repo]; ok {
+			continue
+		}
+		seen[repo] = struct{}{}
+		checkouts = append(checkouts, repositoryCheckout{
+			repo:          repo,
+			path:          repository.Path,
+			defaultBranch: repository.DefaultBranch,
+			remotes:       repository.Remotes,
+		})
+	}
+	requested, ok := r.requestedRepository(selected)
+	if !ok {
+		return checkouts, diagnostics
+	}
+	if _, ok := seen[requested]; ok {
+		return checkouts, diagnostics
+	}
+	checkout := r.checkoutForRepository(ctx, requested)
+	return append([]repositoryCheckout{checkout}, checkouts...), diagnostics
+}
+
+func (r runtimeWorkbenchReloader) checkoutForRepository(ctx context.Context, repo workbench.RepoRef) repositoryCheckout {
 	resolvedPath := config.ResolveRepositoryPath(config.RepositoryPathOptions{
 		Repo:   repo.FullName(),
 		Config: r.config,
 	})
 	if resolvedPath.Path == "" {
-		return workbench.RuntimeLoadResult{
-			Repo:  repo,
-			Items: []workbench.WorkItem{repositoryPathErrorItem(repo, resolvedPath.Diagnostics)},
+		return repositoryCheckout{
+			repo:        repo,
+			diagnostics: repositoryDiagnosticsFromConfig(resolvedPath.Diagnostics),
 		}
 	}
-	return (workbench.RuntimeLoader{
-		Repo:     repo,
-		RepoPath: resolvedPath.Path,
-		Local:    localrepo.Service{},
-		GitHub:   github.CLIService{},
-	}).Load(ctx)
-}
-
-func loadStartupWorkbenchData(startupRepo config.StartupRepository, reloader app.WorkbenchReloader) app.WorkbenchData {
-	repo, ok := repoRefFromFullName(startupRepo.Repo)
-	if !ok {
-		return app.WorkbenchData{}
+	metadata, err := r.local.RepositoryMetadata(ctx, resolvedPath.Path)
+	if err != nil {
+		return repositoryCheckout{
+			repo: repo,
+			path: resolvedPath.Path,
+			diagnostics: []workbench.RepositoryDiagnostic{{
+				Path:    resolvedPath.Path,
+				Message: err.Error(),
+			}},
+		}
 	}
-
-	data := app.WorkbenchData{
-		Repos:          []workbench.RepoRef{repo},
-		Reloader:       reloader,
-		InitialLoading: reloader != nil,
-	}
-	return data
-}
-
-func repositoryPathErrorItem(repo workbench.RepoRef, diagnostics []config.Diagnostic) workbench.WorkItem {
-	summary := "repository path resolution failed"
-	if len(diagnostics) > 0 {
-		summary += ": " + diagnosticSummary(diagnostics)
-	}
-	return workbench.WorkItem{
-		ID:     "repository-path-error:" + repo.FullName(),
-		Repo:   repo,
-		Branch: &workbench.BranchRef{Name: "repository path error"},
-		Local: &workbench.LocalStatus{
-			State:   workbench.LocalUnknown,
-			Summary: summary,
-		},
-		Checks: workbench.CheckSummary{State: workbench.CheckUnknown},
+	return repositoryCheckout{
+		repo:          repo,
+		path:          resolvedPath.Path,
+		defaultBranch: metadata.DefaultBranch,
+		remotes:       metadata.Remotes,
 	}
 }
 
-func diagnosticSummary(diagnostics []config.Diagnostic) string {
-	parts := make([]string, 0, len(diagnostics))
+func (r runtimeWorkbenchReloader) requestedRepository(selected workbench.RepoRef) (workbench.RepoRef, bool) {
+	if selected != (workbench.RepoRef{}) {
+		return selected, true
+	}
+	return repoRefFromFullName(r.startupRepo)
+}
+
+func (r runtimeWorkbenchReloader) githubDiscovery() workbench.GitHubWorkbenchDiscovery {
+	if r.github != nil {
+		return r.github
+	}
+	return github.CLIService{}
+}
+
+func resolvedRepositoryRootPaths(cfg config.Config) ([]string, []config.Diagnostic) {
+	roots, diagnostics := config.ResolveRepositoryRoots(cfg)
+	paths := make([]string, 0, len(roots))
+	for _, root := range roots {
+		paths = append(paths, root.Path)
+	}
+	return paths, diagnostics
+}
+
+func repositoryDiagnosticsFromConfig(diagnostics []config.Diagnostic) []workbench.RepositoryDiagnostic {
+	out := make([]workbench.RepositoryDiagnostic, 0, len(diagnostics))
 	for _, diagnostic := range diagnostics {
-		if diagnostic.Path == "" {
-			parts = append(parts, diagnostic.Message)
-			continue
-		}
-		parts = append(parts, diagnostic.Path+": "+diagnostic.Message)
+		out = append(out, workbench.RepositoryDiagnostic{
+			Path:    diagnostic.Path,
+			Message: diagnostic.Message,
+		})
 	}
-	return strings.Join(parts, "; ")
+	return out
+}
+
+func repositoryDiagnosticsFromLocal(diagnostics []localrepo.RepositoryDiagnostic) []workbench.RepositoryDiagnostic {
+	out := make([]workbench.RepositoryDiagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		out = append(out, workbench.RepositoryDiagnostic{
+			Path:    diagnostic.Path,
+			Message: diagnostic.Message,
+		})
+	}
+	return out
+}
+
+func repositoryDiagnosticRepo(selected workbench.RepoRef, summaries []workbench.RepositorySummary, startupRepo string) workbench.RepoRef {
+	if selected != (workbench.RepoRef{}) {
+		return selected
+	}
+	if repo, ok := repoRefFromFullName(startupRepo); ok {
+		return repo
+	}
+	if len(summaries) > 0 {
+		return summaries[0].Repo
+	}
+	return workbench.RepoRef{Owner: "local", Name: "repositories"}
 }
 
 func repoRefFromFullName(repoName string) (workbench.RepoRef, bool) {

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ type repositoryCheckout struct {
 func (r runtimeWorkbenchReloader) repositoryCheckouts(ctx context.Context, selected workbench.RepoRef, discovered []localrepo.Repository) ([]repositoryCheckout, []workbench.RepositoryDiagnostic) {
 	checkouts := make([]repositoryCheckout, 0, len(discovered)+1)
 	diagnostics := []workbench.RepositoryDiagnostic{}
-	seen := map[workbench.RepoRef]struct{}{}
+	seen := map[string]struct{}{}
 	for _, repository := range discovered {
 		repoName, err := config.ParseGitHubRemoteURL(repository.OriginURL)
 		if err != nil {
@@ -141,10 +141,11 @@ func (r runtimeWorkbenchReloader) repositoryCheckouts(ctx context.Context, selec
 		if !ok {
 			continue
 		}
-		if _, ok := seen[repo]; ok {
+		key := repoFullNameKey(repo)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[repo] = struct{}{}
+		seen[key] = struct{}{}
 		checkouts = append(checkouts, repositoryCheckout{
 			repo:          repo,
 			path:          repository.Path,
@@ -156,7 +157,7 @@ func (r runtimeWorkbenchReloader) repositoryCheckouts(ctx context.Context, selec
 	if !ok {
 		return checkouts, diagnostics
 	}
-	if _, ok := seen[requested]; ok {
+	if _, ok := seen[repoFullNameKey(requested)]; ok {
 		return checkouts, diagnostics
 	}
 	checkout := r.checkoutForRepository(ctx, requested)
@@ -261,4 +262,8 @@ func repoRefFromFullName(repoName string) (workbench.RepoRef, bool) {
 
 func sameRepoFullName(left string, right string) bool {
 	return strings.EqualFold(left, right)
+}
+
+func repoFullNameKey(repo workbench.RepoRef) string {
+	return strings.ToLower(repo.FullName())
 }

--- a/main_test.go
+++ b/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/0maru/gh-zen/internal/config"
+	"github.com/0maru/gh-zen/internal/localrepo"
 	"github.com/0maru/gh-zen/internal/workbench"
 )
 
@@ -53,6 +54,30 @@ func TestSameRepoFullName(t *testing.T) {
 	}
 	if sameRepoFullName("owner/other", "owner/repo") {
 		t.Fatalf("expected different repo names not to match")
+	}
+}
+
+func TestRepositoryCheckoutsDedupesRequestedRepoCaseInsensitively(t *testing.T) {
+	selected := workbench.RepoRef{Owner: "owner", Name: "repo"}
+	checkouts, diagnostics := (runtimeWorkbenchReloader{config: config.Defaults()}).repositoryCheckouts(
+		context.Background(),
+		selected,
+		[]localrepo.Repository{{
+			Path:          "/repos/repo",
+			OriginURL:     "https://github.com/Owner/Repo.git",
+			DefaultBranch: "main",
+			Remotes:       []string{"origin"},
+		}},
+	)
+
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %+v", diagnostics)
+	}
+	if len(checkouts) != 1 {
+		t.Fatalf("expected one checkout, got %+v", checkouts)
+	}
+	if checkouts[0].path != "/repos/repo" || checkouts[0].repo.FullName() != "Owner/Repo" {
+		t.Fatalf("expected discovered checkout only, got %+v", checkouts[0])
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,10 +1,37 @@
 package main
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/0maru/gh-zen/internal/config"
 	"github.com/0maru/gh-zen/internal/workbench"
 )
+
+type fakeMainGitHub struct {
+	prsByRepo    map[string][]workbench.PullRequestRef
+	issuesByRepo map[string][]workbench.IssueRef
+	checks       map[string]workbench.CheckSummary
+}
+
+func (f fakeMainGitHub) PullRequests(_ context.Context, repo string) ([]workbench.PullRequestRef, error) {
+	return append([]workbench.PullRequestRef(nil), f.prsByRepo[repo]...), nil
+}
+
+func (f fakeMainGitHub) Issues(_ context.Context, repo string) ([]workbench.IssueRef, error) {
+	return append([]workbench.IssueRef(nil), f.issuesByRepo[repo]...), nil
+}
+
+func (f fakeMainGitHub) CheckSummary(_ context.Context, repo string, ref string) (workbench.CheckSummary, error) {
+	if summary, ok := f.checks[repo+"@"+ref]; ok {
+		return summary, nil
+	}
+	return workbench.CheckSummary{State: workbench.CheckUnknown}, nil
+}
 
 func TestRepoRefFromFullName(t *testing.T) {
 	got, ok := repoRefFromFullName("0maru/gh-zen")
@@ -26,5 +53,149 @@ func TestSameRepoFullName(t *testing.T) {
 	}
 	if sameRepoFullName("owner/other", "owner/repo") {
 		t.Fatalf("expected different repo names not to match")
+	}
+}
+
+func TestRuntimeWorkbenchReloaderDiscoversConfiguredRoots(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	ghZenPath := filepath.Join(root, "0maru", "gh-zen")
+	dotfilesPath := filepath.Join(root, "0maru", "dotfiles")
+	initRuntimeRepo(t, ghZenPath, "https://github.com/0maru/gh-zen.git")
+	initRuntimeRepo(t, dotfilesPath, "git@github.com:0maru/dotfiles.git")
+	featurePath := filepath.Join(t.TempDir(), "gh-zen-feature")
+	runRuntimeGit(t, ghZenPath, "worktree", "add", "-b", "feature/issue-74", featurePath)
+
+	cfg := config.Defaults()
+	cfg.Repos.Roots = []string{root, filepath.Join(root, "missing")}
+	reloader := runtimeWorkbenchReloader{
+		config:      cfg,
+		startupRepo: "0maru/dotfiles",
+		github: fakeMainGitHub{
+			prsByRepo: map[string][]workbench.PullRequestRef{
+				"0maru/gh-zen": {{
+					Number:     74,
+					Title:      "Repository root discovery",
+					State:      "open",
+					HeadOwner:  "0maru",
+					HeadBranch: "feature/issue-74",
+					LinkedIssues: []workbench.IssueRef{{
+						Number:  74,
+						Certain: true,
+					}},
+				}},
+			},
+			issuesByRepo: map[string][]workbench.IssueRef{
+				"0maru/gh-zen": {{
+					Number:  74,
+					Title:   "Repository root discovery",
+					State:   "open",
+					Certain: true,
+				}},
+			},
+			checks: map[string]workbench.CheckSummary{
+				"0maru/gh-zen@feature/issue-74": {State: workbench.CheckFailing, Failing: 1},
+			},
+		},
+	}
+
+	result := reloader.Load(context.Background(), workbench.RepoRef{Owner: "0maru", Name: "dotfiles"})
+
+	ghZenSummary := requireRepositorySummary(t, result.Repositories, workbench.RepoRef{Owner: "0maru", Name: "gh-zen"})
+	if !sameRuntimePath(t, ghZenSummary.Path, ghZenPath) {
+		t.Fatalf("expected gh-zen path %q, got %+v", ghZenPath, ghZenSummary)
+	}
+	if ghZenSummary.DefaultBranch != "main" {
+		t.Fatalf("expected default branch main, got %+v", ghZenSummary)
+	}
+	if len(ghZenSummary.Remotes) != 1 || ghZenSummary.Remotes[0] != "origin" {
+		t.Fatalf("expected origin remote, got %+v", ghZenSummary.Remotes)
+	}
+	if ghZenSummary.ActiveWorktreeCount != 2 {
+		t.Fatalf("expected main and feature worktrees to be active, got %+v", ghZenSummary)
+	}
+	if ghZenSummary.OpenPullRequestCount != 1 || ghZenSummary.OpenIssueCount != 1 || ghZenSummary.FailingCheckCount != 1 {
+		t.Fatalf("expected GitHub preview counts, got %+v", ghZenSummary)
+	}
+	requireRepositorySummary(t, result.Repositories, workbench.RepoRef{Owner: "0maru", Name: "dotfiles"})
+
+	if !hasRuntimeItem(result.Items, func(item workbench.WorkItem) bool {
+		return item.Repo.FullName() == "0maru/gh-zen" &&
+			item.Branch != nil &&
+			item.Branch.Name == "feature/issue-74" &&
+			item.PullRequest != nil &&
+			item.PullRequest.Number == 74 &&
+			item.Checks.State == workbench.CheckFailing
+	}) {
+		t.Fatalf("expected enriched feature work item, got %+v", result.Items)
+	}
+	if !hasRuntimeItem(result.Items, func(item workbench.WorkItem) bool {
+		return strings.HasPrefix(item.ID, "repository-path-error:") &&
+			item.Local != nil &&
+			strings.Contains(item.Local.Summary, "repos.roots[1]") &&
+			strings.Contains(item.Local.Summary, "not accessible")
+	}) {
+		t.Fatalf("expected missing root diagnostic item while preserving work, got %+v", result.Items)
+	}
+}
+
+func requireRepositorySummary(t *testing.T, summaries []workbench.RepositorySummary, repo workbench.RepoRef) workbench.RepositorySummary {
+	t.Helper()
+	for _, summary := range summaries {
+		if summary.Repo == repo {
+			return summary
+		}
+	}
+	t.Fatalf("repository summary %+v not found in %+v", repo, summaries)
+	return workbench.RepositorySummary{}
+}
+
+func hasRuntimeItem(items []workbench.WorkItem, match func(workbench.WorkItem) bool) bool {
+	for _, item := range items {
+		if match(item) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameRuntimePath(t *testing.T, got string, want string) bool {
+	t.Helper()
+	gotResolved, err := filepath.EvalSymlinks(got)
+	if err != nil {
+		t.Fatalf("resolve got path %q: %v", got, err)
+	}
+	wantResolved, err := filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatalf("resolve want path %q: %v", want, err)
+	}
+	return gotResolved == wantResolved
+}
+
+func initRuntimeRepo(t *testing.T, dir string, origin string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	runRuntimeGit(t, dir, "init", "-b", "main")
+	runRuntimeGit(t, dir, "config", "user.email", "test@example.com")
+	runRuntimeGit(t, dir, "config", "user.name", "Test User")
+	runRuntimeGit(t, dir, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("initial\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runRuntimeGit(t, dir, "add", "README.md")
+	runRuntimeGit(t, dir, "commit", "-m", "initial")
+	runRuntimeGit(t, dir, "remote", "add", "origin", origin)
+}
+
+func runRuntimeGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
 	}
 }


### PR DESCRIPTION
## Summary

- Implements 0-104.

## Source

- Linear: https://linear.app/0maru/issue/0-104/gh-zen-discover-and-browse-repositories-from-configured-roots
- Source type: github_issue
- Source key: 0maru/gh-zen#74
- Source URL: https://github.com/0maru/gh-zen/issues/74
- Closes 0maru/gh-zen#74

## Target

- Repository: gh-zen
- Base branch: main

## Verification

- See the Symphony/Codex run output and Linear issue comments.
