### PR TITLE
[gh-zen] Add first-class issue browsing

### DIFF
--- a/docs/validation/issue-browsing.md
+++ b/docs/validation/issue-browsing.md
@@ -1,0 +1,44 @@
+# Issue Browsing Validation
+
+This plan covers real GitHub behavior for first-class issue browsing in the
+terminal. It is intentionally manual because it requires authenticated `gh`,
+clipboard access, and browser opening on the reviewer machine.
+
+## Prerequisites
+
+- `gh auth status` succeeds for an account that can read the target repository.
+- The target repository has a mix of open and closed issues.
+- At least one issue has labels, an assignee, a milestone, and comments.
+- At least one pull request links to an issue through GitHub closing references.
+
+## Plan
+
+1. Start `gh zen` from a repository configured for the target `owner/repo`.
+2. Select a workbench item that has a linked issue and press `i`.
+3. Verify the issue view opens and selects the linked issue.
+4. Verify the issue list shows number, title, state, labels, assignees,
+   milestone, author, updated time, and comments count where available.
+5. Press `s` to cycle open, closed, and all state filters.
+6. Press `a`, `b`, and `m` to cycle assignee, label, and milestone filters.
+7. Press `/`, enter a query with Unicode text, and confirm matching issues are
+   filtered without corrupting the query.
+8. Verify the preview shows title, state, labels, assignees, milestone, body
+   excerpt, linked pull requests, and comments count when those fields exist.
+9. Press `y` to copy the selected issue URL.
+10. Press `n` to copy the selected issue number in `#123` form.
+11. Press `o` to open the selected issue in the browser.
+12. Press `q` or `esc` and verify the original workbench repository, item, and
+    pane selection are restored.
+
+## Expected Result
+
+- Issue browsing stays inside the terminal until `o` is explicitly used.
+- Filters update the issue list without changing GitHub data.
+- Linked pull requests come from existing pull request issue references.
+- Comments summary is limited to the comments count.
+- Workbench selection is preserved after returning from issue browsing.
+
+## Notes
+
+- ADR 0010 is not added in this change. Track the broader terminal-first GitHub
+  browsing product direction in a separate issue if an ADR is still needed.

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -134,7 +134,7 @@ func (m *model) backToWorkbench() tea.Cmd {
 }
 
 func (m *model) prepareIssueDataForRepo(repo workbench.RepoRef) {
-	if m.issueRepo == repo {
+	if strings.EqualFold(m.issueRepo.FullName(), repo.FullName()) {
 		return
 	}
 	m.issueRepo = repo
@@ -149,8 +149,12 @@ func (m *model) updateIssueDataFromRuntimeResult(result workbench.RuntimeLoadRes
 	if issue, ok := m.selectedIssueRef(); ok {
 		selectedNumber = issue.Number
 	}
-	m.issueRepo = result.Repo
-	workItemIssues := issuesFromWorkItems(result.Items, result.Repo)
+	issueRepo := result.IssuesRepo
+	if !hasRepoRef(issueRepo) {
+		issueRepo = result.Repo
+	}
+	m.issueRepo = issueRepo
+	workItemIssues := issuesFromWorkItems(result.Items, issueRepo)
 	if result.IssuesLoaded {
 		m.issues = mergeIssueRefs(result.Issues, workItemIssues)
 	} else {
@@ -159,12 +163,12 @@ func (m *model) updateIssueDataFromRuntimeResult(result workbench.RuntimeLoadRes
 	if result.PullRequestsLoaded {
 		m.prsByIssueNumber = pullRequestsByIssueNumber(result.PullRequests)
 	} else {
-		m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(result.Items, result.Repo))
+		m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(result.Items, issueRepo))
 	}
 	if result.ViewerSubject.Login != "" {
 		m.viewerLogin = result.ViewerSubject.Login
 	}
-	m.issuesError = issueDiscoveryErrorFromWorkItems(result.Items, result.Repo)
+	m.issuesError = issueDiscoveryErrorFromWorkItems(result.Items, issueRepo)
 	if selectedNumber > 0 && m.selectIssueNumber(selectedNumber) {
 		return
 	}

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -94,6 +94,7 @@ func (m *model) enterIssueView() tea.Cmd {
 	m.screen = screenIssues
 	m.focusedPane = paneWorkItems
 	m.issueSearchEditing = false
+	m.issuePreviewOffset = 0
 	if m.workbenchLoading {
 		m.issuesLoading = true
 	}
@@ -149,9 +150,11 @@ func (m *model) prepareIssueDataForRepo(repo workbench.RepoRef) {
 	m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(m.workItems, repo))
 	m.issuesError = issueDiscoveryErrorFromWorkItems(m.workItems, repo)
 	m.selectedIssue = 0
+	m.issuePreviewOffset = 0
 }
 
 func (m *model) updateIssueDataFromRuntimeResult(result workbench.RuntimeLoadResult) {
+	m.issuePreviewOffset = 0
 	selectedNumber := 0
 	if issue, ok := m.selectedIssueRef(); ok {
 		selectedNumber = issue.Number
@@ -270,6 +273,7 @@ func (m *model) selectIssueNumber(number int) bool {
 	for i, issue := range m.visibleIssues() {
 		if issue.Number == number {
 			m.selectedIssue = i
+			m.issuePreviewOffset = 0
 			return true
 		}
 	}
@@ -290,7 +294,11 @@ func (m *model) moveIssueSelection(delta int) {
 		m.selectedIssue = 0
 		return
 	}
-	m.selectedIssue = clamp(m.selectedIssue+delta, 0, len(issues)-1)
+	next := clamp(m.selectedIssue+delta, 0, len(issues)-1)
+	if next != m.selectedIssue {
+		m.selectedIssue = next
+		m.issuePreviewOffset = 0
+	}
 }
 
 func (m *model) jumpIssueSelection(toEnd bool) {
@@ -301,12 +309,14 @@ func (m *model) jumpIssueSelection(toEnd bool) {
 	}
 	if toEnd {
 		m.selectedIssue = len(issues) - 1
-		return
+	} else {
+		m.selectedIssue = 0
 	}
-	m.selectedIssue = 0
+	m.issuePreviewOffset = 0
 }
 
 func (m *model) clampIssueSelection() {
+	m.issuePreviewOffset = 0
 	issues := m.visibleIssues()
 	if len(issues) == 0 {
 		m.selectedIssue = 0
@@ -423,7 +433,7 @@ func (m model) renderIssueFull(width int) string {
 		bodyHeight = max(m.height-len(out)-frameBorderLines, 1)
 	}
 	left := m.issueLines(paneTextWidth(leftWidth), bodyHeight, focus == paneWorkItems)
-	right := m.issuePreviewLines(paneTextWidth(rightWidth))
+	right := m.issuePreviewViewportLines(paneTextWidth(rightWidth), bodyHeight)
 	if bodyHeight == 0 {
 		bodyHeight = max(len(left), len(right))
 	}
@@ -443,7 +453,6 @@ func (m model) renderIssueCompact(width int) string {
 	focus := m.activePane()
 	out := m.headerLines("gh-zen issues: "+m.issueRepo.FullName(), width)
 
-	previewLines := m.issuePreviewLines(paneTextWidth(contentWidth))
 	issueHeight := 0
 	previewHeight := 0
 	if m.height > 0 {
@@ -452,6 +461,7 @@ func (m model) renderIssueCompact(width int) string {
 		previewHeight = max(availableContentHeight-issueHeight, 1)
 	}
 	issueLines := m.issueLines(paneTextWidth(contentWidth), issueHeight, focus == paneWorkItems)
+	previewLines := m.issuePreviewViewportLines(paneTextWidth(contentWidth), previewHeight)
 	if m.height <= 0 {
 		issueHeight = len(issueLines)
 		previewHeight = len(previewLines)
@@ -483,12 +493,12 @@ func (m model) issueLines(width int, maxLines int, focused bool) []string {
 	blocks := make([][]string, 0, len(issues))
 	for i, issue := range issues {
 		marker := selectionMarker(i == m.selectedIssue, focused)
-		row := fmt.Sprintf("%s %-7s %-7s %4s %-12s %s",
+		row := fmt.Sprintf("%s %-7s %-7s %4s %s %s",
 			marker,
 			issueNumberLabel(issue.Number),
 			issueStateLabel(issue.State),
 			issueCommentShortLabel(issue.CommentsCount),
-			emptyFallback(issue.AuthorLogin, "-"),
+			pad(emptyFallback(issue.AuthorLogin, "-"), 12),
 			issue.Title,
 		)
 		block := []string{truncate(row, width)}
@@ -611,6 +621,52 @@ func (m model) issuePreviewLines(width int) []string {
 		lines = append(lines, truncate("URL: "+issue.URL, width))
 	}
 	return lines
+}
+
+func (m model) issuePreviewViewportLines(width int, maxLines int) []string {
+	lines := m.issuePreviewLines(width)
+	if maxLines <= 0 || len(lines) <= maxLines {
+		return lines
+	}
+	start := clamp(m.issuePreviewOffset, 0, len(lines)-maxLines)
+	return lines[start : start+maxLines]
+}
+
+func (m *model) moveIssuePreview(delta int) {
+	width, height := m.issuePreviewViewportSize()
+	lines := m.issuePreviewLines(width)
+	maxOffset := max(len(lines)-height, 0)
+	current := clamp(m.issuePreviewOffset, 0, maxOffset)
+	m.issuePreviewOffset = clamp(current+delta, 0, maxOffset)
+}
+
+func (m *model) jumpIssuePreview(toEnd bool) {
+	if !toEnd {
+		m.issuePreviewOffset = 0
+		return
+	}
+	width, height := m.issuePreviewViewportSize()
+	m.issuePreviewOffset = max(len(m.issuePreviewLines(width))-height, 0)
+}
+
+func (m model) issuePreviewViewportSize() (int, int) {
+	width := m.effectiveWidth()
+	if width < issueLayoutMinWidth {
+		contentWidth := max(width-paneBorderWidth, 0)
+		if m.height <= 0 {
+			return paneTextWidth(contentWidth), 1
+		}
+		headerHeight := len(m.headerLines("gh-zen issues: "+m.issueRepo.FullName(), width))
+		availableHeight := max(m.height-headerHeight-frameBorderLines*2, 2)
+		issueHeight := max(availableHeight/2, 1)
+		return paneTextWidth(contentWidth), max(availableHeight-issueHeight, 1)
+	}
+	rightWidth := width - issueListPaneWidth - paneBorderWidth*2 - paneGapWidth
+	if m.height <= 0 {
+		return paneTextWidth(rightWidth), 1
+	}
+	headerHeight := len(m.headerLines("gh-zen  issues: "+m.issueRepo.FullName(), width))
+	return paneTextWidth(rightWidth), max(m.height-headerHeight-frameBorderLines, 1)
 }
 
 func issueListMeta(issue workbench.IssueRef) string {
@@ -758,19 +814,31 @@ func hasCaseFolded(values []string, target string) bool {
 func issuesFromWorkItems(items []workbench.WorkItem, repo workbench.RepoRef) []workbench.IssueRef {
 	byNumber := map[int]workbench.IssueRef{}
 	ordered := []workbench.IssueRef{}
-	for _, item := range items {
-		if item.Repo != repo || item.Issue == nil || item.Issue.Number == 0 {
-			continue
+	appendIssue := func(issue workbench.IssueRef) {
+		if issue.Number == 0 {
+			return
 		}
-		if !item.Issue.Certain && item.Issue.Source == workbench.IssueLinkSourceBranch {
-			continue
+		if !issue.Certain && issue.Source == workbench.IssueLinkSourceBranch {
+			return
 		}
-		if _, ok := byNumber[item.Issue.Number]; ok {
-			continue
+		if _, ok := byNumber[issue.Number]; ok {
+			return
 		}
-		issue := *item.Issue
 		byNumber[issue.Number] = issue
 		ordered = append(ordered, issue)
+	}
+	for _, item := range items {
+		if item.Repo != repo {
+			continue
+		}
+		if item.Issue != nil {
+			appendIssue(*item.Issue)
+		}
+		if item.PullRequest != nil {
+			for _, issue := range item.PullRequest.LinkedIssues {
+				appendIssue(issue)
+			}
+		}
 	}
 	return ordered
 }

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -82,6 +82,7 @@ func (m *model) enterIssueView() tea.Cmd {
 		returnRepo = selectedRepo
 	}
 	m.prepareIssueDataForRepo(repo)
+	m.pendingIssueNumber = targetIssueNumber
 	m.workbenchReturn = workbenchReturnState{
 		valid:           true,
 		selectedRepo:    m.selectedRepo,
@@ -102,6 +103,7 @@ func (m *model) enterIssueView() tea.Cmd {
 	if targetIssueNumber > 0 {
 		m.ensureIssueVisible(targetIssueNumber)
 		if m.selectIssueNumber(targetIssueNumber) {
+			m.pendingIssueNumber = 0
 			m.statusMessage = ""
 			return m.startIssueViewReload()
 		}
@@ -146,6 +148,7 @@ func (m *model) backToWorkbench() tea.Cmd {
 	m.issueSearchEditing = false
 	m.issueReloadPending = false
 	m.pendingIssueRepo = workbench.RepoRef{}
+	m.pendingIssueNumber = 0
 	if m.workbenchReturn.valid {
 		m.selectedRepo = m.workbenchReturn.selectedRepo
 		m.selectedView = m.workbenchReturn.selectedView
@@ -163,10 +166,11 @@ func (m *model) prepareIssueDataForRepo(repo workbench.RepoRef) {
 	}
 	m.issueRepo = repo
 	m.issues = issuesFromWorkItems(m.workItems, repo)
-	m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(m.workItems, repo))
+	m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(m.workItems, repo), repo)
 	m.issuesError = issueDiscoveryErrorFromWorkItems(m.workItems, repo)
 	m.selectedIssue = 0
 	m.issuePreviewOffset = 0
+	m.pendingIssueNumber = 0
 }
 
 func (m *model) updateIssueDataFromRuntimeResult(result workbench.RuntimeLoadResult) {
@@ -190,14 +194,14 @@ func (m *model) updateIssueDataFromRuntimeResult(result workbench.RuntimeLoadRes
 		m.issues = workItemIssues
 	}
 	if result.PullRequestsLoaded {
-		m.prsByIssueNumber = pullRequestsByIssueNumber(result.PullRequests)
+		m.prsByIssueNumber = pullRequestsByIssueNumber(result.PullRequests, issueRepo)
 	} else if sameIssueRepo {
 		m.prsByIssueNumber = mergePullRequestIndexes(
 			m.prsByIssueNumber,
-			pullRequestsByIssueNumber(pullRequestsFromWorkItems(result.Items, issueRepo)),
+			pullRequestsByIssueNumber(pullRequestsFromWorkItems(result.Items, issueRepo), issueRepo),
 		)
 	} else {
-		m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(result.Items, issueRepo))
+		m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(result.Items, issueRepo), issueRepo)
 	}
 	if result.ViewerSubject.Login != "" {
 		m.viewerLogin = result.ViewerSubject.Login
@@ -207,6 +211,14 @@ func (m *model) updateIssueDataFromRuntimeResult(result workbench.RuntimeLoadRes
 		m.issuesError = result.IssuesError
 		if m.issuesError == "" {
 			m.issuesError = issueDiscoveryErrorFromWorkItems(result.Items, issueRepo)
+		}
+	}
+	if m.pendingIssueNumber > 0 {
+		m.ensureIssueVisible(m.pendingIssueNumber)
+		if m.selectIssueNumber(m.pendingIssueNumber) {
+			m.pendingIssueNumber = 0
+			m.statusMessage = ""
+			return
 		}
 	}
 	if selectedNumber > 0 && m.selectIssueNumber(selectedNumber) {
@@ -834,6 +846,9 @@ func issuesFromWorkItems(items []workbench.WorkItem, repo workbench.RepoRef) []w
 		if issue.Number == 0 {
 			return
 		}
+		if issue.Repository != "" && !strings.EqualFold(issue.Repository, repo.FullName()) {
+			return
+		}
 		if !issue.Certain && issue.Source == workbench.IssueLinkSourceBranch {
 			return
 		}
@@ -897,12 +912,15 @@ func pullRequestsFromWorkItems(items []workbench.WorkItem, repo workbench.RepoRe
 	return prs
 }
 
-func pullRequestsByIssueNumber(prs []workbench.PullRequestRef) map[int][]workbench.PullRequestRef {
+func pullRequestsByIssueNumber(prs []workbench.PullRequestRef, repo workbench.RepoRef) map[int][]workbench.PullRequestRef {
 	out := map[int][]workbench.PullRequestRef{}
 	for _, pr := range prs {
 		seenIssues := map[int]bool{}
 		for _, issue := range pr.LinkedIssues {
 			if issue.Number == 0 || seenIssues[issue.Number] {
+				continue
+			}
+			if hasRepoRef(repo) && issue.Repository != "" && !strings.EqualFold(issue.Repository, repo.FullName()) {
 				continue
 			}
 			out[issue.Number] = append(out[issue.Number], pr)

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -102,14 +102,21 @@ func (m *model) enterIssueView() tea.Cmd {
 		m.ensureIssueVisible(targetIssueNumber)
 		if m.selectIssueNumber(targetIssueNumber) {
 			m.statusMessage = ""
-			return nil
+			return m.startIssueViewReload()
 		}
 		m.statusMessage = fmt.Sprintf("Issue #%d is not in the loaded issue list", targetIssueNumber)
-		return nil
+		return m.startIssueViewReload()
 	}
 	m.clampIssueSelection()
 	m.statusMessage = ""
-	return nil
+	return m.startIssueViewReload()
+}
+
+func (m *model) startIssueViewReload() tea.Cmd {
+	if m.workbenchReloader == nil || !hasRepoRef(m.issueRepo) {
+		return nil
+	}
+	return m.startWorkbenchReload("Loading issues...")
 }
 
 func (m *model) backToWorkbench() tea.Cmd {

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -1,0 +1,734 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/0maru/gh-zen/internal/workbench"
+)
+
+const (
+	issueAssigneeMe         = "@me"
+	issueAssigneeUnassigned = "(unassigned)"
+)
+
+type issueStateFilter int
+
+const (
+	issueStateOpen issueStateFilter = iota
+	issueStateClosed
+	issueStateAll
+)
+
+type issueFilterState struct {
+	State     issueStateFilter
+	Assignee  string
+	Label     string
+	Milestone string
+	Search    string
+}
+
+func defaultIssueFilterState() issueFilterState {
+	return issueFilterState{State: issueStateOpen}
+}
+
+func (f issueStateFilter) String() string {
+	switch f {
+	case issueStateClosed:
+		return "closed"
+	case issueStateAll:
+		return "all"
+	default:
+		return "open"
+	}
+}
+
+func (f issueStateFilter) next() issueStateFilter {
+	switch f {
+	case issueStateOpen:
+		return issueStateClosed
+	case issueStateClosed:
+		return issueStateAll
+	default:
+		return issueStateOpen
+	}
+}
+
+func (m *model) enterIssueView() tea.Cmd {
+	repo, ok := m.selectedRepoRef()
+	if !ok {
+		m.statusMessage = "No repository selected"
+		return nil
+	}
+
+	targetIssueNumber := 0
+	if item, ok := m.selectedWorkItem(); ok && item.Issue != nil {
+		targetIssueNumber = item.Issue.Number
+	}
+
+	m.prepareIssueDataForRepo(repo)
+	m.workbenchReturn = workbenchReturnState{
+		valid:        true,
+		selectedRepo: m.selectedRepo,
+		selectedView: m.selectedView,
+		viewSelected: m.viewSelected,
+		selectedItem: m.selectedItem,
+		focusedPane:  m.focusedPane,
+	}
+	m.screen = screenIssues
+	m.focusedPane = paneWorkItems
+	m.issueSearchEditing = false
+	if m.workbenchLoading {
+		m.issuesLoading = true
+	}
+
+	if targetIssueNumber > 0 {
+		m.ensureIssueVisible(targetIssueNumber)
+		if m.selectIssueNumber(targetIssueNumber) {
+			m.statusMessage = ""
+			return nil
+		}
+		m.statusMessage = fmt.Sprintf("Issue #%d is not in the loaded issue list", targetIssueNumber)
+		return nil
+	}
+	m.clampIssueSelection()
+	m.statusMessage = ""
+	return nil
+}
+
+func (m *model) backToWorkbench() tea.Cmd {
+	m.screen = screenWorkbench
+	m.issueSearchEditing = false
+	if m.workbenchReturn.valid {
+		m.selectedRepo = m.workbenchReturn.selectedRepo
+		m.selectedView = m.workbenchReturn.selectedView
+		m.viewSelected = m.workbenchReturn.viewSelected
+		m.selectedItem = m.workbenchReturn.selectedItem
+		m.focusedPane = m.workbenchReturn.focusedPane
+	}
+	m.workbenchReturn = workbenchReturnState{}
+	return m.startPreviewLoadIfFocusedItemChanged()
+}
+
+func (m *model) prepareIssueDataForRepo(repo workbench.RepoRef) {
+	if m.issueRepo == repo {
+		return
+	}
+	m.issueRepo = repo
+	m.issues = issuesFromWorkItems(m.workItems, repo)
+	m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(m.workItems, repo))
+	m.issuesError = issueDiscoveryErrorFromWorkItems(m.workItems, repo)
+	m.selectedIssue = 0
+}
+
+func (m *model) updateIssueDataFromRuntimeResult(result workbench.RuntimeLoadResult) {
+	selectedNumber := 0
+	if issue, ok := m.selectedIssueRef(); ok {
+		selectedNumber = issue.Number
+	}
+	m.issueRepo = result.Repo
+	if result.IssuesLoaded {
+		m.issues = cloneIssueRefs(result.Issues)
+	} else {
+		m.issues = issuesFromWorkItems(result.Items, result.Repo)
+	}
+	if result.PullRequestsLoaded {
+		m.prsByIssueNumber = pullRequestsByIssueNumber(result.PullRequests)
+	} else {
+		m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(result.Items, result.Repo))
+	}
+	if result.ViewerSubject.Login != "" {
+		m.viewerLogin = result.ViewerSubject.Login
+	}
+	m.issuesError = issueDiscoveryErrorFromWorkItems(result.Items, result.Repo)
+	if selectedNumber > 0 && m.selectIssueNumber(selectedNumber) {
+		return
+	}
+	m.clampIssueSelection()
+}
+
+func (m model) visibleIssues() []workbench.IssueRef {
+	return filterIssues(m.issues, m.issueFilter, m.viewerLogin)
+}
+
+func filterIssues(issues []workbench.IssueRef, filter issueFilterState, viewerLogin string) []workbench.IssueRef {
+	out := make([]workbench.IssueRef, 0, len(issues))
+	for _, issue := range issues {
+		if issueMatchesFilter(issue, filter, viewerLogin) {
+			out = append(out, issue)
+		}
+	}
+	return out
+}
+
+func issueMatchesFilter(issue workbench.IssueRef, filter issueFilterState, viewerLogin string) bool {
+	switch filter.State {
+	case issueStateClosed:
+		if !strings.EqualFold(issue.State, "closed") {
+			return false
+		}
+	case issueStateAll:
+	default:
+		if issue.State != "" && !strings.EqualFold(issue.State, "open") {
+			return false
+		}
+	}
+	if filter.Assignee != "" {
+		switch filter.Assignee {
+		case issueAssigneeMe:
+			if viewerLogin == "" || !hasCaseFolded(issue.Assignees, viewerLogin) {
+				return false
+			}
+		case issueAssigneeUnassigned:
+			if len(issue.Assignees) != 0 {
+				return false
+			}
+		default:
+			if !hasCaseFolded(issue.Assignees, filter.Assignee) {
+				return false
+			}
+		}
+	}
+	if filter.Label != "" && !hasCaseFolded(issue.Labels, filter.Label) {
+		return false
+	}
+	if filter.Milestone != "" && !strings.EqualFold(issue.Milestone, filter.Milestone) {
+		return false
+	}
+	query := strings.TrimSpace(filter.Search)
+	if query != "" {
+		haystack := strings.ToLower(issue.Title + "\n" + issueBodyExcerpt(issue.Body))
+		if !strings.Contains(haystack, strings.ToLower(query)) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *model) ensureIssueVisible(number int) {
+	for _, issue := range m.issues {
+		if issue.Number == number && !issueMatchesFilter(issue, m.issueFilter, m.viewerLogin) {
+			m.issueFilter = defaultIssueFilterState()
+			if !issueMatchesFilter(issue, m.issueFilter, m.viewerLogin) {
+				m.issueFilter.State = issueStateAll
+			}
+			return
+		}
+	}
+}
+
+func (m *model) selectIssueNumber(number int) bool {
+	for i, issue := range m.visibleIssues() {
+		if issue.Number == number {
+			m.selectedIssue = i
+			return true
+		}
+	}
+	return false
+}
+
+func (m model) selectedIssueRef() (workbench.IssueRef, bool) {
+	issues := m.visibleIssues()
+	if len(issues) == 0 || m.selectedIssue < 0 || m.selectedIssue >= len(issues) {
+		return workbench.IssueRef{}, false
+	}
+	return issues[m.selectedIssue], true
+}
+
+func (m *model) moveIssueSelection(delta int) {
+	issues := m.visibleIssues()
+	if len(issues) == 0 {
+		m.selectedIssue = 0
+		return
+	}
+	m.selectedIssue = clamp(m.selectedIssue+delta, 0, len(issues)-1)
+}
+
+func (m *model) jumpIssueSelection(toEnd bool) {
+	issues := m.visibleIssues()
+	if len(issues) == 0 {
+		m.selectedIssue = 0
+		return
+	}
+	if toEnd {
+		m.selectedIssue = len(issues) - 1
+		return
+	}
+	m.selectedIssue = 0
+}
+
+func (m *model) clampIssueSelection() {
+	issues := m.visibleIssues()
+	if len(issues) == 0 {
+		m.selectedIssue = 0
+		return
+	}
+	m.selectedIssue = clamp(m.selectedIssue, 0, len(issues)-1)
+}
+
+func (m *model) cycleIssueStateFilter() {
+	m.issueFilter.State = m.issueFilter.State.next()
+	m.clampIssueSelection()
+	m.statusMessage = "Issue state filter: " + m.issueFilter.State.String()
+}
+
+func (m *model) cycleIssueAssigneeFilter() {
+	values := issueAssigneeFilterValues(m.issues, m.viewerLogin)
+	m.issueFilter.Assignee = nextFilterValue(values, m.issueFilter.Assignee)
+	m.clampIssueSelection()
+	m.statusMessage = "Issue assignee filter: " + issueAssigneeFilterLabel(m.issueFilter.Assignee)
+}
+
+func (m *model) cycleIssueLabelFilter() {
+	values := append([]string{""}, uniqueSortedIssueValues(m.issues, func(issue workbench.IssueRef) []string {
+		return issue.Labels
+	})...)
+	m.issueFilter.Label = nextFilterValue(values, m.issueFilter.Label)
+	m.clampIssueSelection()
+	m.statusMessage = "Issue label filter: " + issueOptionalFilterLabel(m.issueFilter.Label)
+}
+
+func (m *model) cycleIssueMilestoneFilter() {
+	values := append([]string{""}, uniqueSortedIssueValues(m.issues, func(issue workbench.IssueRef) []string {
+		if issue.Milestone == "" {
+			return nil
+		}
+		return []string{issue.Milestone}
+	})...)
+	m.issueFilter.Milestone = nextFilterValue(values, m.issueFilter.Milestone)
+	m.clampIssueSelection()
+	m.statusMessage = "Issue milestone filter: " + issueOptionalFilterLabel(m.issueFilter.Milestone)
+}
+
+func (m *model) startIssueSearch() {
+	m.issueSearchEditing = true
+	m.statusMessage = "Editing issue search"
+}
+
+func (m *model) clearIssueFilters() {
+	m.issueFilter = defaultIssueFilterState()
+	m.issueSearchEditing = false
+	m.clampIssueSelection()
+	m.statusMessage = "Issue filters cleared"
+}
+
+func (m *model) handleIssueSearchKey(msg tea.KeyMsg) (bool, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEnter:
+		m.issueSearchEditing = false
+		m.clampIssueSelection()
+		m.statusMessage = "Issue search applied"
+		return true, nil
+	case tea.KeyEsc:
+		m.issueSearchEditing = false
+		m.statusMessage = "Issue search kept"
+		return true, nil
+	case tea.KeyCtrlC:
+		return true, tea.Quit
+	case tea.KeyBackspace, tea.KeyCtrlH:
+		m.issueFilter.Search = dropLastRune(m.issueFilter.Search)
+		m.clampIssueSelection()
+		return true, nil
+	case tea.KeyCtrlU:
+		m.issueFilter.Search = ""
+		m.clampIssueSelection()
+		return true, nil
+	case tea.KeySpace:
+		m.issueFilter.Search += " "
+		m.clampIssueSelection()
+		return true, nil
+	case tea.KeyRunes:
+		m.issueFilter.Search += string(msg.Runes)
+		m.clampIssueSelection()
+		return true, nil
+	default:
+		return true, nil
+	}
+}
+
+func (m *model) openSelectedIssueInBrowser() tea.Cmd {
+	issue, ok := m.selectedIssueRef()
+	if !ok {
+		m.statusMessage = "No issue selected"
+		return nil
+	}
+	if issue.URL == "" {
+		m.statusMessage = "No issue URL for selected issue"
+		return nil
+	}
+	label := issue.Label()
+	m.statusMessage = "Opening " + label + "..."
+	return m.actionCommand("Opened "+label, "Open issue failed", func(ctx context.Context) error {
+		return m.runner().Open(ctx, issue.URL)
+	})
+}
+
+func (m model) renderIssueFull(width int) string {
+	leftWidth := issueListPaneWidth
+	rightWidth := width - leftWidth - paneBorderWidth*2 - paneGapWidth
+	focus := m.activePane()
+
+	left := m.issueLines(paneTextWidth(leftWidth), focus == paneWorkItems)
+	right := m.issuePreviewLines(paneTextWidth(rightWidth))
+	out := m.headerLines("gh-zen  issues: "+m.issueRepo.FullName(), width)
+	bodyHeight := m.frameBodyHeight(max(len(left), len(right)), len(out))
+
+	body := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		m.renderPane(m.paneHeading(paneWorkItems), left, leftWidth, bodyHeight, focus == paneWorkItems),
+		paneGap(bodyHeight+frameBorderLines),
+		m.renderPane(m.paneHeading(panePreview), right, rightWidth, bodyHeight, focus == panePreview),
+	)
+	out = append(out, body)
+	return strings.Join(out, "\n") + "\n"
+}
+
+func (m model) renderIssueCompact(width int) string {
+	contentWidth := max(width-paneBorderWidth, 0)
+	focus := m.activePane()
+	out := m.headerLines("gh-zen issues: "+m.issueRepo.FullName(), width)
+
+	issueLines := m.issueLines(paneTextWidth(contentWidth), focus == paneWorkItems)
+	previewLines := m.issuePreviewLines(paneTextWidth(contentWidth))
+	issueHeight := len(issueLines)
+	previewHeight := len(previewLines)
+	if m.height > 0 {
+		availableContentHeight := m.height - len(out) - frameBorderLines*2
+		if availableContentHeight > issueHeight+previewHeight {
+			previewHeight += availableContentHeight - issueHeight - previewHeight
+		}
+	}
+
+	out = append(out,
+		m.renderPane(m.paneHeading(paneWorkItems), issueLines, contentWidth, issueHeight, focus == paneWorkItems),
+		m.renderPane(m.paneHeading(panePreview), previewLines, contentWidth, previewHeight, focus == panePreview),
+	)
+	return strings.Join(out, "\n") + "\n"
+}
+
+func (m model) issueLines(width int, focused bool) []string {
+	lines := []string{truncate(m.issueFilterLine(), width)}
+	if m.issueSearchEditing {
+		lines = append(lines, truncate("Search: "+m.issueFilter.Search+"_", width))
+	}
+	issues := m.visibleIssues()
+	if len(issues) == 0 {
+		return append(lines, m.emptyIssueLine())
+	}
+	for i, issue := range issues {
+		marker := selectionMarker(i == m.selectedIssue, focused)
+		row := fmt.Sprintf("%s %-7s %-7s %4s %-12s %s",
+			marker,
+			issueNumberLabel(issue.Number),
+			issueStateLabel(issue.State),
+			issueCommentShortLabel(issue.CommentsCount),
+			emptyFallback(issue.AuthorLogin, "-"),
+			issue.Title,
+		)
+		lines = append(lines, truncate(row, width))
+		if meta := issueListMeta(issue); meta != "" {
+			lines = append(lines, truncate("  "+meta, width))
+		}
+	}
+	return lines
+}
+
+func (m model) issueFilterLine() string {
+	parts := []string{
+		"state=" + m.issueFilter.State.String(),
+		"assignee=" + issueAssigneeFilterLabel(m.issueFilter.Assignee),
+		"label=" + issueOptionalFilterLabel(m.issueFilter.Label),
+		"milestone=" + issueOptionalFilterLabel(m.issueFilter.Milestone),
+	}
+	search := strings.TrimSpace(m.issueFilter.Search)
+	if search == "" {
+		search = "none"
+	}
+	parts = append(parts, "search="+search)
+	return "Filters: " + strings.Join(parts, " ")
+}
+
+func (m model) emptyIssueLine() string {
+	switch {
+	case m.issuesLoading || m.workbenchLoading:
+		return "  loading issues..."
+	case m.issuesError != "":
+		return "  issue loading failed: " + m.issuesError
+	case len(m.issues) == 0:
+		return "  no issues"
+	default:
+		return "  no issues match filters"
+	}
+}
+
+func (m model) issuePreviewLines(width int) []string {
+	issue, ok := m.selectedIssueRef()
+	if !ok {
+		return []string{"  no issue selected"}
+	}
+	lines := []string{
+		truncate("Issue: "+issue.Label(), width),
+		truncate("State: "+issueStateLabel(issue.State), width),
+	}
+	if issue.AuthorLogin != "" {
+		lines = append(lines, truncate("Author: "+issue.AuthorLogin, width))
+	}
+	if labels := strings.Join(issue.Labels, ", "); labels != "" {
+		lines = append(lines, truncate("Labels: "+labels, width))
+	}
+	if assignees := strings.Join(issue.Assignees, ", "); assignees != "" {
+		lines = append(lines, truncate("Assignees: "+assignees, width))
+	}
+	if issue.Milestone != "" {
+		lines = append(lines, truncate("Milestone: "+issue.Milestone, width))
+	}
+	if issue.UpdatedAt != "" {
+		lines = append(lines, truncate("Updated: "+issue.UpdatedAt, width))
+	}
+	if issue.CommentsCount > 0 {
+		lines = append(lines, truncate("Comments: "+issueCommentsLabel(issue.CommentsCount), width))
+	}
+	if prs := m.prsByIssueNumber[issue.Number]; len(prs) > 0 {
+		lines = append(lines, "Linked PRs:")
+		for _, pr := range prs {
+			lines = append(lines, truncate("  "+pullRequestIssueLinkLabel(pr), width))
+		}
+	}
+	if excerpt := issueBodyExcerpt(issue.Body); excerpt != "" {
+		lines = append(lines, truncate("Body: "+excerpt, width))
+	}
+	if issue.URL != "" {
+		lines = append(lines, truncate("URL: "+issue.URL, width))
+	}
+	return lines
+}
+
+func issueListMeta(issue workbench.IssueRef) string {
+	parts := []string{}
+	if labels := strings.Join(issue.Labels, ","); labels != "" {
+		parts = append(parts, "labels:"+labels)
+	}
+	if assignees := strings.Join(issue.Assignees, ","); assignees != "" {
+		parts = append(parts, "assignees:"+assignees)
+	}
+	if issue.Milestone != "" {
+		parts = append(parts, "milestone:"+issue.Milestone)
+	}
+	if issue.UpdatedAt != "" {
+		parts = append(parts, "updated:"+issue.UpdatedAt)
+	}
+	return strings.Join(parts, "  ")
+}
+
+func issueNumberLabel(number int) string {
+	if number == 0 {
+		return "#?"
+	}
+	return fmt.Sprintf("#%d", number)
+}
+
+func issueStateLabel(state string) string {
+	if state == "" {
+		return "unknown"
+	}
+	return strings.ToLower(state)
+}
+
+func issueCommentShortLabel(count int) string {
+	if count <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%dc", count)
+}
+
+func issueCommentsLabel(count int) string {
+	if count == 1 {
+		return "1 comment"
+	}
+	return fmt.Sprintf("%d comments", count)
+}
+
+func pullRequestIssueLinkLabel(pr workbench.PullRequestRef) string {
+	number := "#?"
+	if pr.Number > 0 {
+		number = fmt.Sprintf("#%d", pr.Number)
+	}
+	if pr.Title == "" {
+		return number
+	}
+	return number + " " + pr.Title
+}
+
+func issueAssigneeFilterValues(issues []workbench.IssueRef, viewerLogin string) []string {
+	values := []string{""}
+	if viewerLogin != "" {
+		values = append(values, issueAssigneeMe)
+	}
+	values = append(values, uniqueSortedIssueValues(issues, func(issue workbench.IssueRef) []string {
+		return issue.Assignees
+	})...)
+	values = append(values, issueAssigneeUnassigned)
+	return compactUniqueStrings(values)
+}
+
+func issueAssigneeFilterLabel(value string) string {
+	switch value {
+	case "":
+		return "any"
+	case issueAssigneeUnassigned:
+		return "unassigned"
+	default:
+		return value
+	}
+}
+
+func issueOptionalFilterLabel(value string) string {
+	if value == "" {
+		return "any"
+	}
+	return value
+}
+
+func nextFilterValue(values []string, current string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	for i, value := range values {
+		if value == current {
+			return values[(i+1)%len(values)]
+		}
+	}
+	return values[0]
+}
+
+func uniqueSortedIssueValues(issues []workbench.IssueRef, values func(workbench.IssueRef) []string) []string {
+	seen := map[string]string{}
+	for _, issue := range issues {
+		for _, value := range values(issue) {
+			if value == "" {
+				continue
+			}
+			key := strings.ToLower(value)
+			if _, ok := seen[key]; !ok {
+				seen[key] = value
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for _, value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func compactUniqueStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, value := range values {
+		key := strings.ToLower(value)
+		if seen[key] {
+			continue
+		}
+		out = append(out, value)
+		seen[key] = true
+	}
+	return out
+}
+
+func hasCaseFolded(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func issuesFromWorkItems(items []workbench.WorkItem, repo workbench.RepoRef) []workbench.IssueRef {
+	byNumber := map[int]workbench.IssueRef{}
+	ordered := []workbench.IssueRef{}
+	for _, item := range items {
+		if item.Repo != repo || item.Issue == nil || item.Issue.Number == 0 {
+			continue
+		}
+		if _, ok := byNumber[item.Issue.Number]; ok {
+			continue
+		}
+		issue := *item.Issue
+		byNumber[issue.Number] = issue
+		ordered = append(ordered, issue)
+	}
+	return ordered
+}
+
+func pullRequestsFromWorkItems(items []workbench.WorkItem, repo workbench.RepoRef) []workbench.PullRequestRef {
+	seen := map[int]bool{}
+	prs := []workbench.PullRequestRef{}
+	for _, item := range items {
+		if item.Repo != repo || item.PullRequest == nil {
+			continue
+		}
+		if item.PullRequest.Number > 0 {
+			if seen[item.PullRequest.Number] {
+				continue
+			}
+			seen[item.PullRequest.Number] = true
+		}
+		prs = append(prs, *item.PullRequest)
+	}
+	return prs
+}
+
+func pullRequestsByIssueNumber(prs []workbench.PullRequestRef) map[int][]workbench.PullRequestRef {
+	out := map[int][]workbench.PullRequestRef{}
+	for _, pr := range prs {
+		seenIssues := map[int]bool{}
+		for _, issue := range pr.LinkedIssues {
+			if issue.Number == 0 || seenIssues[issue.Number] {
+				continue
+			}
+			out[issue.Number] = append(out[issue.Number], pr)
+			seenIssues[issue.Number] = true
+		}
+	}
+	return out
+}
+
+func issueDiscoveryErrorFromWorkItems(items []workbench.WorkItem, repo workbench.RepoRef) string {
+	for _, item := range items {
+		if item.Repo != repo || !strings.HasPrefix(item.ID, "issue-check-discovery-error:") || item.Local == nil {
+			continue
+		}
+		return item.Local.Summary
+	}
+	return ""
+}
+
+func cloneIssueRefs(issues []workbench.IssueRef) []workbench.IssueRef {
+	return append([]workbench.IssueRef(nil), issues...)
+}
+
+func emptyFallback(value string, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func dropLastRune(value string) string {
+	if value == "" {
+		return ""
+	}
+	_, size := utf8.DecodeLastRuneInString(value)
+	if size <= 0 {
+		return ""
+	}
+	return value[:len(value)-size]
+}

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -206,9 +206,8 @@ func (m *model) updateIssueDataFromRuntimeResult(result workbench.RuntimeLoadRes
 	if result.ViewerSubject.Login != "" {
 		m.viewerLogin = result.ViewerSubject.Login
 	}
-	m.issuesError = ""
+	m.issuesError = result.IssuesError
 	if !result.IssuesLoaded {
-		m.issuesError = result.IssuesError
 		if m.issuesError == "" {
 			m.issuesError = issueDiscoveryErrorFromWorkItems(result.Items, issueRepo)
 		}

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -131,7 +131,7 @@ func (m *model) startIssueViewReload() tea.Cmd {
 }
 
 func (m *model) startPendingIssueReload() tea.Cmd {
-	repo := m.pendingIssueRepo
+	repo := m.canonicalRepoRef(m.pendingIssueRepo)
 	m.issueReloadPending = false
 	m.pendingIssueRepo = workbench.RepoRef{}
 	if m.screen != screenIssues || !hasRepoRef(repo) {
@@ -144,6 +144,8 @@ func (m *model) startPendingIssueReload() tea.Cmd {
 func (m *model) backToWorkbench() tea.Cmd {
 	m.screen = screenWorkbench
 	m.issueSearchEditing = false
+	m.issueReloadPending = false
+	m.pendingIssueRepo = workbench.RepoRef{}
 	if m.workbenchReturn.valid {
 		m.selectedRepo = m.workbenchReturn.selectedRepo
 		m.selectedView = m.workbenchReturn.selectedView

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -113,7 +113,7 @@ func (m *model) enterIssueView() tea.Cmd {
 }
 
 func (m *model) startIssueViewReload() tea.Cmd {
-	if m.workbenchReloader == nil || !hasRepoRef(m.issueRepo) {
+	if (m.issueReloader == nil && m.workbenchReloader == nil) || !hasRepoRef(m.issueRepo) {
 		return nil
 	}
 	return m.startWorkbenchReload("Loading issues...")
@@ -153,10 +153,13 @@ func (m *model) updateIssueDataFromRuntimeResult(result workbench.RuntimeLoadRes
 	if !hasRepoRef(issueRepo) {
 		issueRepo = result.Repo
 	}
+	sameIssueRepo := strings.EqualFold(m.issueRepo.FullName(), issueRepo.FullName())
 	m.issueRepo = issueRepo
 	workItemIssues := issuesFromWorkItems(result.Items, issueRepo)
 	if result.IssuesLoaded {
 		m.issues = mergeIssueRefs(result.Issues, workItemIssues)
+	} else if sameIssueRepo {
+		m.issues = mergeIssueRefs(m.issues, workItemIssues)
 	} else {
 		m.issues = workItemIssues
 	}
@@ -396,10 +399,16 @@ func (m model) renderIssueFull(width int) string {
 	rightWidth := width - leftWidth - paneBorderWidth*2 - paneGapWidth
 	focus := m.activePane()
 
-	left := m.issueLines(paneTextWidth(leftWidth), focus == paneWorkItems)
-	right := m.issuePreviewLines(paneTextWidth(rightWidth))
 	out := m.headerLines("gh-zen  issues: "+m.issueRepo.FullName(), width)
-	bodyHeight := m.frameBodyHeight(max(len(left), len(right)), len(out))
+	bodyHeight := 0
+	if m.height > 0 {
+		bodyHeight = max(m.height-len(out)-frameBorderLines, 1)
+	}
+	left := m.issueLines(paneTextWidth(leftWidth), bodyHeight, focus == paneWorkItems)
+	right := m.issuePreviewLines(paneTextWidth(rightWidth))
+	if bodyHeight == 0 {
+		bodyHeight = max(len(left), len(right))
+	}
 
 	body := lipgloss.JoinHorizontal(
 		lipgloss.Top,
@@ -416,15 +425,18 @@ func (m model) renderIssueCompact(width int) string {
 	focus := m.activePane()
 	out := m.headerLines("gh-zen issues: "+m.issueRepo.FullName(), width)
 
-	issueLines := m.issueLines(paneTextWidth(contentWidth), focus == paneWorkItems)
 	previewLines := m.issuePreviewLines(paneTextWidth(contentWidth))
-	issueHeight := len(issueLines)
-	previewHeight := len(previewLines)
+	issueHeight := 0
+	previewHeight := 0
 	if m.height > 0 {
-		availableContentHeight := m.height - len(out) - frameBorderLines*2
-		if availableContentHeight > issueHeight+previewHeight {
-			previewHeight += availableContentHeight - issueHeight - previewHeight
-		}
+		availableContentHeight := max(m.height-len(out)-frameBorderLines*2, 2)
+		issueHeight = max(availableContentHeight/2, 1)
+		previewHeight = max(availableContentHeight-issueHeight, 1)
+	}
+	issueLines := m.issueLines(paneTextWidth(contentWidth), issueHeight, focus == paneWorkItems)
+	if m.height <= 0 {
+		issueHeight = len(issueLines)
+		previewHeight = len(previewLines)
 	}
 
 	out = append(out,
@@ -434,15 +446,23 @@ func (m model) renderIssueCompact(width int) string {
 	return strings.Join(out, "\n") + "\n"
 }
 
-func (m model) issueLines(width int, focused bool) []string {
+func (m model) issueLines(width int, maxLines int, focused bool) []string {
 	lines := []string{truncate(m.issueFilterLine(), width)}
 	if m.issueSearchEditing {
 		lines = append(lines, truncate("Search: "+m.issueFilter.Search+"_", width))
 	}
+	if m.issuesError != "" {
+		lines = append(lines, truncate("Issue loading failed: "+m.issuesError, width))
+	}
 	issues := m.visibleIssues()
 	if len(issues) == 0 {
-		return append(lines, m.emptyIssueLine())
+		lines = append(lines, m.emptyIssueLine())
+		if maxLines > 0 && len(lines) > maxLines {
+			return lines[:maxLines]
+		}
+		return lines
 	}
+	blocks := make([][]string, 0, len(issues))
 	for i, issue := range issues {
 		marker := selectionMarker(i == m.selectedIssue, focused)
 		row := fmt.Sprintf("%s %-7s %-7s %4s %-12s %s",
@@ -453,10 +473,54 @@ func (m model) issueLines(width int, focused bool) []string {
 			emptyFallback(issue.AuthorLogin, "-"),
 			issue.Title,
 		)
-		lines = append(lines, truncate(row, width))
+		block := []string{truncate(row, width)}
 		if meta := issueListMeta(issue); meta != "" {
-			lines = append(lines, truncate("  "+meta, width))
+			block = append(block, truncate("  "+meta, width))
 		}
+		blocks = append(blocks, block)
+	}
+	if maxLines <= 0 {
+		return appendIssueBlocks(lines, blocks)
+	}
+	if len(lines) >= maxLines {
+		return lines[:maxLines]
+	}
+	return appendIssueBlocks(lines, issueBlockViewport(blocks, m.selectedIssue, maxLines-len(lines)))
+}
+
+func issueBlockViewport(blocks [][]string, selected int, maxLines int) [][]string {
+	if len(blocks) == 0 || maxLines <= 0 {
+		return nil
+	}
+	selected = clamp(selected, 0, len(blocks)-1)
+	if len(blocks[selected]) >= maxLines {
+		return [][]string{blocks[selected][:maxLines]}
+	}
+	start := selected
+	end := selected + 1
+	used := len(blocks[selected])
+	for {
+		changed := false
+		if start > 0 && used+len(blocks[start-1]) <= maxLines {
+			start--
+			used += len(blocks[start])
+			changed = true
+		}
+		if end < len(blocks) && used+len(blocks[end]) <= maxLines {
+			used += len(blocks[end])
+			end++
+			changed = true
+		}
+		if !changed {
+			break
+		}
+	}
+	return blocks[start:end]
+}
+
+func appendIssueBlocks(lines []string, blocks [][]string) []string {
+	for _, block := range blocks {
+		lines = append(lines, block...)
 	}
 	return lines
 }

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -570,17 +570,17 @@ func appendIssueBlocks(lines []string, blocks [][]string) []string {
 }
 
 func (m model) issueFilterLine() string {
+	search := strings.TrimSpace(m.issueFilter.Search)
+	if search == "" {
+		search = "none"
+	}
 	parts := []string{
+		"search=" + search,
 		"state=" + m.issueFilter.State.String(),
 		"assignee=" + issueAssigneeFilterLabel(m.issueFilter.Assignee),
 		"label=" + issueOptionalFilterLabel(m.issueFilter.Label),
 		"milestone=" + issueOptionalFilterLabel(m.issueFilter.Milestone),
 	}
-	search := strings.TrimSpace(m.issueFilter.Search)
-	if search == "" {
-		search = "none"
-	}
-	parts = append(parts, "search="+search)
 	return "Filters: " + strings.Join(parts, " ")
 }
 

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -118,13 +118,27 @@ func (m *model) startIssueViewReload() tea.Cmd {
 		return nil
 	}
 	if m.workbenchLoading && m.activeReloadRequest.requestID != 0 {
-		if !m.activeReloadRequest.issueScoped {
+		if !m.activeReloadRequest.issueScoped ||
+			!strings.EqualFold(m.activeReloadRequest.repo.FullName(), m.issueRepo.FullName()) {
 			m.issueReloadPending = true
+			m.pendingIssueRepo = m.issueRepo
 		}
 		return nil
 	}
 	m.issueReloadPending = false
+	m.pendingIssueRepo = workbench.RepoRef{}
 	return m.startWorkbenchReload("Loading issues...")
+}
+
+func (m *model) startPendingIssueReload() tea.Cmd {
+	repo := m.pendingIssueRepo
+	m.issueReloadPending = false
+	m.pendingIssueRepo = workbench.RepoRef{}
+	if m.screen != screenIssues || !hasRepoRef(repo) {
+		return nil
+	}
+	m.prepareIssueDataForRepo(repo)
+	return m.startIssueViewReload()
 }
 
 func (m *model) backToWorkbench() tea.Cmd {

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -116,6 +116,13 @@ func (m *model) startIssueViewReload() tea.Cmd {
 	if (m.issueReloader == nil && m.workbenchReloader == nil) || !hasRepoRef(m.issueRepo) {
 		return nil
 	}
+	if m.workbenchLoading && m.activeReloadRequest.requestID != 0 {
+		if !m.activeReloadRequest.issueScoped {
+			m.issueReloadPending = true
+		}
+		return nil
+	}
+	m.issueReloadPending = false
 	return m.startWorkbenchReload("Loading issues...")
 }
 
@@ -165,13 +172,24 @@ func (m *model) updateIssueDataFromRuntimeResult(result workbench.RuntimeLoadRes
 	}
 	if result.PullRequestsLoaded {
 		m.prsByIssueNumber = pullRequestsByIssueNumber(result.PullRequests)
+	} else if sameIssueRepo {
+		m.prsByIssueNumber = mergePullRequestIndexes(
+			m.prsByIssueNumber,
+			pullRequestsByIssueNumber(pullRequestsFromWorkItems(result.Items, issueRepo)),
+		)
 	} else {
 		m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(result.Items, issueRepo))
 	}
 	if result.ViewerSubject.Login != "" {
 		m.viewerLogin = result.ViewerSubject.Login
 	}
-	m.issuesError = issueDiscoveryErrorFromWorkItems(result.Items, issueRepo)
+	m.issuesError = ""
+	if !result.IssuesLoaded {
+		m.issuesError = result.IssuesError
+		if m.issuesError == "" {
+			m.issuesError = issueDiscoveryErrorFromWorkItems(result.Items, issueRepo)
+		}
+	}
 	if selectedNumber > 0 && m.selectIssueNumber(selectedNumber) {
 		return
 	}
@@ -744,6 +762,9 @@ func issuesFromWorkItems(items []workbench.WorkItem, repo workbench.RepoRef) []w
 		if item.Repo != repo || item.Issue == nil || item.Issue.Number == 0 {
 			continue
 		}
+		if !item.Issue.Certain && item.Issue.Source == workbench.IssueLinkSourceBranch {
+			continue
+		}
 		if _, ok := byNumber[item.Issue.Number]; ok {
 			continue
 		}
@@ -802,6 +823,31 @@ func pullRequestsByIssueNumber(prs []workbench.PullRequestRef) map[int][]workben
 			}
 			out[issue.Number] = append(out[issue.Number], pr)
 			seenIssues[issue.Number] = true
+		}
+	}
+	return out
+}
+
+func mergePullRequestIndexes(primary map[int][]workbench.PullRequestRef, extras map[int][]workbench.PullRequestRef) map[int][]workbench.PullRequestRef {
+	out := make(map[int][]workbench.PullRequestRef, len(primary)+len(extras))
+	for issueNumber, prs := range primary {
+		out[issueNumber] = append([]workbench.PullRequestRef(nil), prs...)
+	}
+	for issueNumber, prs := range extras {
+		seen := map[int]bool{}
+		for _, pr := range out[issueNumber] {
+			if pr.Number > 0 {
+				seen[pr.Number] = true
+			}
+		}
+		for _, pr := range prs {
+			if pr.Number > 0 && seen[pr.Number] {
+				continue
+			}
+			out[issueNumber] = append(out[issueNumber], pr)
+			if pr.Number > 0 {
+				seen[pr.Number] = true
+			}
 		}
 	}
 	return out

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -77,14 +77,19 @@ func (m *model) enterIssueView() tea.Cmd {
 		targetIssueNumber = item.Issue.Number
 	}
 
+	returnRepo := workbench.RepoRef{}
+	if selectedRepo, ok := m.selectedRepoRef(); ok {
+		returnRepo = selectedRepo
+	}
 	m.prepareIssueDataForRepo(repo)
 	m.workbenchReturn = workbenchReturnState{
-		valid:        true,
-		selectedRepo: m.selectedRepo,
-		selectedView: m.selectedView,
-		viewSelected: m.viewSelected,
-		selectedItem: m.selectedItem,
-		focusedPane:  m.focusedPane,
+		valid:           true,
+		selectedRepo:    m.selectedRepo,
+		selectedRepoRef: returnRepo,
+		selectedView:    m.selectedView,
+		viewSelected:    m.viewSelected,
+		selectedItem:    m.selectedItem,
+		focusedPane:     m.focusedPane,
 	}
 	m.screen = screenIssues
 	m.focusedPane = paneWorkItems
@@ -138,10 +143,11 @@ func (m *model) updateIssueDataFromRuntimeResult(result workbench.RuntimeLoadRes
 		selectedNumber = issue.Number
 	}
 	m.issueRepo = result.Repo
+	workItemIssues := issuesFromWorkItems(result.Items, result.Repo)
 	if result.IssuesLoaded {
-		m.issues = cloneIssueRefs(result.Issues)
+		m.issues = mergeIssueRefs(result.Issues, workItemIssues)
 	} else {
-		m.issues = issuesFromWorkItems(result.Items, result.Repo)
+		m.issues = workItemIssues
 	}
 	if result.PullRequestsLoaded {
 		m.prsByIssueNumber = pullRequestsByIssueNumber(result.PullRequests)
@@ -671,6 +677,26 @@ func issuesFromWorkItems(items []workbench.WorkItem, repo workbench.RepoRef) []w
 		ordered = append(ordered, issue)
 	}
 	return ordered
+}
+
+func mergeIssueRefs(primary []workbench.IssueRef, extras []workbench.IssueRef) []workbench.IssueRef {
+	out := make([]workbench.IssueRef, 0, len(primary)+len(extras))
+	seen := map[int]bool{}
+	for _, issue := range primary {
+		if issue.Number == 0 || seen[issue.Number] {
+			continue
+		}
+		seen[issue.Number] = true
+		out = append(out, issue)
+	}
+	for _, issue := range extras {
+		if issue.Number == 0 || seen[issue.Number] {
+			continue
+		}
+		seen[issue.Number] = true
+		out = append(out, issue)
+	}
+	return out
 }
 
 func pullRequestsFromWorkItems(items []workbench.WorkItem, repo workbench.RepoRef) []workbench.PullRequestRef {

--- a/internal/app/issues.go
+++ b/internal/app/issues.go
@@ -61,14 +61,19 @@ func (f issueStateFilter) next() issueStateFilter {
 }
 
 func (m *model) enterIssueView() tea.Cmd {
+	item, hasItem := m.selectedWorkItem()
 	repo, ok := m.selectedRepoRef()
+	if hasItem && hasRepoRef(item.Repo) {
+		repo = item.Repo
+		ok = true
+	}
 	if !ok {
 		m.statusMessage = "No repository selected"
 		return nil
 	}
 
 	targetIssueNumber := 0
-	if item, ok := m.selectedWorkItem(); ok && item.Issue != nil {
+	if hasItem && item.Issue != nil {
 		targetIssueNumber = item.Issue.Number
 	}
 
@@ -203,7 +208,7 @@ func issueMatchesFilter(issue workbench.IssueRef, filter issueFilterState, viewe
 	}
 	query := strings.TrimSpace(filter.Search)
 	if query != "" {
-		haystack := strings.ToLower(issue.Title + "\n" + issueBodyExcerpt(issue.Body))
+		haystack := strings.ToLower(issue.Title + "\n" + issue.Body)
 		if !strings.Contains(haystack, strings.ToLower(query)) {
 			return false
 		}

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -986,9 +986,15 @@ func TestUpdate_IssueRefreshPullRequestFailureKeepsWorkbenchEnrichment(t *testin
 		PullRequest: &workbench.PullRequestRef{Number: 11, Title: "Remote PR", State: "open"},
 		Checks:      workbench.CheckSummary{State: workbench.CheckPassing},
 	}
+	deletedLocalItem := workbench.WorkItem{
+		ID:          "branch:deleted",
+		Repo:        repo,
+		Branch:      &workbench.BranchRef{Name: "deleted"},
+		PullRequest: &workbench.PullRequestRef{Number: 12, Title: "Deleted local branch PR", State: "open"},
+	}
 	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
 		RepositorySummaries: []workbench.RepositorySummary{{Repo: repo, Path: "/repos/gh-zen"}},
-		WorkItems:           []workbench.WorkItem{localItem, pullRequestOnlyItem},
+		WorkItems:           []workbench.WorkItem{localItem, pullRequestOnlyItem, deletedLocalItem},
 	}, fakeDelayedPreviewLoader(0))
 	request := workbenchReloadRequest{requestID: 1, repo: repo, status: "Loading issues...", issueScoped: true}
 	start.screen = screenIssues
@@ -1046,6 +1052,11 @@ func TestUpdate_IssueRefreshPullRequestFailureKeepsWorkbenchEnrichment(t *testin
 		return item.ID == pullRequestOnlyItem.ID && item.PullRequest != nil && item.PullRequest.Number == 11
 	}) {
 		t.Fatalf("expected PR-only item to remain, got %+v", mm.workItems)
+	}
+	if hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool {
+		return item.ID == deletedLocalItem.ID
+	}) {
+		t.Fatalf("expected deleted local item not to be restored, got %+v", mm.workItems)
 	}
 	if !hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool {
 		return strings.HasPrefix(item.ID, "pull-request-discovery-error:")

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -77,6 +77,16 @@ func TestIssueFiltering_SearchesFullIssueBody(t *testing.T) {
 	}
 }
 
+func TestIssueFilterLineKeepsAppliedSearchVisibleAtNormalWidth(t *testing.T) {
+	start := newModel()
+	start.issueFilter.Search = "unicode query"
+
+	line := truncate(start.issueFilterLine(), 61)
+	if !strings.Contains(line, "search=unicode query") {
+		t.Fatalf("expected applied search to remain visible, got %q", line)
+	}
+}
+
 func TestIssuePreviewLines_ShowsLinkedPRsAndComments(t *testing.T) {
 	issue := workbench.IssueRef{
 		Number:        75,
@@ -1279,6 +1289,52 @@ func TestUpdate_IssueRefreshViewerFailureKeepsReviewPerspective(t *testing.T) {
 	pr := got[0].PullRequest
 	if pr.Title != "New title" || !pr.ViewerReviewRequested || !pr.ViewerAuthored || !pr.WaitingOnReview {
 		t.Fatalf("expected refreshed PR data with preserved review perspective, got %+v", pr)
+	}
+}
+
+func TestMergeIssueScopedWorkItemsDoesNotPreserveStateAcrossPullRequests(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	previous := workbench.WorkItem{
+		ID:     "branch:feature",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "feature"},
+		PullRequest: &workbench.PullRequestRef{
+			Number:                10,
+			HeadBranch:            "feature",
+			ViewerReviewRequested: true,
+			ViewerAuthored:        true,
+			WaitingOnReview:       true,
+		},
+		Issue:  &workbench.IssueRef{Number: 75, Title: "Old issue"},
+		Checks: workbench.CheckSummary{State: workbench.CheckFailing, Failing: 1},
+	}
+	current := workbench.WorkItem{
+		ID:          previous.ID,
+		Repo:        repo,
+		Branch:      previous.Branch,
+		PullRequest: &workbench.PullRequestRef{Number: 11, HeadBranch: "feature"},
+		Issue:       &workbench.IssueRef{Number: 76},
+		Checks:      workbench.CheckSummary{State: workbench.CheckUnknown},
+	}
+
+	got := mergeIssueScopedWorkItems([]workbench.WorkItem{previous}, repo, workbench.RuntimeLoadResult{
+		Repo:               repo,
+		Items:              []workbench.WorkItem{current},
+		PullRequestsLoaded: true,
+		ViewerSubjectError: "viewer unavailable",
+		FailedCheckRefs:    []string{"feature"},
+	})
+	if len(got) != 1 || got[0].PullRequest == nil || got[0].PullRequest.Number != 11 {
+		t.Fatalf("expected replacement pull request, got %+v", got)
+	}
+	if got[0].PullRequest.ViewerReviewRequested || got[0].PullRequest.ViewerAuthored || got[0].PullRequest.WaitingOnReview {
+		t.Fatalf("expected new pull request review state, got %+v", got[0].PullRequest)
+	}
+	if got[0].Checks.State != workbench.CheckUnknown {
+		t.Fatalf("expected new pull request check state, got %+v", got[0].Checks)
+	}
+	if got[0].Issue == nil || got[0].Issue.Number != 76 || got[0].Issue.Title != "" {
+		t.Fatalf("expected new issue association, got %+v", got[0].Issue)
 	}
 }
 

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -1338,6 +1338,48 @@ func TestMergeIssueScopedWorkItemsDoesNotPreserveStateAcrossPullRequests(t *test
 	}
 }
 
+func TestMergeIssueScopedWorkItemsDoesNotPreserveStateAcrossBranches(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	previous := workbench.WorkItem{
+		ID:       "worktree:/repos/gh-zen-feature",
+		Repo:     repo,
+		Branch:   &workbench.BranchRef{Name: "feature-a"},
+		Worktree: &workbench.WorktreeRef{Path: "/repos/gh-zen-feature"},
+		PullRequest: &workbench.PullRequestRef{
+			Number:     10,
+			HeadBranch: "feature-a",
+		},
+		Issue:  &workbench.IssueRef{Number: 75, Title: "Old issue"},
+		Checks: workbench.CheckSummary{State: workbench.CheckFailing, Failing: 1},
+	}
+	current := workbench.WorkItem{
+		ID:       previous.ID,
+		Repo:     repo,
+		Branch:   &workbench.BranchRef{Name: "feature-b"},
+		Worktree: previous.Worktree,
+		Issue:    &workbench.IssueRef{Number: 76, Title: "New issue"},
+	}
+
+	got := mergeIssueScopedWorkItems([]workbench.WorkItem{previous}, repo, workbench.RuntimeLoadResult{
+		Repo:               repo,
+		Items:              []workbench.WorkItem{current},
+		PullRequestsLoaded: false,
+		IssuesLoaded:       false,
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected one current branch item, got %+v", got)
+	}
+	if got[0].PullRequest != nil {
+		t.Fatalf("expected old branch pull request not to be restored, got %+v", got[0].PullRequest)
+	}
+	if got[0].Checks.State == workbench.CheckFailing || got[0].Checks.Failing != 0 {
+		t.Fatalf("expected old branch checks not to be restored, got %+v", got[0].Checks)
+	}
+	if got[0].Issue == nil || got[0].Issue.Number != 76 || got[0].Issue.Title != "New issue" {
+		t.Fatalf("expected current branch issue association, got %+v", got[0].Issue)
+	}
+}
+
 func TestSyncWorkbenchReturnAfterReloadMatchesRepositoryCaseInsensitively(t *testing.T) {
 	start := newModel()
 	start.repos = []workbench.RepoRef{

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -293,6 +293,58 @@ func TestUpdate_IssueViewUsesRepoScopedReloader(t *testing.T) {
 	}
 }
 
+func TestUpdate_IssueEntryWaitsForActiveWorkbenchReload(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	workbenchReloader := &fakeWorkbenchReloader{}
+	issueReloader := &fakeIssueReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:         repo,
+				IssuesRepo:   repo,
+				IssuesLoaded: true,
+				Issues:       []workbench.IssueRef{{Number: 75, Title: "Issue browsing", State: "open"}},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:          []workbench.RepoRef{repo},
+		Reloader:       workbenchReloader,
+		IssueReloader:  issueReloader,
+		InitialLoading: true,
+	}, fakeDelayedPreviewLoader(0))
+	initialRequest := start.activeReloadRequest
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd != nil {
+		t.Fatalf("expected issue entry to keep the active workbench reload, got a new command")
+	}
+	mm := got.(model)
+	if mm.activeReloadRequest != initialRequest || !mm.issueReloadPending {
+		t.Fatalf("expected active reload to remain pending before issue reload, got active=%+v pending=%v", mm.activeReloadRequest, mm.issueReloadPending)
+	}
+
+	got, cmd = mm.Update(workbenchReloadMsg{
+		request: initialRequest,
+		result: workbench.RuntimeLoadResult{
+			Repo:         repo,
+			Repositories: []workbench.RepositorySummary{{Repo: repo}},
+			IssuesRepo:   repo,
+			IssuesLoaded: true,
+		},
+	})
+	if cmd == nil {
+		t.Fatalf("expected a repo-scoped issue reload after the workbench reload")
+	}
+	mm = got.(model)
+	if !mm.activeReloadRequest.issueScoped || mm.issueReloadPending {
+		t.Fatalf("expected chained issue reload, got active=%+v pending=%v", mm.activeReloadRequest, mm.issueReloadPending)
+	}
+	requireWorkbenchReloadMsg(t, cmd)
+	if len(issueReloader.calls) != 1 || issueReloader.calls[0] != repo {
+		t.Fatalf("expected one delayed repo-scoped reload for %+v, got %+v", repo, issueReloader.calls)
+	}
+}
+
 func TestUpdate_IssueViewKeepsRawIssueSourceRepo(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "Owner", Name: "Repo"}
 	reloader := &fakeWorkbenchReloader{
@@ -711,6 +763,104 @@ func TestUpdate_IssueRefreshFailureKeepsRawIssues(t *testing.T) {
 	}
 	if !strings.Contains(start.issuesError, "network unavailable") {
 		t.Fatalf("expected issue refresh error state, got %q", start.issuesError)
+	}
+}
+
+func TestUpdate_IssueRefreshFailureKeepsLinkedPullRequests(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	start := newModel()
+	start.issueRepo = repo
+	start.prsByIssueNumber = pullRequestsByIssueNumber([]workbench.PullRequestRef{{
+		Number:       10,
+		Title:        "Previously loaded PR",
+		LinkedIssues: []workbench.IssueRef{{Number: 1}},
+	}})
+
+	start.updateIssueDataFromRuntimeResult(workbench.RuntimeLoadResult{
+		Repo: repo,
+		Items: []workbench.WorkItem{{
+			Repo: repo,
+			PullRequest: &workbench.PullRequestRef{
+				Number:       11,
+				Title:        "Work item PR",
+				LinkedIssues: []workbench.IssueRef{{Number: 2}},
+			},
+		}},
+	})
+
+	if prs := start.prsByIssueNumber[1]; len(prs) != 1 || prs[0].Number != 10 {
+		t.Fatalf("expected previously loaded linked PR to remain, got %+v", start.prsByIssueNumber)
+	}
+	if prs := start.prsByIssueNumber[2]; len(prs) != 1 || prs[0].Number != 11 {
+		t.Fatalf("expected work item linked PR to be merged, got %+v", start.prsByIssueNumber)
+	}
+}
+
+func TestUpdate_IssueRefreshCheckFailureDoesNotReportIssueFailure(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	start := newModel()
+	start.issueRepo = repo
+
+	start.updateIssueDataFromRuntimeResult(workbench.RuntimeLoadResult{
+		Repo:         repo,
+		IssuesRepo:   repo,
+		IssuesLoaded: true,
+		Items: []workbench.WorkItem{{
+			ID:     "issue-check-discovery-error:" + repo.FullName(),
+			Repo:   repo,
+			Local:  &workbench.LocalStatus{Summary: "issue and check discovery failed: checks unavailable"},
+			Checks: workbench.CheckSummary{State: workbench.CheckUnknown},
+		}},
+	})
+
+	if start.issuesError != "" {
+		t.Fatalf("expected successful issue load not to report a check failure, got %q", start.issuesError)
+	}
+}
+
+func TestIssuesFromWorkItemsExcludesUncertainBranchGuess(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	issues := issuesFromWorkItems([]workbench.WorkItem{
+		{Repo: repo, Issue: &workbench.IssueRef{Number: 2026, Certain: false, Source: workbench.IssueLinkSourceBranch}},
+		{Repo: repo, Issue: &workbench.IssueRef{Number: 75, Certain: true, Source: workbench.IssueLinkSourceBranch}},
+		{Repo: repo, Issue: &workbench.IssueRef{Number: 76, Certain: false, Source: workbench.IssueLinkSourcePullRequest}},
+	}, repo)
+
+	if len(issues) != 2 || issues[0].Number != 75 || issues[1].Number != 76 {
+		t.Fatalf("expected only verified or PR-linked issues, got %+v", issues)
+	}
+}
+
+func TestUpdate_IssueRefreshReplacesOnlyTargetRepositorySummary(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	issueReloader := &fakeIssueReloader{results: map[string]workbench.RuntimeLoadResult{
+		repoA.FullName(): {
+			Repo:         repoA,
+			Repositories: []workbench.RepositorySummary{{Repo: repoA, Path: "/new/a", OpenIssueCount: 3}},
+		},
+	}}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		RepositorySummaries: []workbench.RepositorySummary{
+			{Repo: repoA, Path: "/old/a", OpenIssueCount: 1},
+			{Repo: repoB, Path: "/old/b", OpenIssueCount: 2},
+		},
+		IssueReloader: issueReloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.screen = screenIssues
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	mm := got.(model)
+
+	if len(mm.repoSummaries) != 2 {
+		t.Fatalf("expected both repository summaries to remain, got %+v", mm.repoSummaries)
+	}
+	if summary, ok := mm.repoSummary(repoA); !ok || summary.Path != "/new/a" || summary.OpenIssueCount != 3 {
+		t.Fatalf("expected target summary to be refreshed, got %+v ok=%v", summary, ok)
+	}
+	if summary, ok := mm.repoSummary(repoB); !ok || summary.Path != "/old/b" || summary.OpenIssueCount != 2 {
+		t.Fatalf("expected unrelated summary to remain unchanged, got %+v ok=%v", summary, ok)
 	}
 }
 

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -258,6 +258,41 @@ func TestUpdate_IssueViewLoadsRawIssuesForSelectedRepo(t *testing.T) {
 	}
 }
 
+func TestUpdate_IssueViewUsesRepoScopedReloader(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	workbenchReloader := &fakeWorkbenchReloader{}
+	issueReloader := &fakeIssueReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:         repo,
+				IssuesRepo:   repo,
+				IssuesLoaded: true,
+				Issues:       []workbench.IssueRef{{Number: 75, Title: "Issue browsing", State: "open"}},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:         []workbench.RepoRef{repo},
+		Reloader:      workbenchReloader,
+		IssueReloader: issueReloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+	got, _ = got.(model).Update(msg)
+	mm := got.(model)
+
+	if len(workbenchReloader.calls) != 0 {
+		t.Fatalf("expected issue entry not to scan the full workbench, got %+v", workbenchReloader.calls)
+	}
+	if len(issueReloader.calls) != 1 || issueReloader.calls[0] != repo {
+		t.Fatalf("expected one repo-scoped issue reload for %+v, got %+v", repo, issueReloader.calls)
+	}
+	if issues := mm.visibleIssues(); len(issues) != 1 || issues[0].Number != 75 {
+		t.Fatalf("expected repo-scoped issues to be applied, got %+v", issues)
+	}
+}
+
 func TestUpdate_IssueViewKeepsRawIssueSourceRepo(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "Owner", Name: "Repo"}
 	reloader := &fakeWorkbenchReloader{
@@ -642,5 +677,76 @@ func TestUpdate_IssueRefreshUpdatesIssueData(t *testing.T) {
 	}
 	if prs := mm.prsByIssueNumber[2]; len(prs) != 1 || prs[0].Number != 24 {
 		t.Fatalf("expected linked PR index from reload, got %+v", mm.prsByIssueNumber)
+	}
+}
+
+func TestUpdate_IssueRefreshFailureKeepsRawIssues(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:  []workbench.RepoRef{repo},
+		Issues: []workbench.IssueRef{{Number: 1, Title: "Previously loaded", State: "open"}},
+	}, fakeDelayedPreviewLoader(0))
+	start.screen = screenIssues
+	start.issueRepo = repo
+
+	start.updateIssueDataFromRuntimeResult(workbench.RuntimeLoadResult{
+		Repo: repo,
+		Items: []workbench.WorkItem{
+			{
+				ID:    "linked-issue",
+				Repo:  repo,
+				Issue: &workbench.IssueRef{Number: 2, Title: "Linked issue", State: "open"},
+			},
+			{
+				ID:     "issue-check-discovery-error:" + repo.FullName(),
+				Repo:   repo,
+				Local:  &workbench.LocalStatus{Summary: "issue and check discovery failed: network unavailable"},
+				Checks: workbench.CheckSummary{State: workbench.CheckUnknown},
+			},
+		},
+	})
+
+	if len(start.issues) != 2 || start.issues[0].Number != 1 || start.issues[1].Number != 2 {
+		t.Fatalf("expected the prior raw issue and new linked issue to remain, got %+v", start.issues)
+	}
+	if !strings.Contains(start.issuesError, "network unavailable") {
+		t.Fatalf("expected issue refresh error state, got %q", start.issuesError)
+	}
+}
+
+func TestIssueLinesKeepSelectedIssueInsideViewport(t *testing.T) {
+	start := newModel()
+	start.issues = make([]workbench.IssueRef, 20)
+	for i := range start.issues {
+		start.issues[i] = workbench.IssueRef{Number: i + 1, Title: "Issue", State: "open"}
+	}
+	start.selectedIssue = 15
+
+	lines := start.issueLines(80, 6, true)
+	if len(lines) > 6 {
+		t.Fatalf("expected at most six issue lines, got %d: %#v", len(lines), lines)
+	}
+	if got := strings.Join(lines, "\n"); !strings.Contains(got, "> #16") {
+		t.Fatalf("expected selected issue to remain in the viewport, got %q", got)
+	}
+}
+
+func TestRenderIssueFullFitsTerminalHeight(t *testing.T) {
+	start := newModel()
+	start.screen = screenIssues
+	start.width = fullLayoutMinWidth
+	start.height = 12
+	start.issues = make([]workbench.IssueRef, 20)
+	for i := range start.issues {
+		start.issues[i] = workbench.IssueRef{Number: i + 1, Title: "Issue", State: "open"}
+	}
+	start.selectedIssue = 19
+
+	rendered := strings.TrimSuffix(start.renderIssueFull(start.width), "\n")
+	if lines := strings.Count(rendered, "\n") + 1; lines > start.height {
+		t.Fatalf("expected issue view to fit height %d, got %d lines", start.height, lines)
+	}
+	if !strings.Contains(rendered, "#20") {
+		t.Fatalf("expected selected issue to remain visible, got %q", rendered)
 	}
 }

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -53,6 +53,20 @@ func TestIssueFiltering_CoversStateAssigneeLabelMilestoneAndSearch(t *testing.T)
 	assertNumbers("unicode search", issueFilterState{State: issueStateAll, Search: "設定"}, 2)
 }
 
+func TestIssueFiltering_SearchesFullIssueBody(t *testing.T) {
+	body := strings.Repeat("setup details ", 30) + "final diagnostic marker"
+	got := filterIssues([]workbench.IssueRef{{
+		Number: 1,
+		Title:  "Long issue template",
+		State:  "open",
+		Body:   body,
+	}}, issueFilterState{State: issueStateAll, Search: "diagnostic marker"}, "")
+
+	if len(got) != 1 || got[0].Number != 1 {
+		t.Fatalf("expected search to match full issue body, got %+v", got)
+	}
+}
+
 func TestIssuePreviewLines_ShowsLinkedPRsAndComments(t *testing.T) {
 	issue := workbench.IssueRef{
 		Number:        75,
@@ -111,6 +125,86 @@ func TestIssuePreviewLines_OmitsUnavailableLinkedPRsAndZeroComments(t *testing.T
 	}
 }
 
+func TestUpdate_IssueViewUsesSelectedWorkItemRepo(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	repoAItem := workbench.WorkItem{
+		ID:       "branch:repo-a",
+		Repo:     repoA,
+		Branch:   &workbench.BranchRef{Name: "repo-a"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/repo-a"},
+	}
+	repoBItem := workbench.WorkItem{
+		ID:       "branch:repo-b",
+		Repo:     repoB,
+		Branch:   &workbench.BranchRef{Name: "repo-b"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/repo-b"},
+		Issue:    &workbench.IssueRef{Number: 22, Title: "Repo B issue", State: "open"},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{repoAItem, repoBItem},
+	}, fakeDelayedPreviewLoader(0))
+	start.setRepoPaneIndex(len(start.repos))
+	start.selectedItem = 1
+	start.focusedWorkItemID = repoBItem.ID
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd != nil {
+		t.Fatalf("expected issue view transition without command, got %T", cmd)
+	}
+	mm := got.(model)
+	if mm.issueRepo != repoB {
+		t.Fatalf("expected issue view repo %+v, got %+v", repoB, mm.issueRepo)
+	}
+	issue, ok := mm.selectedIssueRef()
+	if !ok || issue.Number != 22 {
+		t.Fatalf("expected selected issue #22 from repo B, got %+v ok=%v", issue, ok)
+	}
+}
+
+func TestUpdate_IssueViewRefreshUsesIssueRepo(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	repoAItem := workbench.WorkItem{
+		ID:       "branch:repo-a",
+		Repo:     repoA,
+		Branch:   &workbench.BranchRef{Name: "repo-a"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/repo-a"},
+	}
+	repoBItem := workbench.WorkItem{
+		ID:       "branch:repo-b",
+		Repo:     repoB,
+		Branch:   &workbench.BranchRef{Name: "repo-b"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/repo-b"},
+		Issue:    &workbench.IssueRef{Number: 22, Title: "Repo B issue", State: "open"},
+	}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repoB.FullName(): {Repo: repoB, Items: []workbench.WorkItem{repoBItem}},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{repoAItem, repoBItem},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.setRepoPaneIndex(len(start.repos))
+	start.selectedItem = 1
+	start.focusedWorkItemID = repoBItem.ID
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, cmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+
+	if msg.request.repo != repoB {
+		t.Fatalf("expected issue refresh request for %+v, got %+v", repoB, msg.request.repo)
+	}
+	if len(reloader.calls) != 1 || reloader.calls[0] != repoB {
+		t.Fatalf("expected reload call for %+v, got %+v", repoB, reloader.calls)
+	}
+}
+
 func TestUpdate_IssueViewBackRestoresWorkbenchSelection(t *testing.T) {
 	start := newModel()
 	start.selectedItem = 2
@@ -129,6 +223,43 @@ func TestUpdate_IssueViewBackRestoresWorkbenchSelection(t *testing.T) {
 	mm = got.(model)
 	if mm.screen != screenWorkbench || mm.selectedItem != 2 || mm.focusedPane != paneWorkItems {
 		t.Fatalf("expected workbench selection to be restored, got screen=%v item=%d focus=%v", mm.screen, mm.selectedItem, mm.focusedPane)
+	}
+}
+
+func TestUpdate_IssueViewRefreshUpdatesReturnSelection(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	first := workbench.WorkItem{ID: "branch:first", Repo: repo, Branch: &workbench.BranchRef{Name: "first"}}
+	second := workbench.WorkItem{ID: "branch:second", Repo: repo, Branch: &workbench.BranchRef{Name: "second"}}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{second, first},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{first, second},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.selectedItem = 1
+	start.focusedWorkItemID = second.ID
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, cmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatalf("expected issue refresh command")
+	}
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	got, _ = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	mm := got.(model)
+
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected return selection to follow reloaded item to index 0, got %d", mm.selectedItem)
+	}
+	if item, ok := mm.selectedWorkItem(); !ok || item.ID != second.ID {
+		t.Fatalf("expected selected work item %q, got %+v ok=%v", second.ID, item, ok)
 	}
 }
 

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -258,6 +258,49 @@ func TestUpdate_IssueViewLoadsRawIssuesForSelectedRepo(t *testing.T) {
 	}
 }
 
+func TestUpdate_IssueViewKeepsRawIssueSourceRepo(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "Owner", Name: "Repo"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:         workbench.RepoRef{},
+				IssuesRepo:   repo,
+				IssuesLoaded: true,
+				Issues: []workbench.IssueRef{{
+					Number:  44,
+					Title:   "Unlinked issue",
+					State:   "open",
+					Certain: true,
+				}},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:    []workbench.RepoRef{repo},
+		Reloader: reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.screen = screenIssues
+	start.issueRepo = repo
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatalf("expected issue refresh command")
+	}
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	mm := got.(model)
+
+	if mm.issueRepo != repo {
+		t.Fatalf("expected issue repo to remain %+v, got %+v", repo, mm.issueRepo)
+	}
+	if issues := mm.visibleIssues(); len(issues) != 1 || issues[0].Number != 44 {
+		t.Fatalf("expected raw issue to remain visible, got %+v", issues)
+	}
+	mm.prepareIssueDataForRepo(workbench.RepoRef{Owner: "owner", Name: "repo"})
+	if issues := mm.visibleIssues(); len(issues) != 1 || issues[0].Number != 44 {
+		t.Fatalf("expected raw issue cache to keep its case-insensitive source repo, got %+v", issues)
+	}
+}
+
 func TestUpdate_IssueViewBackRestoresWorkbenchSelection(t *testing.T) {
 	start := newModel()
 	start.selectedItem = 2

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -1058,6 +1058,113 @@ func TestUpdate_IssueRefreshPullRequestFailureKeepsWorkbenchEnrichment(t *testin
 	}
 }
 
+func TestUpdate_IssueRefreshLocalDiscoveryFailureKeepsLocalWorkItems(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	previous := workbench.WorkItem{
+		ID:       "worktree:/repos/gh-zen-feature",
+		Repo:     repo,
+		Branch:   &workbench.BranchRef{Name: "feature"},
+		Worktree: &workbench.WorktreeRef{Path: "/repos/gh-zen-feature"},
+		Local:    &workbench.LocalStatus{State: workbench.LocalDirty, Summary: "1 status entry"},
+		PullRequest: &workbench.PullRequestRef{
+			Number:     10,
+			Title:      "Old title",
+			State:      "open",
+			HeadOwner:  "0maru",
+			HeadBranch: "feature",
+		},
+		Issue:  &workbench.IssueRef{Number: 75, Title: "Old issue", State: "open"},
+		Checks: workbench.CheckSummary{State: workbench.CheckFailing, Failing: 1},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		RepositorySummaries: []workbench.RepositorySummary{{Repo: repo, Path: "/repos/gh-zen"}},
+		WorkItems:           []workbench.WorkItem{previous},
+	}, fakeDelayedPreviewLoader(0))
+	request := workbenchReloadRequest{requestID: 1, repo: repo, status: "Loading issues...", issueScoped: true}
+	start.screen = screenIssues
+	start.issueRepo = repo
+	start.workbenchLoading = true
+	start.activeReloadRequest = request
+
+	refreshedPR := workbench.PullRequestRef{
+		Number:     10,
+		Title:      "New title",
+		State:      "open",
+		HeadOwner:  "0maru",
+		HeadBranch: "feature",
+		LinkedIssues: []workbench.IssueRef{{
+			Number: 75,
+		}},
+	}
+	got, _ := start.Update(workbenchReloadMsg{
+		request: request,
+		result: workbench.RuntimeLoadResult{
+			Repo: repo,
+			Repositories: []workbench.RepositorySummary{{
+				Repo: repo,
+				Path: "/repos/gh-zen",
+			}},
+			Items: []workbench.WorkItem{
+				{
+					ID:    "local-discovery-error:" + repo.FullName(),
+					Repo:  repo,
+					Local: &workbench.LocalStatus{State: workbench.LocalUnknown, Summary: "local discovery failed: git unavailable"},
+				},
+				{
+					ID:          "pull-request:" + repo.FullName() + ":#10",
+					Repo:        repo,
+					PullRequest: &refreshedPR,
+					Checks:      workbench.CheckSummary{State: workbench.CheckPassing, Passing: 2},
+				},
+			},
+			PullRequests:        []workbench.PullRequestRef{refreshedPR},
+			PullRequestsLoaded:  true,
+			IssuesRepo:          repo,
+			Issues:              []workbench.IssueRef{{Number: 75, Title: "New issue", State: "open"}},
+			IssuesLoaded:        true,
+			LocalDiscoveryError: "git unavailable",
+		},
+	})
+	mm := got.(model)
+
+	var reloaded workbench.WorkItem
+	if !hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool {
+		if item.ID != previous.ID {
+			return false
+		}
+		reloaded = item
+		return true
+	}) {
+		t.Fatalf("expected local worktree to remain, got %+v", mm.workItems)
+	}
+	if reloaded.Worktree == nil || reloaded.Local == nil || reloaded.Local.State != workbench.LocalDirty {
+		t.Fatalf("expected local worktree state to remain, got %+v", reloaded)
+	}
+	if reloaded.PullRequest == nil || reloaded.PullRequest.Title != "New title" {
+		t.Fatalf("expected refreshed PR data on retained worktree, got %+v", reloaded.PullRequest)
+	}
+	if reloaded.Issue == nil || reloaded.Issue.Title != "New issue" {
+		t.Fatalf("expected refreshed issue data on retained worktree, got %+v", reloaded.Issue)
+	}
+	if reloaded.Checks.State != workbench.CheckPassing || reloaded.Checks.Passing != 2 {
+		t.Fatalf("expected refreshed checks on retained worktree, got %+v", reloaded.Checks)
+	}
+	if hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool {
+		return strings.HasPrefix(item.ID, "pull-request:")
+	}) {
+		t.Fatalf("expected linked PR not to be duplicated as a PR-only item, got %+v", mm.workItems)
+	}
+	if !hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool {
+		return strings.HasPrefix(item.ID, "local-discovery-error:")
+	}) {
+		t.Fatalf("expected current local discovery error to remain visible, got %+v", mm.workItems)
+	}
+	summary, ok := mm.repoSummary(repo)
+	if !ok || summary.ActiveWorktreeCount != 1 || summary.OpenPullRequestCount != 1 || summary.OpenIssueCount != 1 {
+		t.Fatalf("expected summary from retained local worktree, got %+v ok=%v", summary, ok)
+	}
+}
+
 func TestUpdate_IssueRefreshCheckFailureKeepsOnlyFailedCheckState(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	failedItem := workbench.WorkItem{

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -111,7 +111,7 @@ func TestIssuePreviewLines_ShowsLinkedPRsAndComments(t *testing.T) {
 		LinkedIssues: []workbench.IssueRef{
 			{Number: 75},
 		},
-	}})
+	}}, m.issueRepo)
 
 	got := strings.Join(m.issuePreviewLines(120), "\n")
 	for _, want := range []string{
@@ -180,6 +180,71 @@ func TestUpdate_IssueViewUsesSelectedWorkItemRepo(t *testing.T) {
 	issue, ok := mm.selectedIssueRef()
 	if !ok || issue.Number != 22 {
 		t.Fatalf("expected selected issue #22 from repo B, got %+v ok=%v", issue, ok)
+	}
+}
+
+func TestUpdate_IssueViewSelectsUncertainTargetAfterReload(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	item := workbench.WorkItem{
+		ID:     "branch:release-75",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "release-75"},
+		Issue:  &workbench.IssueRef{Number: 75, Certain: false, Source: workbench.IssueLinkSourceBranch},
+	}
+	reloader := &fakeIssueReloader{results: map[string]workbench.RuntimeLoadResult{
+		repo.FullName(): {
+			Repo:         repo,
+			Items:        []workbench.WorkItem{item},
+			IssuesRepo:   repo,
+			IssuesLoaded: true,
+			Issues:       []workbench.IssueRef{{Number: 75, Repository: repo.FullName(), Title: "Verified issue", State: "open", Certain: true}},
+		},
+	}}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:         []workbench.RepoRef{repo},
+		WorkItems:     []workbench.WorkItem{item},
+		IssueReloader: reloader,
+	}, fakeDelayedPreviewLoader(0))
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd == nil {
+		t.Fatalf("expected issue reload command")
+	}
+	mm := got.(model)
+	if mm.pendingIssueNumber != 75 {
+		t.Fatalf("expected target issue to remain pending, got %d", mm.pendingIssueNumber)
+	}
+
+	got, _ = mm.Update(requireWorkbenchReloadMsg(t, cmd))
+	mm = got.(model)
+	issue, ok := mm.selectedIssueRef()
+	if !ok || issue.Number != 75 || issue.Title != "Verified issue" {
+		t.Fatalf("expected reloaded target issue to be selected, got %+v ok=%v", issue, ok)
+	}
+	if mm.pendingIssueNumber != 0 {
+		t.Fatalf("expected pending target to clear after selection, got %d", mm.pendingIssueNumber)
+	}
+}
+
+func TestIssueIndexesExcludeOtherRepositoryClosingIssues(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	pr := workbench.PullRequestRef{
+		Number: 24,
+		LinkedIssues: []workbench.IssueRef{
+			{Number: 75, Repository: "other/repo", Title: "External issue", Certain: true},
+			{Number: 75, Repository: repo.FullName(), Title: "Local issue", Certain: true},
+			{Number: 76, Repository: "other/repo", Title: "External only", Certain: true},
+		},
+	}
+	items := []workbench.WorkItem{{Repo: repo, PullRequest: &pr}}
+
+	issues := issuesFromWorkItems(items, repo)
+	if len(issues) != 1 || issues[0].Number != 75 || issues[0].Title != "Local issue" {
+		t.Fatalf("expected only local-repository issues in the catalog, got %+v", issues)
+	}
+	index := pullRequestsByIssueNumber([]workbench.PullRequestRef{pr}, repo)
+	if len(index[75]) != 1 || len(index[76]) != 0 {
+		t.Fatalf("expected linked PR index to exclude other repositories, got %+v", index)
 	}
 }
 
@@ -958,7 +1023,7 @@ func TestUpdate_IssueRefreshFailureKeepsLinkedPullRequests(t *testing.T) {
 		Number:       10,
 		Title:        "Previously loaded PR",
 		LinkedIssues: []workbench.IssueRef{{Number: 1}},
-	}})
+	}}, repo)
 
 	start.updateIssueDataFromRuntimeResult(workbench.RuntimeLoadResult{
 		Repo: repo,

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -346,6 +346,107 @@ func TestUpdate_IssueEntryWaitsForActiveWorkbenchReload(t *testing.T) {
 	}
 }
 
+func TestUpdate_IssueEntryStartsPendingReloadAfterDifferentRepoWorkbenchResponse(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "repo-a"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "repo-b"}
+	issueReloader := &fakeIssueReloader{results: map[string]workbench.RuntimeLoadResult{
+		repoB.FullName(): {
+			Repo:         repoB,
+			IssuesRepo:   repoB,
+			IssuesLoaded: true,
+			Issues:       []workbench.IssueRef{{Number: 75, Title: "Repo B issue", State: "open"}},
+		},
+	}}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:          []workbench.RepoRef{repoA, repoB},
+		Reloader:       &fakeWorkbenchReloader{},
+		IssueReloader:  issueReloader,
+		InitialLoading: true,
+	}, fakeDelayedPreviewLoader(0))
+	initialRequest := start.activeReloadRequest
+	start.screen = screenIssues
+	start.issueRepo = repoB
+	start.issueReloadPending = true
+	start.pendingIssueRepo = repoB
+	start.issuesLoading = true
+
+	got, cmd := start.Update(workbenchReloadMsg{
+		request: initialRequest,
+		result: workbench.RuntimeLoadResult{
+			Repo:         repoA,
+			Repositories: []workbench.RepositorySummary{{Repo: repoA}, {Repo: repoB}},
+			Items: []workbench.WorkItem{{
+				ID:   "repo-a-refreshed-item",
+				Repo: repoA,
+			}},
+		},
+	})
+	if cmd == nil {
+		t.Fatalf("expected pending repo B reload after stale repo A response")
+	}
+	mm := got.(model)
+	if !mm.activeReloadRequest.issueScoped || mm.activeReloadRequest.repo != repoB {
+		t.Fatalf("expected repo B scoped reload, got %+v", mm.activeReloadRequest)
+	}
+	if !hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool { return item.ID == "repo-a-refreshed-item" }) {
+		t.Fatalf("expected the full workbench response to be applied before the pending reload, got %+v", mm.workItems)
+	}
+	requireWorkbenchReloadMsg(t, cmd)
+	if len(issueReloader.calls) != 1 || issueReloader.calls[0] != repoB {
+		t.Fatalf("expected pending reload for %+v, got %+v", repoB, issueReloader.calls)
+	}
+}
+
+func TestUpdate_IssueReentryQueuesDifferentRepoBehindScopedReload(t *testing.T) {
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "repo-b"}
+	repoC := workbench.RepoRef{Owner: "0maru", Name: "repo-c"}
+	issueReloader := &fakeIssueReloader{results: map[string]workbench.RuntimeLoadResult{
+		repoC.FullName(): {
+			Repo:         repoC,
+			IssuesRepo:   repoC,
+			IssuesLoaded: true,
+			Issues:       []workbench.IssueRef{{Number: 3, Title: "Repo C issue", State: "open"}},
+		},
+	}}
+	start := newModel()
+	start.screen = screenIssues
+	start.issueRepo = repoC
+	start.issues = []workbench.IssueRef{{Number: 3, Title: "Cached repo C issue", State: "open"}}
+	start.issueReloader = issueReloader
+	start.workbenchLoading = true
+	start.issuesLoading = true
+	start.nextReloadRequestID = 1
+	start.activeReloadRequest = workbenchReloadRequest{requestID: 1, repo: repoB, status: "Loading issues...", issueScoped: true}
+
+	if cmd := start.startIssueViewReload(); cmd != nil {
+		t.Fatalf("expected repo C reload to wait for active repo B reload")
+	}
+	if !start.issueReloadPending || start.pendingIssueRepo != repoC {
+		t.Fatalf("expected repo C to be recorded as pending, got pending=%v repo=%+v", start.issueReloadPending, start.pendingIssueRepo)
+	}
+
+	got, cmd := start.Update(workbenchReloadMsg{
+		request: workbenchReloadRequest{requestID: 1, repo: repoB, status: "Loading issues...", issueScoped: true},
+		result: workbench.RuntimeLoadResult{
+			Repo:         repoB,
+			IssuesRepo:   repoB,
+			IssuesLoaded: true,
+			Issues:       []workbench.IssueRef{{Number: 2, Title: "Repo B issue", State: "open"}},
+		},
+	})
+	if cmd == nil {
+		t.Fatalf("expected queued repo C reload after repo B completes")
+	}
+	mm := got.(model)
+	if mm.issueRepo != repoC || len(mm.issues) != 1 || mm.issues[0].Number != 3 {
+		t.Fatalf("expected visible repo C issue data to stay intact, got repo=%+v issues=%+v", mm.issueRepo, mm.issues)
+	}
+	if !mm.activeReloadRequest.issueScoped || mm.activeReloadRequest.repo != repoC {
+		t.Fatalf("expected active repo C reload, got %+v", mm.activeReloadRequest)
+	}
+	requireWorkbenchReloadMsg(t, cmd)
+}
+
 func TestUpdate_IssueViewKeepsRawIssueSourceRepo(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "Owner", Name: "Repo"}
 	reloader := &fakeWorkbenchReloader{

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -991,6 +991,79 @@ func TestUpdate_IssueRefreshPullRequestFailureKeepsWorkbenchEnrichment(t *testin
 	}
 }
 
+func TestUpdate_IssueRefreshCheckFailureKeepsOnlyFailedCheckState(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	failedItem := workbench.WorkItem{
+		ID:          "branch:first",
+		Repo:        repo,
+		Branch:      &workbench.BranchRef{Name: "first"},
+		PullRequest: &workbench.PullRequestRef{Number: 10, HeadBranch: "first"},
+		Checks:      workbench.CheckSummary{State: workbench.CheckFailing, Failing: 1},
+	}
+	loadedItem := workbench.WorkItem{
+		ID:          "branch:second",
+		Repo:        repo,
+		Branch:      &workbench.BranchRef{Name: "second"},
+		PullRequest: &workbench.PullRequestRef{Number: 11, HeadBranch: "second"},
+		Checks:      workbench.CheckSummary{State: workbench.CheckFailing, Failing: 1},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		RepositorySummaries: []workbench.RepositorySummary{{Repo: repo}},
+		WorkItems:           []workbench.WorkItem{failedItem, loadedItem},
+	}, fakeDelayedPreviewLoader(0))
+	request := workbenchReloadRequest{requestID: 1, repo: repo, status: "Loading issues...", issueScoped: true}
+	start.screen = screenIssues
+	start.issueRepo = repo
+	start.workbenchLoading = true
+	start.activeReloadRequest = request
+
+	got, _ := start.Update(workbenchReloadMsg{
+		request: request,
+		result: workbench.RuntimeLoadResult{
+			Repo:               repo,
+			Repositories:       []workbench.RepositorySummary{{Repo: repo}},
+			PullRequestsLoaded: true,
+			IssuesRepo:         repo,
+			IssuesLoaded:       true,
+			FailedCheckRefs:    []string{"first"},
+			Items: []workbench.WorkItem{
+				{
+					ID:          failedItem.ID,
+					Repo:        repo,
+					Branch:      failedItem.Branch,
+					PullRequest: failedItem.PullRequest,
+					Checks:      workbench.CheckSummary{State: workbench.CheckUnknown},
+				},
+				{
+					ID:          loadedItem.ID,
+					Repo:        repo,
+					Branch:      loadedItem.Branch,
+					PullRequest: loadedItem.PullRequest,
+					Checks:      workbench.CheckSummary{State: workbench.CheckUnknown},
+				},
+			},
+		},
+	})
+	mm := got.(model)
+
+	for _, item := range mm.workItems {
+		switch item.ID {
+		case failedItem.ID:
+			if item.Checks.State != workbench.CheckFailing || item.Checks.Failing != 1 {
+				t.Fatalf("expected failed check load to preserve previous state, got %+v", item.Checks)
+			}
+		case loadedItem.ID:
+			if item.Checks.State != workbench.CheckUnknown {
+				t.Fatalf("expected successful unknown check load to replace previous state, got %+v", item.Checks)
+			}
+		}
+	}
+	summary, ok := mm.repoSummary(repo)
+	if !ok || summary.FailingCheckCount != 1 {
+		t.Fatalf("expected summary to retain one failed check, got %+v ok=%v", summary, ok)
+	}
+}
+
 func TestUpdate_IssueRefreshReplacesRepositoryCaseInsensitively(t *testing.T) {
 	canonicalRepo := workbench.RepoRef{Owner: "Owner", Name: "Repo"}
 	requestRepo := workbench.RepoRef{Owner: "owner", Name: "repo"}

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -701,6 +701,46 @@ func TestUpdate_IssueViewRefreshUpdatesReturnSelection(t *testing.T) {
 	}
 }
 
+func TestUpdate_IssueViewFullReloadPreservesReturnSelectionAcrossRepoCasing(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "owner", Name: "repo"}
+	canonicalRepo := workbench.RepoRef{Owner: "Owner", Name: "Repo"}
+	first := workbench.WorkItem{ID: "branch:first", Repo: repo, Branch: &workbench.BranchRef{Name: "first"}}
+	second := workbench.WorkItem{ID: "branch:second", Repo: repo, Branch: &workbench.BranchRef{Name: "second"}}
+	reloadedFirst := first
+	reloadedFirst.Repo = canonicalRepo
+	reloadedSecond := second
+	reloadedSecond.Repo = canonicalRepo
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:         canonicalRepo,
+				Repositories: []workbench.RepositorySummary{{Repo: canonicalRepo}},
+				Items:        []workbench.WorkItem{reloadedSecond, reloadedFirst},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{first, second},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.selectedItem = 1
+	start.focusedWorkItemRepo = second.Repo
+	start.focusedWorkItemID = second.ID
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	got, _ = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	mm := got.(model)
+
+	if mm.selectedItem != 0 {
+		t.Fatalf("expected return selection to follow the case-insensitive repo and stable ID to index 0, got %d", mm.selectedItem)
+	}
+	if item, ok := mm.selectedWorkItem(); !ok || item.ID != second.ID || !sameRepoRef(item.Repo, canonicalRepo) {
+		t.Fatalf("expected selected work item %q in canonical repo, got %+v ok=%v", second.ID, item, ok)
+	}
+}
+
 func TestUpdate_IssueViewReloadRefreshesPreviewOnReturn(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	original := workbench.WorkItem{

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -203,14 +203,15 @@ func TestUpdate_IssueViewRefreshUsesIssueRepo(t *testing.T) {
 	start.selectedItem = 1
 	start.focusedWorkItemID = repoBItem.ID
 
-	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
-	got, cmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	got, cmd = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	msg := requireWorkbenchReloadMsg(t, cmd)
 
 	if msg.request.repo != repoB {
 		t.Fatalf("expected issue refresh request for %+v, got %+v", repoB, msg.request.repo)
 	}
-	if len(reloader.calls) != 1 || reloader.calls[0] != repoB {
+	if len(reloader.calls) != 2 || reloader.calls[0] != repoB || reloader.calls[1] != repoB {
 		t.Fatalf("expected reload call for %+v, got %+v", repoB, reloader.calls)
 	}
 }
@@ -343,6 +344,70 @@ func TestUpdate_IssueEntryWaitsForActiveWorkbenchReload(t *testing.T) {
 	requireWorkbenchReloadMsg(t, cmd)
 	if len(issueReloader.calls) != 1 || issueReloader.calls[0] != repo {
 		t.Fatalf("expected one delayed repo-scoped reload for %+v, got %+v", repo, issueReloader.calls)
+	}
+}
+
+func TestUpdate_IssueRefreshWaitsForActiveWorkbenchReload(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:          []workbench.RepoRef{repo},
+		Reloader:       &fakeWorkbenchReloader{},
+		IssueReloader:  &fakeIssueReloader{},
+		InitialLoading: true,
+	}, fakeDelayedPreviewLoader(0))
+	initialRequest := start.activeReloadRequest
+	start.screen = screenIssues
+	start.issueRepo = repo
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd != nil {
+		t.Fatalf("expected issue refresh to keep the active workbench reload, got a new command")
+	}
+	mm := got.(model)
+	if mm.activeReloadRequest != initialRequest || !mm.issueReloadPending || mm.pendingIssueRepo != repo {
+		t.Fatalf("expected issue refresh to wait for the active reload, got active=%+v pending=%v repo=%+v", mm.activeReloadRequest, mm.issueReloadPending, mm.pendingIssueRepo)
+	}
+}
+
+func TestUpdate_IssueRefreshWithFullReloaderDoesNotDuplicateOtherRepositories(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "repo-a"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "repo-b"}
+	oldA := workbench.WorkItem{ID: "branch:old-a", Repo: repoA, Branch: &workbench.BranchRef{Name: "old-a"}}
+	oldB := workbench.WorkItem{ID: "branch:old-b", Repo: repoB, Branch: &workbench.BranchRef{Name: "old-b"}}
+	newA := workbench.WorkItem{ID: "branch:new-a", Repo: repoA, Branch: &workbench.BranchRef{Name: "new-a"}}
+	newB := workbench.WorkItem{ID: "branch:new-b", Repo: repoB, Branch: &workbench.BranchRef{Name: "new-b"}}
+	reloader := &fakeWorkbenchReloader{results: map[string]workbench.RuntimeLoadResult{
+		repoA.FullName(): {Repo: repoA, Items: []workbench.WorkItem{newA, newB}},
+	}}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{oldA, oldB},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.screen = screenIssues
+	start.issueRepo = repoA
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+	if !msg.request.issueScoped || !msg.request.fullResult {
+		t.Fatalf("expected issue lifecycle with full-result semantics, got %+v", msg.request)
+	}
+	got, _ = got.(model).Update(msg)
+	mm := got.(model)
+
+	if hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool { return item.ID == oldA.ID || item.ID == newB.ID }) {
+		t.Fatalf("expected only repo A items from the full-reloader result to replace repo A, got %+v", mm.workItems)
+	}
+	for _, id := range []string{newA.ID, oldB.ID} {
+		count := 0
+		for _, item := range mm.workItems {
+			if item.ID == id {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("expected exactly one %q item, got %d in %+v", id, count, mm.workItems)
+		}
 	}
 }
 
@@ -531,8 +596,9 @@ func TestUpdate_IssueViewRefreshUpdatesReturnSelection(t *testing.T) {
 	start.selectedItem = 1
 	start.focusedWorkItemID = second.ID
 
-	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
-	got, cmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	got, cmd = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	if cmd == nil {
 		t.Fatalf("expected issue refresh command")
 	}
@@ -587,8 +653,9 @@ func TestUpdate_IssueViewReloadRefreshesPreviewOnReturn(t *testing.T) {
 		},
 	}
 
-	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
-	got, cmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	got, cmd = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
 	got, cmd = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	if cmd == nil {
@@ -642,8 +709,9 @@ func TestUpdate_IssueViewRefreshPreservesReturnRepo(t *testing.T) {
 	start.selectedItem = 1
 	start.focusedWorkItemID = repoBItem.ID
 
-	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
-	got, cmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	got, cmd = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
 	got, _ = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	mm := got.(model)
@@ -674,7 +742,7 @@ func TestUpdate_IssueRefreshAppliesAfterReturningToWorkbench(t *testing.T) {
 	}
 	repoBReloaded := repoBItem
 	repoBReloaded.Issue = &workbench.IssueRef{Number: 23, Title: "Reloaded repo B issue", State: "open"}
-	reloader := &fakeWorkbenchReloader{
+	issueReloader := &fakeIssueReloader{
 		results: map[string]workbench.RuntimeLoadResult{
 			repoB.FullName(): {
 				Repo: repoB,
@@ -689,16 +757,15 @@ func TestUpdate_IssueRefreshAppliesAfterReturningToWorkbench(t *testing.T) {
 		},
 	}
 	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
-		Repos:     []workbench.RepoRef{repoA, repoB},
-		WorkItems: []workbench.WorkItem{repoAItem, repoBItem},
-		Reloader:  reloader,
+		Repos:         []workbench.RepoRef{repoA, repoB},
+		WorkItems:     []workbench.WorkItem{repoAItem, repoBItem},
+		IssueReloader: issueReloader,
 	}, fakeDelayedPreviewLoader(0))
 	start.setRepoPaneIndex(len(start.repos))
 	start.selectedItem = 1
 	start.focusedWorkItemID = repoBItem.ID
 
-	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
-	got, cmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
 	msg := requireWorkbenchReloadMsg(t, cmd)
 	got, _ = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	got, _ = got.(model).Update(msg)
@@ -1061,6 +1128,58 @@ func TestUpdate_IssueRefreshCheckFailureKeepsOnlyFailedCheckState(t *testing.T) 
 	summary, ok := mm.repoSummary(repo)
 	if !ok || summary.FailingCheckCount != 1 {
 		t.Fatalf("expected summary to retain one failed check, got %+v ok=%v", summary, ok)
+	}
+}
+
+func TestUpdate_IssueRefreshViewerFailureKeepsReviewPerspective(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	previous := workbench.WorkItem{
+		ID:     "branch:feature",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "feature"},
+		PullRequest: &workbench.PullRequestRef{
+			Number:                10,
+			Title:                 "Old title",
+			HeadBranch:            "feature",
+			ViewerReviewRequested: true,
+			ViewerAuthored:        true,
+			WaitingOnReview:       true,
+		},
+	}
+	refreshed := previous
+	refreshed.PullRequest = &workbench.PullRequestRef{Number: 10, Title: "New title", HeadBranch: "feature"}
+
+	got := mergeIssueScopedWorkItems([]workbench.WorkItem{previous}, repo, workbench.RuntimeLoadResult{
+		Repo:               repo,
+		Items:              []workbench.WorkItem{refreshed},
+		PullRequestsLoaded: true,
+		ViewerSubjectError: "viewer unavailable",
+	})
+	if len(got) != 1 || got[0].PullRequest == nil {
+		t.Fatalf("expected one refreshed pull request item, got %+v", got)
+	}
+	pr := got[0].PullRequest
+	if pr.Title != "New title" || !pr.ViewerReviewRequested || !pr.ViewerAuthored || !pr.WaitingOnReview {
+		t.Fatalf("expected refreshed PR data with preserved review perspective, got %+v", pr)
+	}
+}
+
+func TestSyncWorkbenchReturnAfterReloadMatchesRepositoryCaseInsensitively(t *testing.T) {
+	start := newModel()
+	start.repos = []workbench.RepoRef{
+		{Owner: "Other", Name: "Repo"},
+		{Owner: "Owner", Name: "Repo"},
+	}
+	start.selectedRepo = 0
+	start.workbenchReturn = workbenchReturnState{
+		valid:           true,
+		selectedRepoRef: workbench.RepoRef{Owner: "owner", Name: "repo"},
+	}
+
+	start.syncWorkbenchReturnAfterReload()
+
+	if start.workbenchReturn.selectedRepo != 1 {
+		t.Fatalf("expected case-insensitive return repo index 1, got %+v", start.workbenchReturn)
 	}
 }
 

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -561,8 +561,11 @@ func TestUpdate_IssueViewReloadRefreshesPreviewOnReturn(t *testing.T) {
 	reloader := &fakeWorkbenchReloader{
 		results: map[string]workbench.RuntimeLoadResult{
 			repo.FullName(): {
-				Repo:  repo,
-				Items: []workbench.WorkItem{reloaded},
+				Repo:               repo,
+				Items:              []workbench.WorkItem{reloaded},
+				PullRequestsLoaded: true,
+				IssuesRepo:         repo,
+				IssuesLoaded:       true,
 			},
 		},
 	}
@@ -676,10 +679,12 @@ func TestUpdate_IssueRefreshAppliesAfterReturningToWorkbench(t *testing.T) {
 			repoB.FullName(): {
 				Repo: repoB,
 				Repositories: []workbench.RepositorySummary{
-					{Repo: repoA, Path: "/repos/gh-zen"},
 					{Repo: repoB, Path: "/repos/dotfiles"},
 				},
-				Items: []workbench.WorkItem{repoAItem, repoBReloaded},
+				Items:              []workbench.WorkItem{repoBReloaded},
+				PullRequestsLoaded: true,
+				IssuesRepo:         repoB,
+				IssuesLoaded:       true,
 			},
 		},
 	}
@@ -898,6 +903,182 @@ func TestUpdate_IssueRefreshFailureKeepsLinkedPullRequests(t *testing.T) {
 	}
 }
 
+func TestUpdate_IssueRefreshPullRequestFailureKeepsWorkbenchEnrichment(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	localItem := workbench.WorkItem{
+		ID:          "branch:issue-browser",
+		Repo:        repo,
+		Branch:      &workbench.BranchRef{Name: "issue-browser"},
+		PullRequest: &workbench.PullRequestRef{Number: 10, Title: "Existing PR", State: "open"},
+		Issue:       &workbench.IssueRef{Number: 75, Title: "Existing issue", State: "open"},
+		Checks:      workbench.CheckSummary{State: workbench.CheckFailing, Failing: 1},
+	}
+	pullRequestOnlyItem := workbench.WorkItem{
+		ID:          "pull-request:0maru/gh-zen:#11",
+		Repo:        repo,
+		PullRequest: &workbench.PullRequestRef{Number: 11, Title: "Remote PR", State: "open"},
+		Checks:      workbench.CheckSummary{State: workbench.CheckPassing},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		RepositorySummaries: []workbench.RepositorySummary{{Repo: repo, Path: "/repos/gh-zen"}},
+		WorkItems:           []workbench.WorkItem{localItem, pullRequestOnlyItem},
+	}, fakeDelayedPreviewLoader(0))
+	request := workbenchReloadRequest{requestID: 1, repo: repo, status: "Loading issues...", issueScoped: true}
+	start.screen = screenIssues
+	start.issueRepo = repo
+	start.workbenchLoading = true
+	start.activeReloadRequest = request
+
+	got, _ := start.Update(workbenchReloadMsg{
+		request: request,
+		result: workbench.RuntimeLoadResult{
+			Repo: repo,
+			Repositories: []workbench.RepositorySummary{{
+				Repo: repo,
+				Path: "/repos/gh-zen",
+			}},
+			Items: []workbench.WorkItem{
+				{ID: localItem.ID, Repo: repo, Branch: localItem.Branch},
+				{
+					ID:    "pull-request-discovery-error:" + repo.FullName(),
+					Repo:  repo,
+					Local: &workbench.LocalStatus{Summary: "pull request discovery failed"},
+				},
+			},
+			IssuesRepo:   repo,
+			IssuesLoaded: true,
+			Issues: []workbench.IssueRef{{
+				Number: 75,
+				Title:  "Refreshed issue",
+				State:  "open",
+			}},
+		},
+	})
+	mm := got.(model)
+
+	var reloadedLocal workbench.WorkItem
+	if !hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool {
+		if item.ID != localItem.ID {
+			return false
+		}
+		reloadedLocal = item
+		return true
+	}) {
+		t.Fatalf("expected local item to remain, got %+v", mm.workItems)
+	}
+	if reloadedLocal.PullRequest == nil || reloadedLocal.PullRequest.Number != 10 {
+		t.Fatalf("expected existing PR enrichment to remain, got %+v", reloadedLocal)
+	}
+	if reloadedLocal.Checks.State != workbench.CheckFailing {
+		t.Fatalf("expected existing check result to remain, got %+v", reloadedLocal.Checks)
+	}
+	if reloadedLocal.Issue == nil || reloadedLocal.Issue.Title != "Refreshed issue" {
+		t.Fatalf("expected retained PR link to use refreshed issue metadata, got %+v", reloadedLocal.Issue)
+	}
+	if !hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool {
+		return item.ID == pullRequestOnlyItem.ID && item.PullRequest != nil && item.PullRequest.Number == 11
+	}) {
+		t.Fatalf("expected PR-only item to remain, got %+v", mm.workItems)
+	}
+	if !hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool {
+		return strings.HasPrefix(item.ID, "pull-request-discovery-error:")
+	}) {
+		t.Fatalf("expected current discovery error item to remain, got %+v", mm.workItems)
+	}
+	summary, ok := mm.repoSummary(repo)
+	if !ok || summary.OpenPullRequestCount != 2 || summary.OpenIssueCount != 1 || summary.FailingCheckCount != 1 {
+		t.Fatalf("expected summary from merged work items, got %+v ok=%v", summary, ok)
+	}
+}
+
+func TestUpdate_IssueRefreshReplacesRepositoryCaseInsensitively(t *testing.T) {
+	canonicalRepo := workbench.RepoRef{Owner: "Owner", Name: "Repo"}
+	requestRepo := workbench.RepoRef{Owner: "owner", Name: "repo"}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), canonicalRepo.FullName(), WorkbenchData{
+		RepositorySummaries: []workbench.RepositorySummary{{Repo: canonicalRepo, Path: "/old"}},
+		WorkItems: []workbench.WorkItem{{
+			ID:     "branch:old",
+			Repo:   canonicalRepo,
+			Branch: &workbench.BranchRef{Name: "old"},
+		}},
+	}, fakeDelayedPreviewLoader(0))
+	request := workbenchReloadRequest{requestID: 1, repo: requestRepo, status: "Loading issues...", issueScoped: true}
+	start.screen = screenIssues
+	start.issueRepo = requestRepo
+	start.workbenchLoading = true
+	start.activeReloadRequest = request
+
+	got, _ := start.Update(workbenchReloadMsg{
+		request: request,
+		result: workbench.RuntimeLoadResult{
+			Repo: requestRepo,
+			Repositories: []workbench.RepositorySummary{{
+				Repo: requestRepo,
+				Path: "/new",
+			}},
+			Items: []workbench.WorkItem{{
+				ID:     "branch:new",
+				Repo:   requestRepo,
+				Branch: &workbench.BranchRef{Name: "new"},
+			}},
+			PullRequestsLoaded: true,
+			IssuesRepo:         requestRepo,
+			IssuesLoaded:       true,
+		},
+	})
+	mm := got.(model)
+
+	if len(mm.workItems) != 1 || mm.workItems[0].ID != "branch:new" || mm.workItems[0].Repo != canonicalRepo {
+		t.Fatalf("expected one canonical-cased replacement item, got %+v", mm.workItems)
+	}
+	if summary, ok := mm.repoSummary(canonicalRepo); !ok || summary.Path != "/new" {
+		t.Fatalf("expected canonical summary to be replaced, got %+v ok=%v", summary, ok)
+	}
+}
+
+func TestUpdate_LeavingIssueViewRestoresFullReloadStaleCheck(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "repo-a"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "repo-b"}
+	repoC := workbench.RepoRef{Owner: "0maru", Name: "repo-c"}
+	original := workbench.WorkItem{ID: "branch:original", Repo: repoC}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB, repoC},
+		WorkItems: []workbench.WorkItem{original},
+	}, fakeDelayedPreviewLoader(0))
+	request := workbenchReloadRequest{requestID: 1, repo: repoA, status: "Reloading workbench data..."}
+	start.screen = screenIssues
+	start.issueRepo = repoB
+	start.issueReloadPending = true
+	start.pendingIssueRepo = repoB
+	start.workbenchLoading = true
+	start.activeReloadRequest = request
+
+	start.backToWorkbench()
+	start.selectedRepo = 2
+	if start.issueReloadPending || hasRepoRef(start.pendingIssueRepo) {
+		t.Fatalf("expected leaving issues to clear pending reload state, got pending=%v repo=%+v", start.issueReloadPending, start.pendingIssueRepo)
+	}
+
+	got, cmd := start.Update(workbenchReloadMsg{
+		request: request,
+		result: workbench.RuntimeLoadResult{
+			Repo:         repoA,
+			Repositories: []workbench.RepositorySummary{{Repo: repoA}},
+			Items:        []workbench.WorkItem{{ID: "branch:stale", Repo: repoA}},
+		},
+	})
+	if cmd != nil {
+		t.Fatalf("expected stale full reload to be discarded without a command, got %T", cmd)
+	}
+	mm := got.(model)
+	if repo, ok := mm.selectedRepoRef(); !ok || repo != repoC {
+		t.Fatalf("expected current repo C selection to remain, got %+v ok=%v", repo, ok)
+	}
+	if len(mm.workItems) != 1 || mm.workItems[0].ID != original.ID {
+		t.Fatalf("expected stale response not to replace work items, got %+v", mm.workItems)
+	}
+}
+
 func TestUpdate_IssueRefreshCheckFailureDoesNotReportIssueFailure(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	start := newModel()
@@ -1003,10 +1184,19 @@ func TestIssuePreviewCanScrollToBodyAndURL(t *testing.T) {
 func TestUpdate_IssueRefreshReplacesOnlyTargetRepositorySummary(t *testing.T) {
 	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	refreshedItems := []workbench.WorkItem{
+		{ID: "issue:1", Repo: repoA, Issue: &workbench.IssueRef{Number: 1, State: "open"}},
+		{ID: "issue:2", Repo: repoA, Issue: &workbench.IssueRef{Number: 2, State: "open"}},
+		{ID: "issue:3", Repo: repoA, Issue: &workbench.IssueRef{Number: 3, State: "open"}},
+	}
 	issueReloader := &fakeIssueReloader{results: map[string]workbench.RuntimeLoadResult{
 		repoA.FullName(): {
-			Repo:         repoA,
-			Repositories: []workbench.RepositorySummary{{Repo: repoA, Path: "/new/a", OpenIssueCount: 3}},
+			Repo:               repoA,
+			Repositories:       []workbench.RepositorySummary{{Repo: repoA, Path: "/new/a"}},
+			Items:              refreshedItems,
+			PullRequestsLoaded: true,
+			IssuesRepo:         repoA,
+			IssuesLoaded:       true,
 		},
 	}}
 	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -1529,6 +1529,29 @@ func TestUpdate_IssueRefreshReplacesRepositoryCaseInsensitively(t *testing.T) {
 	}
 }
 
+func TestUpdateIssueDataKeepsPartialIssueMetadataError(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	m := newModel()
+	m.issueRepo = repo
+
+	m.updateIssueDataFromRuntimeResult(workbench.RuntimeLoadResult{
+		Repo:          repo,
+		IssuesRepo:    repo,
+		Issues:        []workbench.IssueRef{{Number: 75, Repository: repo.FullName(), Title: "Issue browser", Certain: true}},
+		IssuesLoaded:  true,
+		IssuesError:   "load issue comment counts: rate limited",
+		PullRequests:  []workbench.PullRequestRef{},
+		ViewerSubject: workbench.ReviewSubjects{},
+	})
+
+	if len(m.issues) != 1 || m.issues[0].Number != 75 {
+		t.Fatalf("expected partial issue data to remain visible, got %+v", m.issues)
+	}
+	if !strings.Contains(m.issuesError, "comment counts") {
+		t.Fatalf("expected the partial metadata error to remain visible, got %q", m.issuesError)
+	}
+}
+
 func TestUpdate_LeavingIssueViewRestoresFullReloadStaleCheck(t *testing.T) {
 	repoA := workbench.RepoRef{Owner: "0maru", Name: "repo-a"}
 	repoB := workbench.RepoRef{Owner: "0maru", Name: "repo-b"}

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -508,6 +508,7 @@ func TestUpdate_IssueEntryStartsPendingReloadAfterDifferentRepoWorkbenchResponse
 	start.issueRepo = repoB
 	start.issueReloadPending = true
 	start.pendingIssueRepo = repoB
+	start.pendingIssueNumber = 75
 	start.issuesLoading = true
 
 	got, cmd := start.Update(workbenchReloadMsg{
@@ -531,7 +532,18 @@ func TestUpdate_IssueEntryStartsPendingReloadAfterDifferentRepoWorkbenchResponse
 	if !hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool { return item.ID == "repo-a-refreshed-item" }) {
 		t.Fatalf("expected the full workbench response to be applied before the pending reload, got %+v", mm.workItems)
 	}
-	requireWorkbenchReloadMsg(t, cmd)
+	if mm.pendingIssueNumber != 75 {
+		t.Fatalf("expected target issue to remain pending, got %d", mm.pendingIssueNumber)
+	}
+	got, _ = mm.Update(requireWorkbenchReloadMsg(t, cmd))
+	mm = got.(model)
+	issue, ok := mm.selectedIssueRef()
+	if !ok || issue.Number != 75 {
+		t.Fatalf("expected pending target issue #75 to be selected, got %+v ok=%v", issue, ok)
+	}
+	if mm.pendingIssueNumber != 0 {
+		t.Fatalf("expected pending target to clear after selection, got %d", mm.pendingIssueNumber)
+	}
 	if len(issueReloader.calls) != 1 || issueReloader.calls[0] != repoB {
 		t.Fatalf("expected pending reload for %+v, got %+v", repoB, issueReloader.calls)
 	}
@@ -1059,6 +1071,7 @@ func TestUpdate_IssueRefreshPullRequestFailureKeepsWorkbenchEnrichment(t *testin
 		ID:          "pull-request:0maru/gh-zen:#11",
 		Repo:        repo,
 		PullRequest: &workbench.PullRequestRef{Number: 11, Title: "Remote PR", State: "open"},
+		Issue:       &workbench.IssueRef{Number: 76, Title: "Old remote issue", State: "open"},
 		Checks:      workbench.CheckSummary{State: workbench.CheckPassing},
 	}
 	deletedLocalItem := workbench.WorkItem{
@@ -1099,6 +1112,10 @@ func TestUpdate_IssueRefreshPullRequestFailureKeepsWorkbenchEnrichment(t *testin
 				Number: 75,
 				Title:  "Refreshed issue",
 				State:  "open",
+			}, {
+				Number: 76,
+				Title:  "Refreshed remote issue",
+				State:  "closed",
 			}},
 		},
 	})
@@ -1124,7 +1141,10 @@ func TestUpdate_IssueRefreshPullRequestFailureKeepsWorkbenchEnrichment(t *testin
 		t.Fatalf("expected retained PR link to use refreshed issue metadata, got %+v", reloadedLocal.Issue)
 	}
 	if !hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool {
-		return item.ID == pullRequestOnlyItem.ID && item.PullRequest != nil && item.PullRequest.Number == 11
+		return item.ID == pullRequestOnlyItem.ID &&
+			item.PullRequest != nil && item.PullRequest.Number == 11 &&
+			item.Issue != nil && item.Issue.Number == 76 &&
+			item.Issue.Title == "Refreshed remote issue" && item.Issue.State == "closed"
 	}) {
 		t.Fatalf("expected PR-only item to remain, got %+v", mm.workItems)
 	}

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -214,6 +214,50 @@ func TestUpdate_IssueViewRefreshUsesIssueRepo(t *testing.T) {
 	}
 }
 
+func TestUpdate_IssueViewLoadsRawIssuesForSelectedRepo(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repoB.FullName(): {
+				Repo:         repoB,
+				IssuesLoaded: true,
+				Issues: []workbench.IssueRef{{
+					Number:  44,
+					Title:   "Unlinked repo B issue",
+					State:   "open",
+					Certain: true,
+				}},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos: []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{{
+			ID:     "branch:repo-a",
+			Repo:   repoA,
+			Branch: &workbench.BranchRef{Name: "repo-a"},
+		}},
+		Reloader: reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.setRepoPaneIndex(1)
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+	if msg.request.repo != repoB {
+		t.Fatalf("expected issue view reload request for %+v, got %+v", repoB, msg.request.repo)
+	}
+	got, _ = got.(model).Update(msg)
+	mm := got.(model)
+
+	if len(reloader.calls) != 1 || reloader.calls[0] != repoB {
+		t.Fatalf("expected reload call for %+v, got %+v", repoB, reloader.calls)
+	}
+	if issues := mm.visibleIssues(); len(issues) != 1 || issues[0].Number != 44 {
+		t.Fatalf("expected raw repo B issue after issue view reload, got %+v", issues)
+	}
+}
+
 func TestUpdate_IssueViewBackRestoresWorkbenchSelection(t *testing.T) {
 	start := newModel()
 	start.selectedItem = 2

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	cfgpkg "github.com/0maru/gh-zen/internal/config"
 	"github.com/0maru/gh-zen/internal/workbench"
@@ -823,11 +824,78 @@ func TestIssuesFromWorkItemsExcludesUncertainBranchGuess(t *testing.T) {
 	issues := issuesFromWorkItems([]workbench.WorkItem{
 		{Repo: repo, Issue: &workbench.IssueRef{Number: 2026, Certain: false, Source: workbench.IssueLinkSourceBranch}},
 		{Repo: repo, Issue: &workbench.IssueRef{Number: 75, Certain: true, Source: workbench.IssueLinkSourceBranch}},
-		{Repo: repo, Issue: &workbench.IssueRef{Number: 76, Certain: false, Source: workbench.IssueLinkSourcePullRequest}},
+		{
+			Repo:  repo,
+			Issue: &workbench.IssueRef{Number: 76, Certain: false, Source: workbench.IssueLinkSourcePullRequest},
+			PullRequest: &workbench.PullRequestRef{LinkedIssues: []workbench.IssueRef{
+				{Number: 76, Title: "First linked issue"},
+				{Number: 77, Title: "Second linked issue"},
+			}},
+		},
 	}, repo)
 
-	if len(issues) != 2 || issues[0].Number != 75 || issues[1].Number != 76 {
+	if len(issues) != 3 || issues[0].Number != 75 || issues[1].Number != 76 || issues[2].Number != 77 {
 		t.Fatalf("expected only verified or PR-linked issues, got %+v", issues)
+	}
+}
+
+func TestIssueLinesKeepLongAuthorInsideFixedColumn(t *testing.T) {
+	start := newModel()
+	start.issues = []workbench.IssueRef{
+		{Number: 75, Title: "ASCII title", State: "open", AuthorLogin: "author-name-that-is-far-too-long"},
+		{Number: 76, Title: "Unicode title", State: "open", AuthorLogin: "長いユーザー名です"},
+	}
+
+	lines := start.issueLines(61, 0, true)
+	if len(lines) != 3 {
+		t.Fatalf("expected filter plus two issue rows, got %#v", lines)
+	}
+	titleColumns := make([]int, 2)
+	for i, title := range []string{"ASCII title", "Unicode title"} {
+		byteIndex := strings.Index(lines[i+1], title)
+		if byteIndex < 0 {
+			t.Fatalf("expected %q to remain visible, got %q", title, lines[i+1])
+		}
+		titleColumns[i] = lipgloss.Width(lines[i+1][:byteIndex])
+	}
+	if titleColumns[0] != titleColumns[1] {
+		t.Fatalf("expected author columns to keep titles aligned, got columns %v", titleColumns)
+	}
+}
+
+func TestIssuePreviewCanScrollToBodyAndURL(t *testing.T) {
+	start := newModel()
+	start.screen = screenIssues
+	start.focusedPane = panePreview
+	start.width = issueLayoutMinWidth
+	start.height = 10
+	start.issueRepo = workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	start.issues = []workbench.IssueRef{{
+		Number: 75,
+		Title:  "Issue with many linked pull requests",
+		State:  "open",
+		Body:   "The body remains reachable.",
+		URL:    "https://example.test/issues/75",
+	}}
+	prs := make([]workbench.PullRequestRef, 10)
+	for i := range prs {
+		prs[i] = workbench.PullRequestRef{Number: i + 1, Title: "Linked pull request"}
+	}
+	start.prsByIssueNumber = map[int][]workbench.PullRequestRef{75: prs}
+
+	if got := start.renderIssueFull(start.width); strings.Contains(got, "Body:") {
+		t.Fatalf("expected body to begin below the initial preview viewport, got %q", got)
+	}
+	start.moveFocusedSelection(1)
+	if start.issuePreviewOffset != 1 {
+		t.Fatalf("expected preview j/k movement to advance one line, got offset %d", start.issuePreviewOffset)
+	}
+	start.jumpFocusedSelection(true)
+	got := start.renderIssueFull(start.width)
+	for _, want := range []string{"Body:", "URL:"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected scrolled preview to contain %q, got %q", want, got)
+		}
 	}
 }
 

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -1,0 +1,239 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	cfgpkg "github.com/0maru/gh-zen/internal/config"
+	"github.com/0maru/gh-zen/internal/workbench"
+)
+
+func TestIssueFiltering_CoversStateAssigneeLabelMilestoneAndSearch(t *testing.T) {
+	issues := []workbench.IssueRef{
+		{
+			Number:    1,
+			Title:     "Add issue browser",
+			State:     "open",
+			Body:      "Show labels and assignees in the terminal.",
+			Labels:    []string{"enhancement"},
+			Assignees: []string{"0maru"},
+			Milestone: "v1",
+		},
+		{
+			Number: 2,
+			Title:  "設定を検索する",
+			State:  "closed",
+			Body:   "Unicode search should preserve Japanese text.",
+			Labels: []string{"bug"},
+		},
+	}
+
+	assertNumbers := func(name string, filter issueFilterState, want ...int) {
+		t.Helper()
+		got := filterIssues(issues, filter, "0maru")
+		if len(got) != len(want) {
+			t.Fatalf("%s: expected %v, got %+v", name, want, got)
+		}
+		for i, issue := range got {
+			if issue.Number != want[i] {
+				t.Fatalf("%s: expected %v, got %+v", name, want, got)
+			}
+		}
+	}
+
+	assertNumbers("default open", defaultIssueFilterState(), 1)
+	assertNumbers("closed", issueFilterState{State: issueStateClosed}, 2)
+	assertNumbers("all", issueFilterState{State: issueStateAll}, 1, 2)
+	assertNumbers("me", issueFilterState{State: issueStateAll, Assignee: issueAssigneeMe}, 1)
+	assertNumbers("unassigned", issueFilterState{State: issueStateAll, Assignee: issueAssigneeUnassigned}, 2)
+	assertNumbers("label", issueFilterState{State: issueStateAll, Label: "bug"}, 2)
+	assertNumbers("milestone", issueFilterState{State: issueStateAll, Milestone: "v1"}, 1)
+	assertNumbers("unicode search", issueFilterState{State: issueStateAll, Search: "設定"}, 2)
+}
+
+func TestIssuePreviewLines_ShowsLinkedPRsAndComments(t *testing.T) {
+	issue := workbench.IssueRef{
+		Number:        75,
+		Title:         "Add first-class issue browsing",
+		State:         "open",
+		URL:           "https://example.test/issues/75",
+		Body:          "Render issue title, body, labels, linked pull requests, and comments count.",
+		Labels:        []string{"enhancement", "ux"},
+		Assignees:     []string{"0maru"},
+		Milestone:     "v1",
+		AuthorLogin:   "alice",
+		CommentsCount: 2,
+		UpdatedAt:     "2026-06-21T12:00:00Z",
+	}
+	m := newModel()
+	m.screen = screenIssues
+	m.issueRepo = workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	m.issues = []workbench.IssueRef{issue}
+	m.prsByIssueNumber = pullRequestsByIssueNumber([]workbench.PullRequestRef{{
+		Number: 24,
+		Title:  "Add issue view",
+		LinkedIssues: []workbench.IssueRef{
+			{Number: 75},
+		},
+	}})
+
+	got := strings.Join(m.issuePreviewLines(120), "\n")
+	for _, want := range []string{
+		"Issue: #75 Add first-class issue browsing",
+		"State: open",
+		"Author: alice",
+		"Labels: enhancement, ux",
+		"Assignees: 0maru",
+		"Milestone: v1",
+		"Updated: 2026-06-21T12:00:00Z",
+		"Comments: 2 comments",
+		"Linked PRs:",
+		"#24 Add issue view",
+		"Body: Render issue title",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected preview to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestIssuePreviewLines_OmitsUnavailableLinkedPRsAndZeroComments(t *testing.T) {
+	m := newModel()
+	m.screen = screenIssues
+	m.issues = []workbench.IssueRef{{Number: 1, Title: "No comments", State: "open"}}
+	m.prsByIssueNumber = map[int][]workbench.PullRequestRef{}
+
+	got := strings.Join(m.issuePreviewLines(120), "\n")
+	if strings.Contains(got, "Comments:") || strings.Contains(got, "Linked PRs:") {
+		t.Fatalf("expected unavailable summary rows to be omitted, got:\n%s", got)
+	}
+}
+
+func TestUpdate_IssueViewBackRestoresWorkbenchSelection(t *testing.T) {
+	start := newModel()
+	start.selectedItem = 2
+	start.focusedPane = paneWorkItems
+	start.focusedWorkItemID = start.visibleWorkItems()[2].ID
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	mm := got.(model)
+	if mm.screen != screenIssues {
+		t.Fatalf("expected issue screen, got %v", mm.screen)
+	}
+	got, cmd := mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd != nil {
+		t.Fatalf("expected back to workbench without preview reload, got %T", cmd)
+	}
+	mm = got.(model)
+	if mm.screen != screenWorkbench || mm.selectedItem != 2 || mm.focusedPane != paneWorkItems {
+		t.Fatalf("expected workbench selection to be restored, got screen=%v item=%d focus=%v", mm.screen, mm.selectedItem, mm.focusedPane)
+	}
+}
+
+func TestUpdate_IssueSearchPreservesUnicodeInput(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos: []workbench.RepoRef{repo},
+		Issues: []workbench.IssueRef{
+			{Number: 1, Title: "English", State: "open"},
+			{Number: 2, Title: "設定を検索する", State: "open"},
+		},
+	}, fakeDelayedPreviewLoader(0))
+	start.screen = screenIssues
+	start.issueRepo = repo
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	got, _ = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("設定")})
+	got, _ = got.(model).Update(tea.KeyMsg{Type: tea.KeyEnter})
+	mm := got.(model)
+
+	if mm.issueFilter.Search != "設定" {
+		t.Fatalf("expected unicode query to be preserved, got %q", mm.issueFilter.Search)
+	}
+	issues := mm.visibleIssues()
+	if len(issues) != 1 || issues[0].Number != 2 {
+		t.Fatalf("expected search to select issue #2, got %+v", issues)
+	}
+}
+
+func TestUpdate_IssueViewActionsCopyAndOpenSelectedIssue(t *testing.T) {
+	runner := &fakeActionRunner{}
+	start := newModel()
+	start.actionRunner = runner
+	start.selectedItem = 1
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, cmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatalf("expected copy issue URL command")
+	}
+	got, _ = got.(model).Update(cmd())
+	if len(runner.copied) != 1 || runner.copied[0] != "https://github.com/0maru/gh-zen/issues/9" {
+		t.Fatalf("expected issue URL to copy, got %#v", runner.copied)
+	}
+
+	got, cmd = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if cmd == nil {
+		t.Fatalf("expected copy issue number command")
+	}
+	got, _ = got.(model).Update(cmd())
+	if len(runner.copied) != 2 || runner.copied[1] != "#9" {
+		t.Fatalf("expected issue number to copy, got %#v", runner.copied)
+	}
+
+	got, cmd = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	if cmd == nil {
+		t.Fatalf("expected open issue command")
+	}
+	got, _ = got.(model).Update(cmd())
+	if len(runner.opened) != 1 || runner.opened[0] != "https://github.com/0maru/gh-zen/issues/9" {
+		t.Fatalf("expected issue URL to open, got %#v", runner.opened)
+	}
+}
+
+func TestUpdate_IssueRefreshUpdatesIssueData(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:         repo,
+				IssuesLoaded: true,
+				Issues: []workbench.IssueRef{
+					{Number: 2, Title: "Reloaded issue", State: "open"},
+				},
+				PullRequestsLoaded: true,
+				PullRequests: []workbench.PullRequestRef{
+					{Number: 24, Title: "Linked PR", LinkedIssues: []workbench.IssueRef{{Number: 2}}},
+				},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:    []workbench.RepoRef{repo},
+		Reloader: reloader,
+		Issues:   []workbench.IssueRef{{Number: 1, Title: "Old issue", State: "open"}},
+	}, fakeDelayedPreviewLoader(0))
+	start.screen = screenIssues
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatalf("expected issue refresh command")
+	}
+	mm := got.(model)
+	if !mm.issuesLoading {
+		t.Fatalf("expected issue loading state during refresh")
+	}
+	got, cmd = mm.Update(requireWorkbenchReloadMsg(t, cmd))
+	if cmd != nil {
+		t.Fatalf("expected issue reload not to start workbench preview command, got %T", cmd)
+	}
+	mm = got.(model)
+	if len(mm.issues) != 1 || mm.issues[0].Number != 2 {
+		t.Fatalf("expected reloaded issue data, got %+v", mm.issues)
+	}
+	if prs := mm.prsByIssueNumber[2]; len(prs) != 1 || prs[0].Number != 24 {
+		t.Fatalf("expected linked PR index from reload, got %+v", mm.prsByIssueNumber)
+	}
+}

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -10,6 +10,15 @@ import (
 	"github.com/0maru/gh-zen/internal/workbench"
 )
 
+func hasWorkItem(items []workbench.WorkItem, match func(workbench.WorkItem) bool) bool {
+	for _, item := range items {
+		if match(item) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestIssueFiltering_CoversStateAssigneeLabelMilestoneAndSearch(t *testing.T) {
 	issues := []workbench.IssueRef{
 		{
@@ -263,6 +272,113 @@ func TestUpdate_IssueViewRefreshUpdatesReturnSelection(t *testing.T) {
 	}
 }
 
+func TestUpdate_IssueViewRefreshPreservesReturnRepo(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	repoAItem := workbench.WorkItem{
+		ID:       "branch:repo-a",
+		Repo:     repoA,
+		Branch:   &workbench.BranchRef{Name: "repo-a"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/repo-a"},
+	}
+	repoBItem := workbench.WorkItem{
+		ID:       "branch:repo-b",
+		Repo:     repoB,
+		Branch:   &workbench.BranchRef{Name: "repo-b"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/repo-b"},
+		Issue:    &workbench.IssueRef{Number: 22, Title: "Repo B issue", State: "open"},
+	}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repoB.FullName(): {
+				Repo: repoB,
+				Repositories: []workbench.RepositorySummary{
+					{Repo: repoB, Path: "/repos/dotfiles"},
+					{Repo: repoA, Path: "/repos/gh-zen"},
+				},
+				Items: []workbench.WorkItem{repoBItem, repoAItem},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{repoAItem, repoBItem},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.setRepoPaneIndex(len(start.repos))
+	start.selectedItem = 1
+	start.focusedWorkItemID = repoBItem.ID
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, cmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	got, _ = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	mm := got.(model)
+
+	if mm.screen != screenWorkbench {
+		t.Fatalf("expected workbench screen, got %v", mm.screen)
+	}
+	if repo, ok := mm.selectedRepoRef(); !ok || repo != repoA {
+		t.Fatalf("expected return repo %+v, got %+v ok=%v", repoA, repo, ok)
+	}
+}
+
+func TestUpdate_IssueRefreshAppliesAfterReturningToWorkbench(t *testing.T) {
+	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	repoAItem := workbench.WorkItem{
+		ID:       "branch:repo-a",
+		Repo:     repoA,
+		Branch:   &workbench.BranchRef{Name: "repo-a"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/repo-a"},
+	}
+	repoBItem := workbench.WorkItem{
+		ID:       "branch:repo-b",
+		Repo:     repoB,
+		Branch:   &workbench.BranchRef{Name: "repo-b"},
+		Worktree: &workbench.WorktreeRef{Path: "/tmp/repo-b"},
+		Issue:    &workbench.IssueRef{Number: 22, Title: "Repo B issue", State: "open"},
+	}
+	repoBReloaded := repoBItem
+	repoBReloaded.Issue = &workbench.IssueRef{Number: 23, Title: "Reloaded repo B issue", State: "open"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repoB.FullName(): {
+				Repo: repoB,
+				Repositories: []workbench.RepositorySummary{
+					{Repo: repoA, Path: "/repos/gh-zen"},
+					{Repo: repoB, Path: "/repos/dotfiles"},
+				},
+				Items: []workbench.WorkItem{repoAItem, repoBReloaded},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repoA.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repoA, repoB},
+		WorkItems: []workbench.WorkItem{repoAItem, repoBItem},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.setRepoPaneIndex(len(start.repos))
+	start.selectedItem = 1
+	start.focusedWorkItemID = repoBItem.ID
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, cmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	msg := requireWorkbenchReloadMsg(t, cmd)
+	got, _ = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	got, _ = got.(model).Update(msg)
+	mm := got.(model)
+
+	if repo, ok := mm.selectedRepoRef(); !ok || repo != repoA {
+		t.Fatalf("expected current workbench repo %+v to be preserved, got %+v ok=%v", repoA, repo, ok)
+	}
+	if !hasWorkItem(mm.workItems, func(item workbench.WorkItem) bool {
+		return item.Repo == repoB && item.Issue != nil && item.Issue.Number == 23
+	}) {
+		t.Fatalf("expected repo B refresh result to be applied, got %+v", mm.workItems)
+	}
+}
+
 func TestUpdate_IssueSearchPreservesUnicodeInput(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
@@ -341,11 +457,30 @@ func TestUpdate_IssueRefreshUpdatesIssueData(t *testing.T) {
 			},
 		},
 	}
+	linkedItem := workbench.WorkItem{
+		ID:    "pull-request:missing-linked-issue",
+		Repo:  repo,
+		Issue: &workbench.IssueRef{Number: 99, Title: "Linked issue outside list", State: "open"},
+	}
 	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
 		Repos:    []workbench.RepoRef{repo},
 		Reloader: reloader,
 		Issues:   []workbench.IssueRef{{Number: 1, Title: "Old issue", State: "open"}},
 	}, fakeDelayedPreviewLoader(0))
+	reloader.results[repo.FullName()] = workbench.RuntimeLoadResult{
+		Repo: repo,
+		Items: []workbench.WorkItem{
+			linkedItem,
+		},
+		IssuesLoaded: true,
+		Issues: []workbench.IssueRef{
+			{Number: 2, Title: "Reloaded issue", State: "open"},
+		},
+		PullRequestsLoaded: true,
+		PullRequests: []workbench.PullRequestRef{
+			{Number: 24, Title: "Linked PR", LinkedIssues: []workbench.IssueRef{{Number: 2}}},
+		},
+	}
 	start.screen = screenIssues
 
 	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
@@ -361,7 +496,7 @@ func TestUpdate_IssueRefreshUpdatesIssueData(t *testing.T) {
 		t.Fatalf("expected issue reload not to start workbench preview command, got %T", cmd)
 	}
 	mm = got.(model)
-	if len(mm.issues) != 1 || mm.issues[0].Number != 2 {
+	if len(mm.issues) != 2 || mm.issues[0].Number != 2 || mm.issues[1].Number != 99 {
 		t.Fatalf("expected reloaded issue data, got %+v", mm.issues)
 	}
 	if prs := mm.prsByIssueNumber[2]; len(prs) != 1 || prs[0].Number != 24 {

--- a/internal/app/issues_test.go
+++ b/internal/app/issues_test.go
@@ -316,6 +316,60 @@ func TestUpdate_IssueViewRefreshUpdatesReturnSelection(t *testing.T) {
 	}
 }
 
+func TestUpdate_IssueViewReloadRefreshesPreviewOnReturn(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	original := workbench.WorkItem{
+		ID:     "branch:feature",
+		Repo:   repo,
+		Branch: &workbench.BranchRef{Name: "feature"},
+		Issue:  &workbench.IssueRef{Number: 75, Title: "Old issue", State: "open"},
+	}
+	reloaded := original
+	reloaded.Issue = &workbench.IssueRef{Number: 75, Title: "Reloaded issue", State: "open"}
+	reloader := &fakeWorkbenchReloader{
+		results: map[string]workbench.RuntimeLoadResult{
+			repo.FullName(): {
+				Repo:  repo,
+				Items: []workbench.WorkItem{reloaded},
+			},
+		},
+	}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:     []workbench.RepoRef{repo},
+		WorkItems: []workbench.WorkItem{original},
+		Reloader:  reloader,
+	}, fakeDelayedPreviewLoader(0))
+	start.focusedWorkItemRepo = repo
+	start.focusedWorkItemID = original.ID
+	start.preview = previewState{
+		status:              previewLoaded,
+		focusedWorkItemRepo: repo,
+		focusedWorkItemID:   original.ID,
+		loaded: previewData{
+			workItemRepo: repo,
+			workItemID:   original.ID,
+			item:         original,
+		},
+	}
+
+	got, _ := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, cmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	got, _ = got.(model).Update(requireWorkbenchReloadMsg(t, cmd))
+	got, cmd = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd == nil {
+		t.Fatalf("expected preview reload command after issue reload")
+	}
+	previewMsg := requirePreviewResultMsg(t, cmd)
+	if previewMsg.data.item.Issue == nil || previewMsg.data.item.Issue.Title != "Reloaded issue" {
+		t.Fatalf("expected preview reload to use reloaded work item, got %+v", previewMsg.data.item)
+	}
+	got, _ = got.(model).Update(previewMsg)
+	mm := got.(model)
+	if mm.preview.loaded.item.Issue == nil || mm.preview.loaded.item.Issue.Title != "Reloaded issue" {
+		t.Fatalf("expected refreshed preview item, got %+v", mm.preview.loaded.item)
+	}
+}
+
 func TestUpdate_IssueViewRefreshPreservesReturnRepo(t *testing.T) {
 	repoA := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	repoB := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -376,7 +376,7 @@ func (k workbenchKeyMap) issueContextualHelp(focus paneFocus, visiblePanes []pan
 	short := []key.Binding{paneNumbers, paneKeys, k.ToggleHelp, k.BackToWorkbench}
 	full := [][]key.Binding{panes, actions, filters, system}
 
-	if focus == paneWorkItems {
+	if focus == paneWorkItems || focus == panePreview {
 		move := combinedBinding("move", k.MoveDown, k.MoveUp)
 		jump := combinedBinding("jump", k.JumpTop, k.JumpBottom)
 		short = append([]key.Binding{move, jump}, short...)

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -9,22 +9,31 @@ import (
 type actionID string
 
 const (
-	actionMoveDown          actionID = "move_down"
-	actionMoveUp            actionID = "move_up"
-	actionJumpTop           actionID = "jump_top"
-	actionJumpBottom        actionID = "jump_bottom"
-	actionFocusNextPane     actionID = "focus_next_pane"
-	actionFocusPreviousPane actionID = "focus_previous_pane"
-	actionFocusPane1        actionID = "focus_pane_1"
-	actionFocusPane2        actionID = "focus_pane_2"
-	actionFocusPane3        actionID = "focus_pane_3"
-	actionToggleHelp        actionID = "toggle_help"
-	actionRefresh           actionID = "refresh"
-	actionOpenPullRequest   actionID = "open_pr"
-	actionOpenIssue         actionID = "open_issue"
-	actionCopyURL           actionID = "copy_url"
-	actionCopyWorktreePath  actionID = "copy_worktree_path"
-	actionQuit              actionID = "quit"
+	actionMoveDown            actionID = "move_down"
+	actionMoveUp              actionID = "move_up"
+	actionJumpTop             actionID = "jump_top"
+	actionJumpBottom          actionID = "jump_bottom"
+	actionFocusNextPane       actionID = "focus_next_pane"
+	actionFocusPreviousPane   actionID = "focus_previous_pane"
+	actionFocusPane1          actionID = "focus_pane_1"
+	actionFocusPane2          actionID = "focus_pane_2"
+	actionFocusPane3          actionID = "focus_pane_3"
+	actionToggleHelp          actionID = "toggle_help"
+	actionRefresh             actionID = "refresh"
+	actionOpenPullRequest     actionID = "open_pr"
+	actionOpenIssue           actionID = "open_issue"
+	actionOpenInBrowser       actionID = "open_in_browser"
+	actionCopyURL             actionID = "copy_url"
+	actionCopyIssueNumber     actionID = "copy_issue_number"
+	actionCopyWorktreePath    actionID = "copy_worktree_path"
+	actionCycleIssueState     actionID = "cycle_issue_state"
+	actionCycleIssueAssignee  actionID = "cycle_issue_assignee"
+	actionCycleIssueLabel     actionID = "cycle_issue_label"
+	actionCycleIssueMilestone actionID = "cycle_issue_milestone"
+	actionStartIssueSearch    actionID = "start_issue_search"
+	actionClearIssueFilters   actionID = "clear_issue_filters"
+	actionBackToWorkbench     actionID = "back_to_workbench"
+	actionQuit                actionID = "quit"
 )
 
 type actionBinding struct {
@@ -33,22 +42,32 @@ type actionBinding struct {
 }
 
 type workbenchKeyMap struct {
-	MoveDown          key.Binding
-	MoveUp            key.Binding
-	JumpTop           key.Binding
-	JumpBottom        key.Binding
-	FocusNextPane     key.Binding
-	FocusPreviousPane key.Binding
-	FocusPane1        key.Binding
-	FocusPane2        key.Binding
-	FocusPane3        key.Binding
-	ToggleHelp        key.Binding
-	Refresh           key.Binding
-	OpenPullRequest   key.Binding
-	OpenIssue         key.Binding
-	CopyURL           key.Binding
-	CopyWorktreePath  key.Binding
-	Quit              key.Binding
+	MoveDown            key.Binding
+	MoveUp              key.Binding
+	JumpTop             key.Binding
+	JumpBottom          key.Binding
+	FocusNextPane       key.Binding
+	FocusPreviousPane   key.Binding
+	FocusPane1          key.Binding
+	FocusPane2          key.Binding
+	FocusPane3          key.Binding
+	ToggleHelp          key.Binding
+	Refresh             key.Binding
+	OpenPullRequest     key.Binding
+	OpenIssue           key.Binding
+	OpenInBrowser       key.Binding
+	CopyURL             key.Binding
+	CopyIssueNumber     key.Binding
+	CopyWorktreePath    key.Binding
+	CycleIssueState     key.Binding
+	CycleIssueAssignee  key.Binding
+	CycleIssueLabel     key.Binding
+	CycleIssueMilestone key.Binding
+	StartIssueSearch    key.Binding
+	ClearIssueFilters   key.Binding
+	BackToWorkbench     key.Binding
+	ForceQuit           key.Binding
+	Quit                key.Binding
 }
 
 type contextualHelpKeyMap struct {
@@ -116,15 +135,55 @@ func DefaultKeyMap() workbenchKeyMap {
 		),
 		OpenIssue: key.NewBinding(
 			key.WithKeys("i"),
-			key.WithHelp("i", "open issue"),
+			key.WithHelp("i", "issues"),
+		),
+		OpenInBrowser: key.NewBinding(
+			key.WithKeys("o"),
+			key.WithHelp("o", "open"),
 		),
 		CopyURL: key.NewBinding(
 			key.WithKeys("y"),
 			key.WithHelp("y", "copy URL"),
 		),
+		CopyIssueNumber: key.NewBinding(
+			key.WithKeys("n"),
+			key.WithHelp("n", "copy #"),
+		),
 		CopyWorktreePath: key.NewBinding(
 			key.WithKeys("Y"),
 			key.WithHelp("Y", "copy path"),
+		),
+		CycleIssueState: key.NewBinding(
+			key.WithKeys("s"),
+			key.WithHelp("s", "state"),
+		),
+		CycleIssueAssignee: key.NewBinding(
+			key.WithKeys("a"),
+			key.WithHelp("a", "assignee"),
+		),
+		CycleIssueLabel: key.NewBinding(
+			key.WithKeys("b"),
+			key.WithHelp("b", "label"),
+		),
+		CycleIssueMilestone: key.NewBinding(
+			key.WithKeys("m"),
+			key.WithHelp("m", "milestone"),
+		),
+		StartIssueSearch: key.NewBinding(
+			key.WithKeys("/"),
+			key.WithHelp("/", "search"),
+		),
+		ClearIssueFilters: key.NewBinding(
+			key.WithKeys("x"),
+			key.WithHelp("x", "clear filters"),
+		),
+		BackToWorkbench: key.NewBinding(
+			key.WithKeys("q", "esc"),
+			key.WithHelp("q/esc", "back"),
+		),
+		ForceQuit: key.NewBinding(
+			key.WithKeys("ctrl+c"),
+			key.WithHelp("ctrl+c", "quit"),
 		),
 		Quit: key.NewBinding(
 			key.WithKeys("q", "esc", "ctrl+c"),
@@ -133,7 +192,7 @@ func DefaultKeyMap() workbenchKeyMap {
 	}
 }
 
-func (k workbenchKeyMap) actionBindings() []actionBinding {
+func (k workbenchKeyMap) workbenchActionBindings() []actionBinding {
 	return []actionBinding{
 		{id: actionQuit, binding: k.Quit},
 		{id: actionToggleHelp, binding: k.ToggleHelp},
@@ -149,22 +208,76 @@ func (k workbenchKeyMap) actionBindings() []actionBinding {
 		{id: actionRefresh, binding: k.Refresh},
 		{id: actionOpenPullRequest, binding: k.OpenPullRequest},
 		{id: actionOpenIssue, binding: k.OpenIssue},
+		{id: actionOpenInBrowser, binding: k.OpenInBrowser},
 		{id: actionCopyURL, binding: k.CopyURL},
 		{id: actionCopyWorktreePath, binding: k.CopyWorktreePath},
 	}
 }
 
-func (k workbenchKeyMap) contextualHelp(focus paneFocus, visiblePanes []paneFocus) contextualHelpKeyMap {
+func (k workbenchKeyMap) issueActionBindings() []actionBinding {
+	return []actionBinding{
+		{id: actionBackToWorkbench, binding: k.BackToWorkbench},
+		{id: actionQuit, binding: k.ForceQuit},
+		{id: actionToggleHelp, binding: k.ToggleHelp},
+		{id: actionFocusNextPane, binding: k.FocusNextPane},
+		{id: actionFocusPreviousPane, binding: k.FocusPreviousPane},
+		{id: actionFocusPane1, binding: k.FocusPane1},
+		{id: actionFocusPane2, binding: k.FocusPane2},
+		{id: actionMoveDown, binding: k.MoveDown},
+		{id: actionMoveUp, binding: k.MoveUp},
+		{id: actionJumpTop, binding: k.JumpTop},
+		{id: actionJumpBottom, binding: k.JumpBottom},
+		{id: actionRefresh, binding: k.Refresh},
+		{id: actionOpenInBrowser, binding: k.OpenInBrowser},
+		{id: actionCopyURL, binding: k.CopyURL},
+		{id: actionCopyIssueNumber, binding: k.CopyIssueNumber},
+		{id: actionCycleIssueState, binding: k.CycleIssueState},
+		{id: actionCycleIssueAssignee, binding: k.CycleIssueAssignee},
+		{id: actionCycleIssueLabel, binding: k.CycleIssueLabel},
+		{id: actionCycleIssueMilestone, binding: k.CycleIssueMilestone},
+		{id: actionStartIssueSearch, binding: k.StartIssueSearch},
+		{id: actionClearIssueFilters, binding: k.ClearIssueFilters},
+	}
+}
+
+func (k workbenchKeyMap) contextualHelp(screen appScreen, focus paneFocus, visiblePanes []paneFocus) contextualHelpKeyMap {
+	if screen == screenIssues {
+		return k.issueContextualHelp(focus, visiblePanes)
+	}
+
 	paneNumbers := k.visiblePaneBinding(visiblePanes)
 	paneKeys := combinedBinding("pane", k.FocusPreviousPane, k.FocusNextPane)
 	system := []key.Binding{k.ToggleHelp, k.Quit}
-	actions := []key.Binding{k.OpenPullRequest, k.OpenIssue, k.CopyURL, k.CopyWorktreePath, k.Refresh}
+	actions := []key.Binding{k.OpenPullRequest, k.OpenIssue, k.OpenInBrowser, k.CopyURL, k.CopyWorktreePath, k.Refresh}
 	panes := []key.Binding{k.FocusPreviousPane, k.FocusNextPane, paneNumbers}
 
 	short := []key.Binding{paneNumbers, paneKeys, k.ToggleHelp, k.Quit}
 	full := [][]key.Binding{panes, actions, system}
 
 	if focus == paneRepositories || focus == paneWorkItems {
+		move := combinedBinding("move", k.MoveDown, k.MoveUp)
+		jump := combinedBinding("jump", k.JumpTop, k.JumpBottom)
+		short = append([]key.Binding{move, jump}, short...)
+		full = append([][]key.Binding{
+			{k.MoveUp, k.MoveDown, k.JumpTop, k.JumpBottom},
+		}, full...)
+	}
+
+	return contextualHelpKeyMap{short: short, full: full}
+}
+
+func (k workbenchKeyMap) issueContextualHelp(focus paneFocus, visiblePanes []paneFocus) contextualHelpKeyMap {
+	paneNumbers := k.visiblePaneBinding(visiblePanes)
+	paneKeys := combinedBinding("pane", k.FocusPreviousPane, k.FocusNextPane)
+	system := []key.Binding{k.BackToWorkbench, k.ForceQuit, k.ToggleHelp}
+	actions := []key.Binding{k.OpenInBrowser, k.CopyURL, k.CopyIssueNumber, k.Refresh}
+	filters := []key.Binding{k.CycleIssueState, k.CycleIssueAssignee, k.CycleIssueLabel, k.CycleIssueMilestone, k.StartIssueSearch, k.ClearIssueFilters}
+	panes := []key.Binding{k.FocusPreviousPane, k.FocusNextPane, paneNumbers}
+
+	short := []key.Binding{paneNumbers, paneKeys, k.ToggleHelp, k.BackToWorkbench}
+	full := [][]key.Binding{panes, actions, filters, system}
+
+	if focus == paneWorkItems {
 		move := combinedBinding("move", k.MoveDown, k.MoveUp)
 		jump := combinedBinding("jump", k.JumpTop, k.JumpBottom)
 		short = append([]key.Binding{move, jump}, short...)

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -320,6 +320,7 @@ type workbenchReloadRequest struct {
 	repo        workbench.RepoRef
 	status      string
 	issueScoped bool
+	fullResult  bool
 }
 
 type workbenchReloadMsg struct {
@@ -845,6 +846,9 @@ func bestWorkItemURL(item workbench.WorkItem) (string, string, bool) {
 }
 
 func (m *model) refreshWorkbenchData() tea.Cmd {
+	if m.screen == screenIssues {
+		return m.startIssueViewReload()
+	}
 	return m.startWorkbenchReload("Reloading workbench data...")
 }
 
@@ -873,6 +877,7 @@ func (m *model) beginWorkbenchReload(status string) bool {
 		repo:        repo,
 		status:      status,
 		issueScoped: issueScoped,
+		fullResult:  issueScoped && m.issueReloader == nil,
 	}
 	m.activeReloadRequest = request
 	m.workbenchLoading = true
@@ -932,7 +937,7 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 			selectedRepo = repo
 		}
 	}
-	if msg.request.issueScoped {
+	if msg.request.issueScoped && !msg.request.fullResult {
 		m.workItems = mergeIssueScopedWorkItems(m.workItems, msg.request.repo, msg.result)
 		for _, summary := range msg.result.Repositories {
 			m.replaceIssueScopedRepositorySummary(summary)
@@ -940,7 +945,10 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	} else if len(msg.result.Repositories) > 0 {
 		m.replaceWorkbenchData(msg.result, selectedRepo)
 	} else {
-		m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
+		replacement := filterWorkItems(msg.result.Items, func(item workbench.WorkItem) bool {
+			return sameRepoRef(item.Repo, msg.request.repo)
+		})
+		m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, replacement)
 	}
 	m.restoreSelectedWorkItem(selectedWorkItemRepo, selectedWorkItemID)
 	if m.screen == screenIssues && m.workbenchReturn.valid {
@@ -966,9 +974,7 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		if pendingIssueReload {
 			return m.startPendingIssueReload()
 		}
-		if msg.request.issueScoped {
-			m.clearFocusedWorkItem()
-		}
+		m.clearFocusedWorkItem()
 		return nil
 	}
 	return m.startPreviewLoadForCurrentItem()
@@ -1306,8 +1312,13 @@ func mergeIssueScopedWorkItems(items []workbench.WorkItem, repo workbench.RepoRe
 				replacement[index].PullRequest = previous.PullRequest
 				replacement[index].Checks = previous.Checks
 				replacement[index].Issue = refreshedIssueRef(previous.Issue, result)
-			} else if checkRefFailed(replacement[index], result.FailedCheckRefs) {
-				replacement[index].Checks = previous.Checks
+			} else {
+				if result.ViewerSubjectError != "" && previous.PullRequest != nil && replacement[index].PullRequest != nil {
+					preserveViewerReviewPerspective(replacement[index].PullRequest, previous.PullRequest)
+				}
+				if checkRefFailed(replacement[index], result.FailedCheckRefs) {
+					replacement[index].Checks = previous.Checks
+				}
 			}
 			if !result.IssuesLoaded && previous.Issue != nil {
 				replacement[index].Issue = previous.Issue
@@ -1321,6 +1332,12 @@ func mergeIssueScopedWorkItems(items []workbench.WorkItem, repo workbench.RepoRe
 	}
 
 	return replaceRepoWorkItems(items, repo, replacement)
+}
+
+func preserveViewerReviewPerspective(current *workbench.PullRequestRef, previous *workbench.PullRequestRef) {
+	current.ViewerReviewRequested = previous.ViewerReviewRequested
+	current.ViewerAuthored = previous.ViewerAuthored
+	current.WaitingOnReview = previous.WaitingOnReview
 }
 
 func checkRefFailed(item workbench.WorkItem, failedRefs []string) bool {
@@ -1423,11 +1440,11 @@ func (m *model) restoreSelectedRepo(repo workbench.RepoRef) {
 }
 
 func (m model) repoIndex(repo workbench.RepoRef) (int, bool) {
-	if repo == (workbench.RepoRef{}) {
+	if !hasRepoRef(repo) {
 		return 0, false
 	}
 	for i, candidate := range m.repos {
-		if candidate == repo {
+		if sameRepoRef(candidate, repo) {
 			return i, true
 		}
 	}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -907,7 +907,9 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	if msg.request != m.activeReloadRequest {
 		return nil
 	}
-	if !msg.request.issueScoped && !m.issueReloadPending && m.reloadRequestIsStale(msg.request) {
+	if !msg.request.issueScoped &&
+		!(m.screen == screenIssues && m.issueReloadPending) &&
+		m.reloadRequestIsStale(msg.request) {
 		m.workbenchLoading = false
 		if m.screen == screenIssues {
 			m.issuesLoading = false
@@ -931,9 +933,9 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		}
 	}
 	if msg.request.issueScoped {
-		m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
+		m.workItems = mergeIssueScopedWorkItems(m.workItems, msg.request.repo, msg.result)
 		for _, summary := range msg.result.Repositories {
-			m.replaceRepositorySummary(summary)
+			m.replaceIssueScopedRepositorySummary(summary)
 		}
 	} else if len(msg.result.Repositories) > 0 {
 		m.replaceWorkbenchData(msg.result, selectedRepo)
@@ -1255,10 +1257,24 @@ func filterWorkItems(items []workbench.WorkItem, keep func(workbench.WorkItem) b
 }
 
 func replaceRepoWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, replacement []workbench.WorkItem) []workbench.WorkItem {
+	canonicalRepo := repo
+	for _, item := range items {
+		if sameRepoRef(item.Repo, repo) {
+			canonicalRepo = item.Repo
+			break
+		}
+	}
+	replacement = cloneWorkItems(replacement)
+	for i := range replacement {
+		if sameRepoRef(replacement[i].Repo, repo) {
+			replacement[i].Repo = canonicalRepo
+		}
+	}
+
 	out := make([]workbench.WorkItem, 0, len(items)+len(replacement))
 	replaced := false
 	for _, item := range items {
-		if item.Repo == repo {
+		if sameRepoRef(item.Repo, repo) {
 			if !replaced {
 				out = append(out, replacement...)
 				replaced = true
@@ -1271,6 +1287,57 @@ func replaceRepoWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, re
 		out = append(out, replacement...)
 	}
 	return out
+}
+
+func mergeIssueScopedWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, result workbench.RuntimeLoadResult) []workbench.WorkItem {
+	replacement := cloneWorkItems(result.Items)
+	byID := make(map[string]int, len(replacement))
+	for i, item := range replacement {
+		byID[item.ID] = i
+	}
+
+	for _, previous := range items {
+		if !sameRepoRef(previous.Repo, repo) {
+			continue
+		}
+		index, found := byID[previous.ID]
+		if found {
+			if !result.PullRequestsLoaded && previous.PullRequest != nil {
+				replacement[index].PullRequest = previous.PullRequest
+				replacement[index].Checks = previous.Checks
+				replacement[index].Issue = refreshedIssueRef(previous.Issue, result)
+			}
+			if !result.IssuesLoaded && previous.Issue != nil {
+				replacement[index].Issue = previous.Issue
+			}
+			continue
+		}
+		if !result.PullRequestsLoaded && previous.PullRequest != nil {
+			byID[previous.ID] = len(replacement)
+			replacement = append(replacement, previous)
+		}
+	}
+
+	return replaceRepoWorkItems(items, repo, replacement)
+}
+
+func refreshedIssueRef(previous *workbench.IssueRef, result workbench.RuntimeLoadResult) *workbench.IssueRef {
+	if previous == nil || !result.IssuesLoaded {
+		return previous
+	}
+	for _, issue := range result.Issues {
+		if issue.Number != previous.Number {
+			continue
+		}
+		issue.Certain = previous.Certain
+		issue.Source = previous.Source
+		return &issue
+	}
+	return previous
+}
+
+func sameRepoRef(left workbench.RepoRef, right workbench.RepoRef) bool {
+	return hasRepoRef(left) && hasRepoRef(right) && strings.EqualFold(left.FullName(), right.FullName())
 }
 
 func (m *model) replaceWorkbenchData(result workbench.RuntimeLoadResult, selectedRepo workbench.RepoRef) {
@@ -1293,6 +1360,32 @@ func (m *model) replaceRepositorySummary(summary workbench.RepositorySummary) {
 	summary.Remotes = append([]string(nil), summary.Remotes...)
 	m.repoSummaries = append(m.repoSummaries, summary)
 	m.repos = append(m.repos, summary.Repo)
+}
+
+func (m *model) replaceIssueScopedRepositorySummary(summary workbench.RepositorySummary) {
+	repo := m.canonicalRepoRef(summary.Repo)
+	summary = workbench.SummarizeRepository(
+		repo,
+		summary.Path,
+		summary.DefaultBranch,
+		summary.Remotes,
+		m.workItems,
+	)
+	m.replaceRepositorySummary(summary)
+}
+
+func (m model) canonicalRepoRef(repo workbench.RepoRef) workbench.RepoRef {
+	for _, candidate := range m.repos {
+		if sameRepoRef(candidate, repo) {
+			return candidate
+		}
+	}
+	for _, item := range m.workItems {
+		if sameRepoRef(item.Repo, repo) {
+			return item.Repo
+		}
+	}
+	return repo
 }
 
 func (m *model) restoreSelectedRepo(repo workbench.RepoRef) {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -140,6 +140,7 @@ type model struct {
 	issuesLoading        bool
 	issueReloadPending   bool
 	pendingIssueRepo     workbench.RepoRef
+	pendingIssueNumber   int
 	issuesError          string
 	prsByIssueNumber     map[int][]workbench.PullRequestRef
 	viewerLogin          string
@@ -283,7 +284,7 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 		issues:            cloneIssueRefs(data.Issues),
 		issueFilter:       defaultIssueFilterState(),
 		issuesLoading:     data.InitialLoading,
-		prsByIssueNumber:  pullRequestsByIssueNumber(data.PullRequests),
+		prsByIssueNumber:  map[int][]workbench.PullRequestRef{},
 		viewerLogin:       data.ViewerSubject.Login,
 		workbenchSource:   source,
 		previewLoader:     loader,
@@ -304,8 +305,9 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 	if repo, ok := m.selectedRepoRef(); ok {
 		m.issueRepo = repo
 		m.issues = mergeIssueRefs(m.issues, issuesFromWorkItems(m.workItems, repo))
+		m.prsByIssueNumber = pullRequestsByIssueNumber(data.PullRequests, repo)
 		if len(m.prsByIssueNumber) == 0 {
-			m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(m.workItems, repo))
+			m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(m.workItems, repo), repo)
 		}
 	}
 	if data.InitialLoading {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -959,9 +959,11 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	}
 	pendingIssueReload := m.issueReloadPending
 	pendingIssueRepo := m.pendingIssueRepo
-	updateVisibleIssues := !pendingIssueReload ||
-		!msg.request.issueScoped ||
-		strings.EqualFold(msg.request.repo.FullName(), pendingIssueRepo.FullName())
+	resultIssueRepo := msg.result.IssuesRepo
+	if !hasRepoRef(resultIssueRepo) {
+		resultIssueRepo = msg.result.Repo
+	}
+	updateVisibleIssues := !pendingIssueReload || sameRepoRef(resultIssueRepo, pendingIssueRepo)
 	if updateVisibleIssues {
 		m.updateIssueDataFromRuntimeResult(msg.result)
 	}
@@ -1333,6 +1335,7 @@ func mergeIssueScopedWorkItems(items []workbench.WorkItem, repo workbench.RepoRe
 			continue
 		}
 		if !result.PullRequestsLoaded && previous.PullRequest != nil && !isLocalDiscoveryWorkItem(previous) {
+			previous.Issue = refreshedIssueRef(previous.Issue, result)
 			byID[previous.ID] = len(replacement)
 			replacement = append(replacement, previous)
 		}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -150,6 +150,7 @@ type model struct {
 	nextPreviewRequestID int
 	previewLoader        previewLoader
 	workbenchReloader    WorkbenchReloader
+	issueReloader        IssueReloader
 	nextReloadRequestID  int
 	activeReloadRequest  workbenchReloadRequest
 	workbenchFilter      cfgpkg.WorkbenchFilter
@@ -171,6 +172,7 @@ type WorkbenchData struct {
 	Issues              []workbench.IssueRef
 	ViewerSubject       workbench.ReviewSubjects
 	Reloader            WorkbenchReloader
+	IssueReloader       IssueReloader
 	ActionsLoader       ActionsLoader
 	InitialLoading      bool
 	Demo                bool
@@ -190,6 +192,11 @@ type workbenchReturnState struct {
 // as the selection anchor.
 type WorkbenchReloader interface {
 	Load(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult
+}
+
+// IssueReloader refreshes runtime data for one repository without scanning all configured repositories.
+type IssueReloader interface {
+	LoadIssues(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult
 }
 
 type repoViewFilter int
@@ -278,6 +285,7 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 		workbenchSource:   source,
 		previewLoader:     loader,
 		workbenchReloader: data.Reloader,
+		issueReloader:     data.IssueReloader,
 		workbenchFilter:   cfg.Workbench.Filter,
 		actionsLoader:     actionsLoader,
 		actionRunner:      systemActionRunner{},
@@ -845,7 +853,8 @@ func (m *model) startWorkbenchReload(status string) tea.Cmd {
 }
 
 func (m *model) beginWorkbenchReload(status string) bool {
-	if m.workbenchReloader == nil {
+	issueScoped := m.screen == screenIssues && hasRepoRef(m.issueRepo)
+	if m.workbenchReloader == nil && (!issueScoped || m.issueReloader == nil) {
 		return false
 	}
 	repo, ok := m.reloadRepoRef()
@@ -860,7 +869,7 @@ func (m *model) beginWorkbenchReload(status string) bool {
 		requestID:   m.nextReloadRequestID,
 		repo:        repo,
 		status:      status,
-		issueScoped: m.screen == screenIssues && hasRepoRef(m.issueRepo),
+		issueScoped: issueScoped,
 	}
 	m.activeReloadRequest = request
 	m.workbenchLoading = true
@@ -878,6 +887,12 @@ func (m model) canReloadWithoutSelectedRepo() bool {
 
 func (m model) workbenchReloadCommand(request workbenchReloadRequest) tea.Cmd {
 	return func() tea.Msg {
+		if request.issueScoped && m.issueReloader != nil {
+			return workbenchReloadMsg{
+				request: request,
+				result:  m.issueReloader.LoadIssues(context.Background(), request.repo),
+			}
+		}
 		return workbenchReloadMsg{
 			request: request,
 			result:  m.workbenchReloader.Load(context.Background(), request.repo),

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1328,7 +1328,7 @@ func mergeIssueScopedWorkItems(items []workbench.WorkItem, repo workbench.RepoRe
 			}
 			continue
 		}
-		if !result.PullRequestsLoaded && previous.PullRequest != nil {
+		if !result.PullRequestsLoaded && previous.PullRequest != nil && !isLocalDiscoveryWorkItem(previous) {
 			byID[previous.ID] = len(replacement)
 			replacement = append(replacement, previous)
 		}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1297,6 +1297,9 @@ func replaceRepoWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, re
 
 func mergeIssueScopedWorkItems(items []workbench.WorkItem, repo workbench.RepoRef, result workbench.RuntimeLoadResult) []workbench.WorkItem {
 	replacement := cloneWorkItems(result.Items)
+	if result.LocalDiscoveryError != "" {
+		replacement = rebuildAfterLocalDiscoveryFailure(items, repo, result)
+	}
 	byID := make(map[string]int, len(replacement))
 	for i, item := range replacement {
 		byID[item.ID] = i
@@ -1332,6 +1335,61 @@ func mergeIssueScopedWorkItems(items []workbench.WorkItem, repo workbench.RepoRe
 	}
 
 	return replaceRepoWorkItems(items, repo, replacement)
+}
+
+func rebuildAfterLocalDiscoveryFailure(items []workbench.WorkItem, repo workbench.RepoRef, result workbench.RuntimeLoadResult) []workbench.WorkItem {
+	localItems := filterWorkItems(items, func(item workbench.WorkItem) bool {
+		return sameRepoRef(item.Repo, repo) && isLocalDiscoveryWorkItem(item)
+	})
+	if !result.PullRequestsLoaded {
+		return append(cloneWorkItems(result.Items), localItems...)
+	}
+
+	for i := range localItems {
+		localItems[i].PullRequest = nil
+		localItems[i].Issue = nil
+		localItems[i].Checks = workbench.CheckSummary{}
+	}
+	rebuilt := workbench.LinkPullRequestsForRepo(repo, localItems, result.PullRequests)
+	rebuilt = workbench.LinkIssues(rebuilt, result.Issues)
+	for i := range rebuilt {
+		if rebuilt[i].PullRequest == nil {
+			continue
+		}
+		if checks, ok := checkSummaryForPullRequest(*rebuilt[i].PullRequest, result.Items); ok {
+			rebuilt[i].Checks = checks
+		}
+	}
+	for _, item := range result.Items {
+		if hasWorkbenchErrorItems([]workbench.WorkItem{item}) {
+			rebuilt = append(rebuilt, item)
+		}
+	}
+	return rebuilt
+}
+
+func isLocalDiscoveryWorkItem(item workbench.WorkItem) bool {
+	return item.Worktree != nil ||
+		strings.HasPrefix(item.ID, "worktree:") ||
+		strings.HasPrefix(item.ID, "branch:") ||
+		strings.HasPrefix(item.ID, "remote:")
+}
+
+func checkSummaryForPullRequest(pr workbench.PullRequestRef, items []workbench.WorkItem) (workbench.CheckSummary, bool) {
+	for _, item := range items {
+		if item.PullRequest == nil || !samePullRequest(pr, *item.PullRequest) {
+			continue
+		}
+		return item.Checks, true
+	}
+	return workbench.CheckSummary{}, false
+}
+
+func samePullRequest(left workbench.PullRequestRef, right workbench.PullRequestRef) bool {
+	if left.Number > 0 || right.Number > 0 {
+		return left.Number > 0 && left.Number == right.Number
+	}
+	return left.HeadBranch != "" && left.HeadBranch == right.HeadBranch && strings.EqualFold(left.HeadOwner, right.HeadOwner)
 }
 
 func preserveViewerReviewPerspective(current *workbench.PullRequestRef, previous *workbench.PullRequestRef) {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -134,6 +134,7 @@ type model struct {
 	issueRepo            workbench.RepoRef
 	issues               []workbench.IssueRef
 	selectedIssue        int
+	issuePreviewOffset   int
 	issueFilter          issueFilterState
 	issueSearchEditing   bool
 	issuesLoading        bool
@@ -1061,8 +1062,11 @@ func previousPane(current paneFocus, order []paneFocus) paneFocus {
 // moveFocusedSelection keeps j/k scoped to the active pane.
 func (m *model) moveFocusedSelection(delta int) {
 	if m.screen == screenIssues {
-		if m.activePane() == paneWorkItems {
+		switch m.activePane() {
+		case paneWorkItems:
 			m.moveIssueSelection(delta)
+		case panePreview:
+			m.moveIssuePreview(delta)
 		}
 		return
 	}
@@ -1081,8 +1085,11 @@ func (m *model) moveFocusedSelection(delta int) {
 // jumpFocusedSelection keeps g/G behavior aligned with the active pane.
 func (m *model) jumpFocusedSelection(toEnd bool) {
 	if m.screen == screenIssues {
-		if m.activePane() == paneWorkItems {
+		switch m.activePane() {
+		case paneWorkItems:
 			m.jumpIssueSelection(toEnd)
+		case panePreview:
+			m.jumpIssuePreview(toEnd)
 		}
 		return
 	}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -153,12 +153,13 @@ type WorkbenchData struct {
 }
 
 type workbenchReturnState struct {
-	valid        bool
-	selectedRepo int
-	selectedView int
-	viewSelected bool
-	selectedItem int
-	focusedPane  paneFocus
+	valid           bool
+	selectedRepo    int
+	selectedRepoRef workbench.RepoRef
+	selectedView    int
+	viewSelected    bool
+	selectedItem    int
+	focusedPane     paneFocus
 }
 
 // WorkbenchReloader reloads runtime workbench data using the selected repository
@@ -262,9 +263,7 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 	m.applyStartupRepo(startupRepo)
 	if repo, ok := m.selectedRepoRef(); ok {
 		m.issueRepo = repo
-		if len(m.issues) == 0 {
-			m.issues = issuesFromWorkItems(m.workItems, repo)
-		}
+		m.issues = mergeIssueRefs(m.issues, issuesFromWorkItems(m.workItems, repo))
 		if len(m.prsByIssueNumber) == 0 {
 			m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(m.workItems, repo))
 		}
@@ -277,9 +276,10 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 }
 
 type workbenchReloadRequest struct {
-	requestID int
-	repo      workbench.RepoRef
-	status    string
+	requestID   int
+	repo        workbench.RepoRef
+	status      string
+	issueScoped bool
 }
 
 type workbenchReloadMsg struct {
@@ -683,13 +683,17 @@ func (m *model) beginWorkbenchReload(status string) bool {
 	}
 	repo, ok := m.reloadRepoRef()
 	if !ok {
-		return false
+		if !m.canReloadWithoutSelectedRepo() {
+			return false
+		}
+		repo = workbench.RepoRef{}
 	}
 	m.nextReloadRequestID++
 	request := workbenchReloadRequest{
-		requestID: m.nextReloadRequestID,
-		repo:      repo,
-		status:    status,
+		requestID:   m.nextReloadRequestID,
+		repo:        repo,
+		status:      status,
+		issueScoped: m.screen == screenIssues && hasRepoRef(m.issueRepo),
 	}
 	m.activeReloadRequest = request
 	m.workbenchLoading = true
@@ -699,6 +703,10 @@ func (m *model) beginWorkbenchReload(status string) bool {
 	}
 	m.statusMessage = status
 	return true
+}
+
+func (m model) canReloadWithoutSelectedRepo() bool {
+	return m.screen == screenWorkbench && len(m.repos) == 0
 }
 
 func (m model) workbenchReloadCommand(request workbenchReloadRequest) tea.Cmd {
@@ -714,8 +722,7 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	if msg.request != m.activeReloadRequest {
 		return nil
 	}
-	repo, ok := m.reloadRepoRef()
-	if msg.request.repo != (workbench.RepoRef{}) && (!ok || repo != msg.request.repo) {
+	if !msg.request.issueScoped && m.reloadRequestIsStale(msg.request) {
 		m.workbenchLoading = false
 		if m.screen == screenIssues {
 			m.issuesLoading = false
@@ -732,16 +739,20 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		selectedWorkItemRepo = item.Repo
 		selectedWorkItemID = item.ID
 	}
+	selectedRepo := msg.request.repo
+	if msg.request.issueScoped && m.screen != screenIssues {
+		if repo, ok := m.selectedRepoRef(); ok {
+			selectedRepo = repo
+		}
+	}
 	if len(msg.result.Repositories) > 0 {
-		m.replaceWorkbenchData(msg.result, msg.request.repo)
+		m.replaceWorkbenchData(msg.result, selectedRepo)
 	} else {
 		m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
 	}
 	m.restoreSelectedWorkItem(selectedWorkItemRepo, selectedWorkItemID)
 	if m.screen == screenIssues && m.workbenchReturn.valid {
-		m.workbenchReturn.selectedRepo = m.selectedRepo
-		m.workbenchReturn.selectedView = m.selectedView
-		m.workbenchReturn.viewSelected = m.viewSelected
+		m.syncWorkbenchReturnAfterReload()
 		m.workbenchReturn.selectedItem = m.selectedItem
 	}
 	m.updateIssueDataFromRuntimeResult(msg.result)
@@ -756,6 +767,22 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		return nil
 	}
 	return m.startPreviewLoadForCurrentItem()
+}
+
+func (m model) reloadRequestIsStale(request workbenchReloadRequest) bool {
+	repo, ok := m.reloadRepoRef()
+	return request.repo != (workbench.RepoRef{}) && (!ok || repo != request.repo)
+}
+
+func (m *model) syncWorkbenchReturnAfterReload() {
+	if m.workbenchReturn.selectedRepoRef == (workbench.RepoRef{}) {
+		return
+	}
+	if index, ok := m.repoIndex(m.workbenchReturn.selectedRepoRef); ok {
+		m.workbenchReturn.selectedRepo = index
+		return
+	}
+	m.workbenchReturn.selectedRepo = m.selectedRepo
 }
 
 func (m model) reloadRepoRef() (workbench.RepoRef, bool) {
@@ -1028,13 +1055,9 @@ func (m *model) replaceWorkbenchData(result workbench.RuntimeLoadResult, selecte
 }
 
 func (m *model) restoreSelectedRepo(repo workbench.RepoRef) {
-	if repo != (workbench.RepoRef{}) {
-		for i, candidate := range m.repos {
-			if candidate == repo {
-				m.selectedRepo = i
-				return
-			}
-		}
+	if index, ok := m.repoIndex(repo); ok {
+		m.selectedRepo = index
+		return
 	}
 	if len(m.repos) == 0 {
 		m.selectedRepo = 0
@@ -1045,6 +1068,18 @@ func (m *model) restoreSelectedRepo(repo workbench.RepoRef) {
 	if m.viewSelected {
 		m.selectedView = clamp(m.selectedView, 0, max(len(repoViews)-1, 0))
 	}
+}
+
+func (m model) repoIndex(repo workbench.RepoRef) (int, bool) {
+	if repo == (workbench.RepoRef{}) {
+		return 0, false
+	}
+	for i, candidate := range m.repos {
+		if candidate == repo {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 func hasWorkbenchErrorItems(items []workbench.WorkItem) bool {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1313,7 +1313,7 @@ func mergeIssueScopedWorkItems(items []workbench.WorkItem, repo workbench.RepoRe
 		if found {
 			samePR := previous.PullRequest != nil && replacement[index].PullRequest != nil &&
 				samePullRequest(*previous.PullRequest, *replacement[index].PullRequest)
-			if !result.PullRequestsLoaded && previous.PullRequest != nil {
+			if !result.PullRequestsLoaded && previous.PullRequest != nil && sameWorkItemBranch(previous, replacement[index]) {
 				replacement[index].PullRequest = previous.PullRequest
 				replacement[index].Checks = previous.Checks
 				replacement[index].Issue = refreshedIssueRef(previous.Issue, result)
@@ -1396,6 +1396,10 @@ func samePullRequest(left workbench.PullRequestRef, right workbench.PullRequestR
 
 func sameIssueRef(left *workbench.IssueRef, right *workbench.IssueRef) bool {
 	return left != nil && right != nil && left.Number > 0 && left.Number == right.Number
+}
+
+func sameWorkItemBranch(left workbench.WorkItem, right workbench.WorkItem) bool {
+	return left.Branch != nil && right.Branch != nil && left.Branch.Name != "" && left.Branch.Name == right.Branch.Name
 }
 
 func preserveViewerReviewPerspective(current *workbench.PullRequestRef, previous *workbench.PullRequestRef) {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -137,6 +137,7 @@ type model struct {
 	issueFilter          issueFilterState
 	issueSearchEditing   bool
 	issuesLoading        bool
+	issueReloadPending   bool
 	issuesError          string
 	prsByIssueNumber     map[int][]workbench.PullRequestRef
 	viewerLogin          string
@@ -927,7 +928,12 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 			selectedRepo = repo
 		}
 	}
-	if len(msg.result.Repositories) > 0 {
+	if msg.request.issueScoped {
+		m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
+		for _, summary := range msg.result.Repositories {
+			m.replaceRepositorySummary(summary)
+		}
+	} else if len(msg.result.Repositories) > 0 {
 		m.replaceWorkbenchData(msg.result, selectedRepo)
 	} else {
 		m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
@@ -937,6 +943,8 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		m.syncWorkbenchReturnAfterReload()
 		m.workbenchReturn.selectedItem = m.selectedItem
 	}
+	pendingIssueReload := m.issueReloadPending && !msg.request.issueScoped
+	pendingIssueRepo := m.issueRepo
 	m.updateIssueDataFromRuntimeResult(msg.result)
 	m.workbenchLoading = false
 	m.issuesLoading = false
@@ -946,6 +954,11 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		m.statusMessage = ""
 	}
 	if m.screen == screenIssues {
+		if pendingIssueReload {
+			m.issueReloadPending = false
+			m.prepareIssueDataForRepo(pendingIssueRepo)
+			return m.startIssueViewReload()
+		}
 		if msg.request.issueScoped {
 			m.clearFocusedWorkItem()
 		}
@@ -1254,6 +1267,21 @@ func (m *model) replaceWorkbenchData(result workbench.RuntimeLoadResult, selecte
 	m.repos = repoRefsFromSummaries(m.repoSummaries)
 	m.workItems = cloneWorkItems(result.Items)
 	m.restoreSelectedRepo(selectedRepo)
+}
+
+func (m *model) replaceRepositorySummary(summary workbench.RepositorySummary) {
+	for i := range m.repoSummaries {
+		if !strings.EqualFold(m.repoSummaries[i].Repo.FullName(), summary.Repo.FullName()) {
+			continue
+		}
+		summary.Repo = m.repoSummaries[i].Repo
+		summary.Remotes = append([]string(nil), summary.Remotes...)
+		m.repoSummaries[i] = summary
+		return
+	}
+	summary.Remotes = append([]string(nil), summary.Remotes...)
+	m.repoSummaries = append(m.repoSummaries, summary)
+	m.repos = append(m.repos, summary.Repo)
 }
 
 func (m *model) restoreSelectedRepo(repo workbench.RepoRef) {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1306,6 +1306,8 @@ func mergeIssueScopedWorkItems(items []workbench.WorkItem, repo workbench.RepoRe
 				replacement[index].PullRequest = previous.PullRequest
 				replacement[index].Checks = previous.Checks
 				replacement[index].Issue = refreshedIssueRef(previous.Issue, result)
+			} else if checkRefFailed(replacement[index], result.FailedCheckRefs) {
+				replacement[index].Checks = previous.Checks
 			}
 			if !result.IssuesLoaded && previous.Issue != nil {
 				replacement[index].Issue = previous.Issue
@@ -1319,6 +1321,22 @@ func mergeIssueScopedWorkItems(items []workbench.WorkItem, repo workbench.RepoRe
 	}
 
 	return replaceRepoWorkItems(items, repo, replacement)
+}
+
+func checkRefFailed(item workbench.WorkItem, failedRefs []string) bool {
+	if item.PullRequest == nil {
+		return false
+	}
+	ref := item.PullRequest.HeadBranch
+	if strings.HasPrefix(item.ID, "pull-request:") && item.PullRequest.Number > 0 {
+		ref = fmt.Sprintf("%d", item.PullRequest.Number)
+	}
+	for _, failedRef := range failedRefs {
+		if failedRef == ref {
+			return true
+		}
+	}
+	return false
 }
 
 func refreshedIssueRef(previous *workbench.IssueRef, result workbench.RuntimeLoadResult) *workbench.IssueRef {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -139,6 +139,7 @@ type model struct {
 	issueSearchEditing   bool
 	issuesLoading        bool
 	issueReloadPending   bool
+	pendingIssueRepo     workbench.RepoRef
 	issuesError          string
 	prsByIssueNumber     map[int][]workbench.PullRequestRef
 	viewerLogin          string
@@ -906,7 +907,7 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	if msg.request != m.activeReloadRequest {
 		return nil
 	}
-	if !msg.request.issueScoped && m.reloadRequestIsStale(msg.request) {
+	if !msg.request.issueScoped && !m.issueReloadPending && m.reloadRequestIsStale(msg.request) {
 		m.workbenchLoading = false
 		if m.screen == screenIssues {
 			m.issuesLoading = false
@@ -944,9 +945,14 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		m.syncWorkbenchReturnAfterReload()
 		m.workbenchReturn.selectedItem = m.selectedItem
 	}
-	pendingIssueReload := m.issueReloadPending && !msg.request.issueScoped
-	pendingIssueRepo := m.issueRepo
-	m.updateIssueDataFromRuntimeResult(msg.result)
+	pendingIssueReload := m.issueReloadPending
+	pendingIssueRepo := m.pendingIssueRepo
+	updateVisibleIssues := !pendingIssueReload ||
+		!msg.request.issueScoped ||
+		strings.EqualFold(msg.request.repo.FullName(), pendingIssueRepo.FullName())
+	if updateVisibleIssues {
+		m.updateIssueDataFromRuntimeResult(msg.result)
+	}
 	m.workbenchLoading = false
 	m.issuesLoading = false
 	if hasWorkbenchErrorItems(msg.result.Items) {
@@ -956,9 +962,7 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	}
 	if m.screen == screenIssues {
 		if pendingIssueReload {
-			m.issueReloadPending = false
-			m.prepareIssueDataForRepo(pendingIssueRepo)
-			return m.startIssueViewReload()
+			return m.startPendingIssueReload()
 		}
 		if msg.request.issueScoped {
 			m.clearFocusedWorkItem()

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -21,6 +21,7 @@ const (
 	defaultWidth           = 100
 	repoPaneWidth          = 23
 	workItemPaneWidth      = 41
+	issueListPaneWidth     = 62
 	paneGapWidth           = 1
 	paneContentPaddingLeft = 1
 	paneBorderGlyph        = "│"
@@ -33,6 +34,14 @@ const (
 	frameBottomRightGlyph  = "┘"
 	previewPaneMinWidth    = 28
 	fullLayoutMinWidth     = repoPaneWidth + workItemPaneWidth + previewPaneMinWidth + paneBorderWidth*3 + paneGapWidth*2
+	issueLayoutMinWidth    = issueListPaneWidth + previewPaneMinWidth + paneBorderWidth*2 + paneGapWidth
+)
+
+type appScreen int
+
+const (
+	screenWorkbench appScreen = iota
+	screenIssues
 )
 
 // paneFocus tracks the pane that owns pane-scoped key handling.
@@ -66,15 +75,50 @@ func (p paneFocus) borderLabel() string {
 	}
 }
 
+func (m model) paneLabel(p paneFocus) string {
+	if m.screen == screenIssues {
+		switch p {
+		case panePreview:
+			return "Preview"
+		default:
+			return "Issues"
+		}
+	}
+	return p.label()
+}
+
+func (m model) paneBorderLabel(p paneFocus) string {
+	if m.screen == screenIssues {
+		switch p {
+		case panePreview:
+			return "Preview"
+		default:
+			return "Issues"
+		}
+	}
+	return p.borderLabel()
+}
+
 type model struct {
 	width                int
 	height               int
+	screen               appScreen
 	repos                []workbench.RepoRef
 	selectedRepo         int
 	selectedView         int
 	viewSelected         bool
 	workItems            []workbench.WorkItem
 	selectedItem         int
+	issueRepo            workbench.RepoRef
+	issues               []workbench.IssueRef
+	selectedIssue        int
+	issueFilter          issueFilterState
+	issueSearchEditing   bool
+	issuesLoading        bool
+	issuesError          string
+	prsByIssueNumber     map[int][]workbench.PullRequestRef
+	viewerLogin          string
+	workbenchReturn      workbenchReturnState
 	workbenchSource      workbenchDataSource
 	workbenchLoading     bool
 	focusedPane          paneFocus
@@ -97,9 +141,21 @@ type model struct {
 type WorkbenchData struct {
 	Repos          []workbench.RepoRef
 	WorkItems      []workbench.WorkItem
+	PullRequests   []workbench.PullRequestRef
+	Issues         []workbench.IssueRef
+	ViewerSubject  workbench.ReviewSubjects
 	Reloader       WorkbenchReloader
 	InitialLoading bool
 	Demo           bool
+}
+
+type workbenchReturnState struct {
+	valid        bool
+	selectedRepo int
+	selectedView int
+	viewSelected bool
+	selectedItem int
+	focusedPane  paneFocus
 }
 
 // WorkbenchReloader reloads runtime workbench data for one selected repository.
@@ -179,6 +235,11 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 	m := model{
 		repos:             cloneRepoRefs(data.Repos),
 		workItems:         cloneWorkItems(data.WorkItems),
+		issues:            cloneIssueRefs(data.Issues),
+		issueFilter:       defaultIssueFilterState(),
+		issuesLoading:     data.InitialLoading,
+		prsByIssueNumber:  pullRequestsByIssueNumber(data.PullRequests),
+		viewerLogin:       data.ViewerSubject.Login,
 		workbenchSource:   source,
 		previewLoader:     loader,
 		workbenchReloader: data.Reloader,
@@ -193,6 +254,15 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 		startupRepo = cfg.Startup.Repo
 	}
 	m.applyStartupRepo(startupRepo)
+	if repo, ok := m.selectedRepoRef(); ok {
+		m.issueRepo = repo
+		if len(m.issues) == 0 {
+			m.issues = issuesFromWorkItems(m.workItems, repo)
+		}
+		if len(m.prsByIssueNumber) == 0 {
+			m.prsByIssueNumber = pullRequestsByIssueNumber(pullRequestsFromWorkItems(m.workItems, repo))
+		}
+	}
 	if data.InitialLoading {
 		m.beginWorkbenchReload("Loading workbench data...")
 	}
@@ -263,6 +333,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case workbenchReloadMsg:
 		return m, m.handleWorkbenchReload(msg)
 	case tea.KeyMsg:
+		if m.screen == screenIssues && m.issueSearchEditing {
+			handled, cmd := m.handleIssueSearchKey(msg)
+			if handled {
+				return m, cmd
+			}
+		}
 		if action, ok := m.matchedAction(msg); ok {
 			return m, m.handleAction(action)
 		}
@@ -340,7 +416,11 @@ func (m *model) handlePreviewResult(msg previewResultMsg) {
 }
 
 func (m model) matchedAction(msg tea.KeyMsg) (actionID, bool) {
-	for _, binding := range m.keys.actionBindings() {
+	bindings := m.keys.workbenchActionBindings()
+	if m.screen == screenIssues {
+		bindings = m.keys.issueActionBindings()
+	}
+	for _, binding := range bindings {
 		if key.Matches(msg, binding.binding) {
 			return binding.id, true
 		}
@@ -366,15 +446,27 @@ func (m *model) handleAction(action actionID) tea.Cmd {
 		m.focusPaneByNumber(3)
 	case actionMoveDown:
 		m.moveFocusedSelection(1)
+		if m.screen == screenIssues {
+			return nil
+		}
 		return m.startPreviewLoadIfFocusedItemChanged()
 	case actionMoveUp:
 		m.moveFocusedSelection(-1)
+		if m.screen == screenIssues {
+			return nil
+		}
 		return m.startPreviewLoadIfFocusedItemChanged()
 	case actionJumpTop:
 		m.jumpFocusedSelection(false)
+		if m.screen == screenIssues {
+			return nil
+		}
 		return m.startPreviewLoadIfFocusedItemChanged()
 	case actionJumpBottom:
 		m.jumpFocusedSelection(true)
+		if m.screen == screenIssues {
+			return nil
+		}
 		return m.startPreviewLoadIfFocusedItemChanged()
 	case actionRefresh:
 		cmd := m.refreshWorkbenchData()
@@ -386,11 +478,29 @@ func (m *model) handleAction(action actionID) tea.Cmd {
 	case actionOpenPullRequest:
 		return m.openPullRequest()
 	case actionOpenIssue:
-		return m.openIssue()
+		return m.enterIssueView()
+	case actionOpenInBrowser:
+		return m.openInBrowser()
 	case actionCopyURL:
 		return m.copyURL()
+	case actionCopyIssueNumber:
+		return m.copyIssueNumber()
 	case actionCopyWorktreePath:
 		return m.copyWorktreePath()
+	case actionCycleIssueState:
+		m.cycleIssueStateFilter()
+	case actionCycleIssueAssignee:
+		m.cycleIssueAssigneeFilter()
+	case actionCycleIssueLabel:
+		m.cycleIssueLabelFilter()
+	case actionCycleIssueMilestone:
+		m.cycleIssueMilestoneFilter()
+	case actionStartIssueSearch:
+		m.startIssueSearch()
+	case actionClearIssueFilters:
+		m.clearIssueFilters()
+	case actionBackToWorkbench:
+		return m.backToWorkbench()
 	}
 	return nil
 }
@@ -412,24 +522,52 @@ func (m *model) openPullRequest() tea.Cmd {
 	})
 }
 
-func (m *model) openIssue() tea.Cmd {
+func (m *model) openInBrowser() tea.Cmd {
+	if m.screen == screenIssues {
+		return m.openSelectedIssueInBrowser()
+	}
+
 	item, ok := m.selectedWorkItem()
 	if !ok {
 		m.statusMessage = "No work item selected"
 		return nil
 	}
-	if item.Issue == nil || item.Issue.URL == "" {
-		m.statusMessage = "No issue URL for selected work item"
+	if item.Issue != nil && item.Issue.URL != "" {
+		label := item.Issue.Label()
+		m.statusMessage = "Opening " + label + "..."
+		return m.actionCommand("Opened "+label, "Open issue failed", func(ctx context.Context) error {
+			return m.runner().Open(ctx, item.Issue.URL)
+		})
+	}
+	if item.PullRequest == nil || item.PullRequest.URL == "" {
+		m.statusMessage = "No browser URL for selected work item"
 		return nil
 	}
-	label := item.Issue.Label()
+	label := item.PullRequest.NumberLabel()
 	m.statusMessage = "Opening " + label + "..."
-	return m.actionCommand("Opened "+label, "Open issue failed", func(ctx context.Context) error {
-		return m.runner().Open(ctx, item.Issue.URL)
+	return m.actionCommand("Opened "+label, "Open PR failed", func(ctx context.Context) error {
+		return m.runner().Open(ctx, item.PullRequest.URL)
 	})
 }
 
 func (m *model) copyURL() tea.Cmd {
+	if m.screen == screenIssues {
+		issue, ok := m.selectedIssueRef()
+		if !ok {
+			m.statusMessage = "No issue selected"
+			return nil
+		}
+		if issue.URL == "" {
+			m.statusMessage = "No issue URL for selected issue"
+			return nil
+		}
+		label := issue.Label()
+		m.statusMessage = "Copying " + label + " URL..."
+		return m.actionCommand("Copied "+label+" URL", "Copy URL failed", func(ctx context.Context) error {
+			return m.runner().Copy(ctx, issue.URL)
+		})
+	}
+
 	item, ok := m.selectedWorkItem()
 	if !ok {
 		m.statusMessage = "No work item selected"
@@ -443,6 +581,23 @@ func (m *model) copyURL() tea.Cmd {
 	m.statusMessage = "Copying " + label + " URL..."
 	return m.actionCommand("Copied "+label+" URL", "Copy URL failed", func(ctx context.Context) error {
 		return m.runner().Copy(ctx, target)
+	})
+}
+
+func (m *model) copyIssueNumber() tea.Cmd {
+	issue, ok := m.selectedIssueRef()
+	if !ok {
+		m.statusMessage = "No issue selected"
+		return nil
+	}
+	if issue.Number == 0 {
+		m.statusMessage = "No issue number for selected issue"
+		return nil
+	}
+	label := issueNumberLabel(issue.Number)
+	m.statusMessage = "Copying " + label + "..."
+	return m.actionCommand("Copied "+label, "Copy issue number failed", func(ctx context.Context) error {
+		return m.runner().Copy(ctx, label)
 	})
 }
 
@@ -524,6 +679,10 @@ func (m *model) beginWorkbenchReload(status string) bool {
 	}
 	m.activeReloadRequest = request
 	m.workbenchLoading = true
+	if m.screen == screenIssues {
+		m.issuesLoading = true
+		m.issuesError = ""
+	}
 	m.statusMessage = status
 	return true
 }
@@ -544,6 +703,9 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	repo, ok := m.selectedRepoRef()
 	if !ok || repo != msg.request.repo {
 		m.workbenchLoading = false
+		if m.screen == screenIssues {
+			m.issuesLoading = false
+		}
 		if m.statusMessage == msg.request.status {
 			m.statusMessage = ""
 		}
@@ -558,11 +720,16 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	}
 	m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
 	m.restoreSelectedWorkItem(selectedWorkItemRepo, selectedWorkItemID)
+	m.updateIssueDataFromRuntimeResult(msg.result)
 	m.workbenchLoading = false
+	m.issuesLoading = false
 	if hasWorkbenchErrorItems(msg.result.Items) {
 		m.statusMessage = "Workbench loaded with partial errors"
 	} else {
 		m.statusMessage = ""
+	}
+	if m.screen == screenIssues {
+		return nil
 	}
 	return m.startPreviewLoadForCurrentItem()
 }
@@ -586,6 +753,9 @@ func (m *model) focusPaneByNumber(number int) {
 
 // paneOrder is the visible pane traversal order for tab navigation.
 func (m model) paneOrder() []paneFocus {
+	if m.screen == screenIssues {
+		return []paneFocus{paneWorkItems, panePreview}
+	}
 	if m.isCompact() {
 		return []paneFocus{paneWorkItems, panePreview}
 	}
@@ -634,6 +804,12 @@ func previousPane(current paneFocus, order []paneFocus) paneFocus {
 
 // moveFocusedSelection keeps j/k scoped to the active pane.
 func (m *model) moveFocusedSelection(delta int) {
+	if m.screen == screenIssues {
+		if m.activePane() == paneWorkItems {
+			m.moveIssueSelection(delta)
+		}
+		return
+	}
 	switch m.activePane() {
 	case paneRepositories:
 		m.moveRepoSelection(delta)
@@ -644,6 +820,12 @@ func (m *model) moveFocusedSelection(delta int) {
 
 // jumpFocusedSelection keeps g/G behavior aligned with the active pane.
 func (m *model) jumpFocusedSelection(toEnd bool) {
+	if m.screen == screenIssues {
+		if m.activePane() == paneWorkItems {
+			m.jumpIssueSelection(toEnd)
+		}
+		return
+	}
 	switch m.activePane() {
 	case paneRepositories:
 		if toEnd {
@@ -921,6 +1103,12 @@ func matchFilterPattern(pattern string, value string, match func(pattern string,
 func (m model) View() string {
 	width := m.effectiveWidth()
 
+	if m.screen == screenIssues {
+		if width < issueLayoutMinWidth {
+			return m.renderIssueCompact(width)
+		}
+		return m.renderIssueFull(width)
+	}
 	if width < fullLayoutMinWidth {
 		return m.renderCompact(width)
 	}
@@ -1065,9 +1253,9 @@ func (m model) headerLines(title string, width int) []string {
 // keymapLines keeps the active pane affordances visible near the title.
 func (m model) keymapLines(width int) []string {
 	focus := m.activePane()
-	prefix := focus.label() + " keys: "
+	prefix := m.paneLabel(focus) + " keys: "
 	helpWidth := max(width-lipgloss.Width(prefix), 0)
-	helpView := m.styledHelp(helpWidth).View(m.keys.contextualHelp(focus, m.paneOrder()))
+	helpView := m.styledHelp(helpWidth).View(m.keys.contextualHelp(m.screen, focus, m.paneOrder()))
 	lines := strings.Split(helpView, "\n")
 	indent := strings.Repeat(" ", lipgloss.Width(prefix))
 
@@ -1169,9 +1357,9 @@ func paneTextWidth(width int) int {
 func (m model) paneHeading(pane paneFocus) string {
 	number, ok := m.paneNumber(pane)
 	if !ok {
-		return pane.borderLabel()
+		return m.paneBorderLabel(pane)
 	}
-	return fmt.Sprintf("%s[%d]", pane.borderLabel(), number)
+	return fmt.Sprintf("%s[%d]", m.paneBorderLabel(pane), number)
 }
 
 func (m model) paneNumber(pane paneFocus) (int, bool) {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1543,7 +1543,7 @@ func (m *model) restoreSelectedWorkItem(repo workbench.RepoRef, workItemID strin
 	}
 	if workItemID != "" {
 		for i, item := range items {
-			if item.Repo == repo && item.ID == workItemID {
+			if sameRepoRef(item.Repo, repo) && item.ID == workItemID {
 				m.selectedItem = i
 				return
 			}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -667,7 +667,7 @@ func (m *model) beginWorkbenchReload(status string) bool {
 	if m.workbenchReloader == nil {
 		return false
 	}
-	repo, ok := m.selectedRepoRef()
+	repo, ok := m.reloadRepoRef()
 	if !ok {
 		return false
 	}
@@ -700,7 +700,7 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	if msg.request != m.activeReloadRequest {
 		return nil
 	}
-	repo, ok := m.selectedRepoRef()
+	repo, ok := m.reloadRepoRef()
 	if !ok || repo != msg.request.repo {
 		m.workbenchLoading = false
 		if m.screen == screenIssues {
@@ -720,6 +720,12 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 	}
 	m.workItems = replaceRepoWorkItems(m.workItems, msg.request.repo, msg.result.Items)
 	m.restoreSelectedWorkItem(selectedWorkItemRepo, selectedWorkItemID)
+	if m.screen == screenIssues && m.workbenchReturn.valid {
+		m.workbenchReturn.selectedRepo = m.selectedRepo
+		m.workbenchReturn.selectedView = m.selectedView
+		m.workbenchReturn.viewSelected = m.viewSelected
+		m.workbenchReturn.selectedItem = m.selectedItem
+	}
 	m.updateIssueDataFromRuntimeResult(msg.result)
 	m.workbenchLoading = false
 	m.issuesLoading = false
@@ -732,6 +738,13 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		return nil
 	}
 	return m.startPreviewLoadForCurrentItem()
+}
+
+func (m model) reloadRepoRef() (workbench.RepoRef, bool) {
+	if m.screen == screenIssues && hasRepoRef(m.issueRepo) {
+		return m.issueRepo, true
+	}
+	return m.selectedRepoRef()
 }
 
 func (m *model) focusNextPane() {
@@ -930,6 +943,10 @@ func (m model) selectedRepoRef() (workbench.RepoRef, bool) {
 		return workbench.RepoRef{}, false
 	}
 	return m.repos[m.selectedRepo], true
+}
+
+func hasRepoRef(repo workbench.RepoRef) bool {
+	return repo.Owner != "" || repo.Name != ""
 }
 
 func (m model) selectedRepoView() (repoView, bool) {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1311,19 +1311,21 @@ func mergeIssueScopedWorkItems(items []workbench.WorkItem, repo workbench.RepoRe
 		}
 		index, found := byID[previous.ID]
 		if found {
+			samePR := previous.PullRequest != nil && replacement[index].PullRequest != nil &&
+				samePullRequest(*previous.PullRequest, *replacement[index].PullRequest)
 			if !result.PullRequestsLoaded && previous.PullRequest != nil {
 				replacement[index].PullRequest = previous.PullRequest
 				replacement[index].Checks = previous.Checks
 				replacement[index].Issue = refreshedIssueRef(previous.Issue, result)
 			} else {
-				if result.ViewerSubjectError != "" && previous.PullRequest != nil && replacement[index].PullRequest != nil {
+				if result.ViewerSubjectError != "" && samePR {
 					preserveViewerReviewPerspective(replacement[index].PullRequest, previous.PullRequest)
 				}
-				if checkRefFailed(replacement[index], result.FailedCheckRefs) {
+				if samePR && checkRefFailed(replacement[index], result.FailedCheckRefs) {
 					replacement[index].Checks = previous.Checks
 				}
 			}
-			if !result.IssuesLoaded && previous.Issue != nil {
+			if !result.IssuesLoaded && sameIssueRef(previous.Issue, replacement[index].Issue) {
 				replacement[index].Issue = previous.Issue
 			}
 			continue
@@ -1390,6 +1392,10 @@ func samePullRequest(left workbench.PullRequestRef, right workbench.PullRequestR
 		return left.Number > 0 && left.Number == right.Number
 	}
 	return left.HeadBranch != "" && left.HeadBranch == right.HeadBranch && strings.EqualFold(left.HeadOwner, right.HeadOwner)
+}
+
+func sameIssueRef(left *workbench.IssueRef, right *workbench.IssueRef) bool {
+	return left != nil && right != nil && left.Number > 0 && left.Number == right.Number
 }
 
 func preserveViewerReviewPerspective(current *workbench.PullRequestRef, previous *workbench.PullRequestRef) {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -764,6 +764,9 @@ func (m *model) handleWorkbenchReload(msg workbenchReloadMsg) tea.Cmd {
 		m.statusMessage = ""
 	}
 	if m.screen == screenIssues {
+		if msg.request.issueScoped {
+			m.clearFocusedWorkItem()
+		}
 		return nil
 	}
 	return m.startPreviewLoadForCurrentItem()

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -115,6 +115,28 @@ func TestInit_ReturnsNilCmd(t *testing.T) {
 	}
 }
 
+func TestInit_StartsInitialReloadWithoutSelectedRepository(t *testing.T) {
+	reloader := &fakeWorkbenchReloader{}
+	start := newModelWithRuntimeData(cfgpkg.Defaults(), "", WorkbenchData{
+		Reloader:       reloader,
+		InitialLoading: true,
+	}, fakeDelayedPreviewLoader(0))
+
+	if !start.workbenchLoading || start.activeReloadRequest.requestID == 0 {
+		t.Fatalf("expected initial workbench reload request, got loading=%v request=%+v", start.workbenchLoading, start.activeReloadRequest)
+	}
+	if start.activeReloadRequest.repo != (workbench.RepoRef{}) {
+		t.Fatalf("expected zero repo reload request, got %+v", start.activeReloadRequest.repo)
+	}
+	msg := requireWorkbenchReloadMsg(t, start.Init())
+	if msg.request.repo != (workbench.RepoRef{}) {
+		t.Fatalf("expected zero repo reload command, got %+v", msg.request.repo)
+	}
+	if len(reloader.calls) != 1 || reloader.calls[0] != (workbench.RepoRef{}) {
+		t.Fatalf("expected reloader to be called with zero repo, got %+v", reloader.calls)
+	}
+}
+
 func TestUpdate_RefreshReloadsWorkbenchData(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	original := workbench.WorkItem{

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -971,7 +971,8 @@ func TestUpdate_ActionKeysAreBound(t *testing.T) {
 	}{
 		{"refresh", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}, actionRefresh},
 		{"open PR", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}}, actionOpenPullRequest},
-		{"open issue", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}}, actionOpenIssue},
+		{"show issues", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}}, actionOpenIssue},
+		{"open in browser", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}}, actionOpenInBrowser},
 		{"copy URL", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}, actionCopyURL},
 		{"copy worktree path", tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}}, actionCopyWorktreePath},
 	}
@@ -1008,13 +1009,35 @@ func TestUpdate_OpenPullRequestRunsActionCommand(t *testing.T) {
 	}
 }
 
-func TestUpdate_OpenIssueRunsActionCommand(t *testing.T) {
+func TestUpdate_OpenIssueEntersIssueView(t *testing.T) {
+	start := newModel()
+	start.selectedItem = 1
+	start.focusedPane = paneWorkItems
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd != nil {
+		t.Fatalf("expected issue view transition without command, got %T", cmd)
+	}
+	mm := got.(model)
+	if mm.screen != screenIssues {
+		t.Fatalf("expected issue screen, got %v", mm.screen)
+	}
+	issue, ok := mm.selectedIssueRef()
+	if !ok || issue.Number != 9 {
+		t.Fatalf("expected linked issue #9 to be selected, got %+v ok=%v", issue, ok)
+	}
+	if !mm.workbenchReturn.valid || mm.workbenchReturn.selectedItem != 1 || mm.workbenchReturn.focusedPane != paneWorkItems {
+		t.Fatalf("expected workbench return state to be captured, got %+v", mm.workbenchReturn)
+	}
+}
+
+func TestUpdate_OpenInBrowserRunsIssueActionCommand(t *testing.T) {
 	runner := &fakeActionRunner{}
 	start := newModel()
 	start.actionRunner = runner
 	start.selectedItem = 1
 
-	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
 	if cmd == nil {
 		t.Fatalf("expected open issue command")
 	}

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -86,6 +86,19 @@ type fakeWorkbenchReloader struct {
 	deadlineSet []bool
 }
 
+type fakeIssueReloader struct {
+	results map[string]workbench.RuntimeLoadResult
+	calls   []workbench.RepoRef
+}
+
+func (r *fakeIssueReloader) LoadIssues(_ context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
+	r.calls = append(r.calls, repo)
+	if result, ok := r.results[repo.FullName()]; ok {
+		return result
+	}
+	return workbench.RuntimeLoadResult{Repo: repo}
+}
+
 func (r *fakeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
 	r.calls = append(r.calls, repo)
 	_, hasDeadline := ctx.Deadline()

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -106,7 +106,7 @@ func TestView_FullHelpShowsContextualActions(t *testing.T) {
 	m.help.ShowAll = true
 	got := ansi.Strip(m.View())
 
-	for _, want := range []string{"p open PR", "i open issue", "y copy URL", "Y copy path", "r refresh"} {
+	for _, want := range []string{"p open PR", "i issues", "o open", "y copy URL", "Y copy path", "r refresh"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected full help to include %q, got:\n%s", want, got)
 		}
@@ -120,7 +120,7 @@ func TestView_FullHelpShowsContextualActions(t *testing.T) {
 	if strings.Contains(got, "j down") || strings.Contains(got, "G bottom") {
 		t.Fatalf("expected preview full help to omit movement keys, got:\n%s", got)
 	}
-	if !strings.Contains(got, "p open PR") || !strings.Contains(got, "r refresh") {
+	if !strings.Contains(got, "p open PR") || !strings.Contains(got, "o open") || !strings.Contains(got, "r refresh") {
 		t.Fatalf("expected preview full help to keep actions, got:\n%s", got)
 	}
 }

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -150,6 +150,25 @@ func TestView_FullHelpShowsContextualActions(t *testing.T) {
 	}
 }
 
+func TestView_IssuePreviewHelpShowsScrollKeys(t *testing.T) {
+	m := newModel()
+	m.screen = screenIssues
+	m.focusedPane = panePreview
+	m.issueRepo = workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	m.issues = []workbench.IssueRef{{Number: 75, Title: "Issue browser", State: "open"}}
+
+	got := ansi.Strip(m.View())
+	if !strings.Contains(got, "Preview keys: j/k move  g/G jump") {
+		t.Fatalf("expected issue preview keymap to show scroll keys, got:\n%s", got)
+	}
+
+	m.help.ShowAll = true
+	got = ansi.Strip(m.View())
+	if !strings.Contains(got, "j down") || !strings.Contains(got, "G bottom") {
+		t.Fatalf("expected issue preview full help to show scroll keys, got:\n%s", got)
+	}
+}
+
 func TestView_FullLayoutSeparatesPanes(t *testing.T) {
 	got := newModel().View()
 	lines := strings.Split(got, "\n")

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -82,7 +82,7 @@ const (
 	pullRequestClosingIssuesQuery = `
 query($owner:String!, $name:String!, $after:String) {
   repository(owner:$owner, name:$name) {
-    pullRequests(first:100, after:$after, states:[OPEN, CLOSED, MERGED], orderBy:{field:UPDATED_AT, direction:DESC}) {
+    pullRequests(first:100, after:$after, states:[OPEN, CLOSED, MERGED], orderBy:{field:CREATED_AT, direction:DESC}) {
       nodes {
         number
         closingIssuesReferences(first:100) {

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -206,7 +206,7 @@ func (s CLIService) PullRequests(ctx context.Context, repo string) ([]workbench.
 	if err := json.Unmarshal(output, &payload); err != nil {
 		return nil, fmt.Errorf("parse gh pr list output: %w", err)
 	}
-	closingIssuesByPR, _ := s.pullRequestClosingIssues(ctx, repo)
+	closingIssuesByPR, closingIssuesErr := s.pullRequestClosingIssues(ctx, repo)
 
 	prs := make([]workbench.PullRequestRef, 0, len(payload))
 	for _, pr := range payload {
@@ -221,7 +221,7 @@ func (s CLIService) PullRequests(ctx context.Context, repo string) ([]workbench.
 			BaseBranch:     pr.BaseRefName,
 			IsDraft:        pr.IsDraft,
 			UpdatedAt:      pr.UpdatedAt,
-			LinkedIssues:   linkedIssues(closingIssuesByPR[pr.Number], repo, pr.Body),
+			LinkedIssues:   linkedIssues(closingIssuesByPR[pr.Number], repo, pr.Body, closingIssuesErr != nil),
 			ReviewState:    reviewState(pr.ReviewDecision),
 			ReviewRequests: reviewRequests(pr.ReviewRequests),
 			LatestReviews:  latestReviews(pr.LatestReviews),
@@ -760,8 +760,11 @@ func logLines(value string) []string {
 	return strings.Split(value, "\n")
 }
 
-func linkedIssues(closingIssues []workbench.IssueRef, repo string, body string) []workbench.IssueRef {
+func linkedIssues(closingIssues []workbench.IssueRef, repo string, body string, useBodyFallback bool) []workbench.IssueRef {
 	issues := append([]workbench.IssueRef(nil), closingIssues...)
+	if !useBodyFallback {
+		return issues
+	}
 	seen := map[string]bool{}
 	for _, issue := range issues {
 		if issue.Number > 0 {

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -260,7 +260,10 @@ func (s CLIService) IssuesWithOptions(ctx context.Context, repo string, opts wor
 	}
 	commentCounts := map[int]int{}
 	if opts.IncludeCommentsCount {
-		commentCounts, _ = s.issueCommentCounts(ctx, repo)
+		commentCounts, err = s.issueCommentCounts(ctx, repo)
+		if err != nil {
+			return nil, fmt.Errorf("load issue comment counts: %w", err)
+		}
 	}
 	issues := make([]workbench.IssueRef, 0, len(payload))
 	for _, issue := range payload {

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -122,8 +122,7 @@ query($owner:String!, $name:String!, $after:String) {
 )
 
 var (
-	closingIssueTextPattern = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[^\n\r.]*`)
-	issueNumberPattern      = regexp.MustCompile(`#(\d+)`)
+	closingIssueReferencePattern = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b:?\s+#(\d+)\b`)
 )
 
 // Error describes a gh-backed service failure.
@@ -778,21 +777,19 @@ func issuesFromGraphQL(payload []ghIssue) []workbench.IssueRef {
 func linkedIssuesFromBody(body string) []workbench.IssueRef {
 	seen := map[int]bool{}
 	issues := []workbench.IssueRef{}
-	for _, text := range closingIssueTextPattern.FindAllString(body, -1) {
-		for _, match := range issueNumberPattern.FindAllStringSubmatch(text, -1) {
-			if len(match) < 2 {
-				continue
-			}
-			number, err := strconv.Atoi(match[1])
-			if err != nil || seen[number] {
-				continue
-			}
-			issues = append(issues, workbench.IssueRef{
-				Number:  number,
-				Certain: true,
-			})
-			seen[number] = true
+	for _, match := range closingIssueReferencePattern.FindAllStringSubmatch(body, -1) {
+		if len(match) < 2 {
+			continue
 		}
+		number, err := strconv.Atoi(match[1])
+		if err != nil || seen[number] {
+			continue
+		}
+		issues = append(issues, workbench.IssueRef{
+			Number:  number,
+			Certain: true,
+		})
+		seen[number] = true
 	}
 	return issues
 }

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -91,6 +91,9 @@ query($owner:String!, $name:String!, $after:String) {
             title
             state
             url
+            repository {
+              nameWithOwner
+            }
           }
         }
       }
@@ -227,8 +230,13 @@ func (s CLIService) PullRequests(ctx context.Context, repo string) ([]workbench.
 	return prs, nil
 }
 
-// Issues loads issue summaries through gh.
+// Issues loads issue summaries and browser-only metadata through gh.
 func (s CLIService) Issues(ctx context.Context, repo string) ([]workbench.IssueRef, error) {
+	return s.IssuesWithOptions(ctx, repo, workbench.IssueListOptions{IncludeCommentsCount: true})
+}
+
+// IssuesWithOptions loads issue summaries while allowing workbench refreshes to defer comment counts.
+func (s CLIService) IssuesWithOptions(ctx context.Context, repo string, opts workbench.IssueListOptions) ([]workbench.IssueRef, error) {
 	output, err := s.runner().Run(ctx, "issue", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", issueListFields)
 	if err != nil {
 		return nil, err
@@ -250,11 +258,15 @@ func (s CLIService) Issues(ctx context.Context, repo string) ([]workbench.IssueR
 	if err := json.Unmarshal(output, &payload); err != nil {
 		return nil, fmt.Errorf("parse gh issue list output: %w", err)
 	}
-	commentCounts, _ := s.issueCommentCounts(ctx, repo)
+	commentCounts := map[int]int{}
+	if opts.IncludeCommentsCount {
+		commentCounts, _ = s.issueCommentCounts(ctx, repo)
+	}
 	issues := make([]workbench.IssueRef, 0, len(payload))
 	for _, issue := range payload {
 		issues = append(issues, workbench.IssueRef{
 			Number:        issue.Number,
+			Repository:    repo,
 			Title:         issue.Title,
 			State:         strings.ToLower(issue.State),
 			URL:           issue.URL,
@@ -484,7 +496,7 @@ func (s CLIService) pullRequestClosingIssues(ctx context.Context, repo string) (
 		}
 		for _, pr := range payload.Data.Repository.PullRequests.Nodes {
 			if pr.Number > 0 {
-				issuesByPR[pr.Number] = issuesFromGraphQL(pr.ClosingIssues.Nodes)
+				issuesByPR[pr.Number] = issuesFromGraphQL(pr.ClosingIssues.Nodes, repo)
 			}
 		}
 		if !payload.Data.Repository.PullRequests.PageInfo.HasNextPage {
@@ -564,10 +576,13 @@ type ghLabel struct {
 }
 
 type ghIssue struct {
-	Number int    `json:"number"`
-	Title  string `json:"title"`
-	State  string `json:"state"`
-	URL    string `json:"url"`
+	Number     int    `json:"number"`
+	Title      string `json:"title"`
+	State      string `json:"state"`
+	URL        string `json:"url"`
+	Repository struct {
+		NameWithOwner string `json:"nameWithOwner"`
+	} `json:"repository"`
 }
 
 type ghReviewRequest struct {
@@ -744,34 +759,48 @@ func logLines(value string) []string {
 
 func linkedIssues(closingIssues []workbench.IssueRef, repo string, body string) []workbench.IssueRef {
 	issues := append([]workbench.IssueRef(nil), closingIssues...)
-	seen := map[int]bool{}
+	seen := map[string]bool{}
 	for _, issue := range issues {
 		if issue.Number > 0 {
-			seen[issue.Number] = true
+			seen[issueIdentity(issue, repo)] = true
 		}
 	}
 	for _, issue := range linkedIssuesFromBody(repo, body) {
-		if issue.Number == 0 || seen[issue.Number] {
+		identity := issueIdentity(issue, repo)
+		if issue.Number == 0 || seen[identity] {
 			continue
 		}
 		issues = append(issues, issue)
-		seen[issue.Number] = true
+		seen[identity] = true
 	}
 	return issues
 }
 
-func issuesFromGraphQL(payload []ghIssue) []workbench.IssueRef {
+func issuesFromGraphQL(payload []ghIssue, fallbackRepo string) []workbench.IssueRef {
 	issues := make([]workbench.IssueRef, 0, len(payload))
 	for _, issue := range payload {
+		repository := issue.Repository.NameWithOwner
+		if repository == "" {
+			repository = fallbackRepo
+		}
 		issues = append(issues, workbench.IssueRef{
-			Number:  issue.Number,
-			Title:   issue.Title,
-			State:   strings.ToLower(issue.State),
-			URL:     issue.URL,
-			Certain: true,
+			Number:     issue.Number,
+			Repository: repository,
+			Title:      issue.Title,
+			State:      strings.ToLower(issue.State),
+			URL:        issue.URL,
+			Certain:    true,
 		})
 	}
 	return issues
+}
+
+func issueIdentity(issue workbench.IssueRef, fallbackRepo string) string {
+	repository := issue.Repository
+	if repository == "" {
+		repository = fallbackRepo
+	}
+	return strings.ToLower(repository) + "#" + strconv.Itoa(issue.Number)
 }
 
 func linkedIssuesFromBody(repo string, body string) []workbench.IssueRef {
@@ -799,8 +828,9 @@ func linkedIssuesFromBody(repo string, body string) []workbench.IssueRef {
 			continue
 		}
 		issues = append(issues, workbench.IssueRef{
-			Number:  number,
-			Certain: true,
+			Number:     number,
+			Repository: repo,
+			Certain:    true,
 		})
 		seen[number] = true
 	}

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -105,7 +105,7 @@ query($owner:String!, $name:String!, $after:String) {
 	issueCommentCountsQuery = `
 query($owner:String!, $name:String!, $after:String) {
   repository(owner:$owner, name:$name) {
-    issues(first:100, after:$after, states:[OPEN, CLOSED], orderBy:{field:UPDATED_AT, direction:DESC}) {
+    issues(first:100, after:$after, states:[OPEN, CLOSED], orderBy:{field:CREATED_AT, direction:DESC}) {
       nodes {
         number
         comments {

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -122,7 +122,7 @@ query($owner:String!, $name:String!, $after:String) {
 )
 
 var (
-	closingIssueReferencePattern = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b:?\s+#(\d+)\b`)
+	closingIssueReferencePattern = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b:?\s+(?:#(\d+)\b|([[:alnum:]_.-]+)/([[:alnum:]_.-]+)#(\d+)\b|https://github\.com/([[:alnum:]_.-]+)/([[:alnum:]_.-]+)/issues/(\d+)\b)`)
 )
 
 // Error describes a gh-backed service failure.
@@ -218,7 +218,7 @@ func (s CLIService) PullRequests(ctx context.Context, repo string) ([]workbench.
 			BaseBranch:     pr.BaseRefName,
 			IsDraft:        pr.IsDraft,
 			UpdatedAt:      pr.UpdatedAt,
-			LinkedIssues:   linkedIssues(closingIssuesByPR[pr.Number], pr.Body),
+			LinkedIssues:   linkedIssues(closingIssuesByPR[pr.Number], repo, pr.Body),
 			ReviewState:    reviewState(pr.ReviewDecision),
 			ReviewRequests: reviewRequests(pr.ReviewRequests),
 			LatestReviews:  latestReviews(pr.LatestReviews),
@@ -742,7 +742,7 @@ func logLines(value string) []string {
 	return strings.Split(value, "\n")
 }
 
-func linkedIssues(closingIssues []workbench.IssueRef, body string) []workbench.IssueRef {
+func linkedIssues(closingIssues []workbench.IssueRef, repo string, body string) []workbench.IssueRef {
 	issues := append([]workbench.IssueRef(nil), closingIssues...)
 	seen := map[int]bool{}
 	for _, issue := range issues {
@@ -750,7 +750,7 @@ func linkedIssues(closingIssues []workbench.IssueRef, body string) []workbench.I
 			seen[issue.Number] = true
 		}
 	}
-	for _, issue := range linkedIssuesFromBody(body) {
+	for _, issue := range linkedIssuesFromBody(repo, body) {
 		if issue.Number == 0 || seen[issue.Number] {
 			continue
 		}
@@ -774,14 +774,27 @@ func issuesFromGraphQL(payload []ghIssue) []workbench.IssueRef {
 	return issues
 }
 
-func linkedIssuesFromBody(body string) []workbench.IssueRef {
+func linkedIssuesFromBody(repo string, body string) []workbench.IssueRef {
 	seen := map[int]bool{}
 	issues := []workbench.IssueRef{}
 	for _, match := range closingIssueReferencePattern.FindAllStringSubmatch(body, -1) {
-		if len(match) < 2 {
+		if len(match) < 8 {
 			continue
 		}
-		number, err := strconv.Atoi(match[1])
+		numberText := match[1]
+		referenceRepo := repo
+		switch {
+		case match[4] != "":
+			referenceRepo = match[2] + "/" + match[3]
+			numberText = match[4]
+		case match[7] != "":
+			referenceRepo = match[5] + "/" + match[6]
+			numberText = match[7]
+		}
+		if !strings.EqualFold(referenceRepo, repo) {
+			continue
+		}
+		number, err := strconv.Atoi(numberText)
 		if err != nil || seen[number] {
 			continue
 		}

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -85,7 +85,7 @@ query($owner:String!, $name:String!, $after:String) {
     pullRequests(first:100, after:$after, states:[OPEN, CLOSED, MERGED], orderBy:{field:UPDATED_AT, direction:DESC}) {
       nodes {
         number
-        closingIssuesReferences(first:20) {
+        closingIssuesReferences(first:100) {
           nodes {
             number
             title
@@ -95,11 +95,37 @@ query($owner:String!, $name:String!, $after:String) {
               nameWithOwner
             }
           }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
         }
       }
       pageInfo {
         hasNextPage
         endCursor
+      }
+    }
+  }
+}`
+	pullRequestClosingIssuePageQuery = `
+query($owner:String!, $name:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      closingIssuesReferences(first:100, after:$after) {
+        nodes {
+          number
+          title
+          state
+          url
+          repository {
+            nameWithOwner
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
       }
     }
   }
@@ -259,11 +285,9 @@ func (s CLIService) IssuesWithOptions(ctx context.Context, repo string, opts wor
 		return nil, fmt.Errorf("parse gh issue list output: %w", err)
 	}
 	commentCounts := map[int]int{}
+	var commentCountsErr error
 	if opts.IncludeCommentsCount {
-		commentCounts, err = s.issueCommentCounts(ctx, repo)
-		if err != nil {
-			return nil, fmt.Errorf("load issue comment counts: %w", err)
-		}
+		commentCounts, commentCountsErr = s.issueCommentCounts(ctx, repo)
 	}
 	issues := make([]workbench.IssueRef, 0, len(payload))
 	for _, issue := range payload {
@@ -282,6 +306,9 @@ func (s CLIService) IssuesWithOptions(ctx context.Context, repo string, opts wor
 			UpdatedAt:     issue.UpdatedAt,
 			Certain:       true,
 		})
+	}
+	if commentCountsErr != nil {
+		return issues, fmt.Errorf("load issue comment counts: %w", commentCountsErr)
 	}
 	return issues, nil
 }
@@ -471,6 +498,7 @@ func (s CLIService) pullRequestClosingIssues(ctx context.Context, repo string) (
 
 	issuesByPR := map[int][]workbench.IssueRef{}
 	after := ""
+	fetched := 0
 	for {
 		output, err := s.runner().Run(ctx, "api", "graphql", "-f", "owner="+owner, "-f", "name="+name, "-f", "after="+after, "-f", "query="+pullRequestClosingIssuesQuery)
 		if err != nil {
@@ -483,7 +511,11 @@ func (s CLIService) pullRequestClosingIssues(ctx context.Context, repo string) (
 						Nodes []struct {
 							Number        int `json:"number"`
 							ClosingIssues struct {
-								Nodes []ghIssue `json:"nodes"`
+								Nodes    []ghIssue `json:"nodes"`
+								PageInfo struct {
+									HasNextPage bool   `json:"hasNextPage"`
+									EndCursor   string `json:"endCursor"`
+								} `json:"pageInfo"`
 							} `json:"closingIssuesReferences"`
 						} `json:"nodes"`
 						PageInfo struct {
@@ -498,11 +530,22 @@ func (s CLIService) pullRequestClosingIssues(ctx context.Context, repo string) (
 			return issuesByPR, fmt.Errorf("parse gh pull request closing issues output: %w", err)
 		}
 		for _, pr := range payload.Data.Repository.PullRequests.Nodes {
-			if pr.Number > 0 {
-				issuesByPR[pr.Number] = issuesFromGraphQL(pr.ClosingIssues.Nodes, repo)
+			if pr.Number <= 0 {
+				continue
 			}
+			closingIssues := append([]ghIssue(nil), pr.ClosingIssues.Nodes...)
+			if pr.ClosingIssues.PageInfo.HasNextPage && pr.ClosingIssues.PageInfo.EndCursor != "" {
+				additional, err := s.pullRequestClosingIssuePages(ctx, owner, name, pr.Number, pr.ClosingIssues.PageInfo.EndCursor)
+				closingIssues = append(closingIssues, additional...)
+				if err != nil {
+					issuesByPR[pr.Number] = issuesFromGraphQL(closingIssues, repo)
+					return issuesByPR, err
+				}
+			}
+			issuesByPR[pr.Number] = issuesFromGraphQL(closingIssues, repo)
 		}
-		if !payload.Data.Repository.PullRequests.PageInfo.HasNextPage {
+		fetched += len(payload.Data.Repository.PullRequests.Nodes)
+		if !payload.Data.Repository.PullRequests.PageInfo.HasNextPage || fetched >= listLimitCount {
 			return issuesByPR, nil
 		}
 		after = payload.Data.Repository.PullRequests.PageInfo.EndCursor
@@ -510,6 +553,41 @@ func (s CLIService) pullRequestClosingIssues(ctx context.Context, repo string) (
 			return issuesByPR, nil
 		}
 	}
+}
+
+func (s CLIService) pullRequestClosingIssuePages(ctx context.Context, owner string, name string, number int, after string) ([]ghIssue, error) {
+	var issues []ghIssue
+	for after != "" {
+		output, err := s.runner().Run(ctx, "api", "graphql", "-f", "owner="+owner, "-f", "name="+name, "-F", "number="+strconv.Itoa(number), "-f", "after="+after, "-f", "query="+pullRequestClosingIssuePageQuery)
+		if err != nil {
+			return issues, err
+		}
+		var payload struct {
+			Data struct {
+				Repository struct {
+					PullRequest struct {
+						ClosingIssues struct {
+							Nodes    []ghIssue `json:"nodes"`
+							PageInfo struct {
+								HasNextPage bool   `json:"hasNextPage"`
+								EndCursor   string `json:"endCursor"`
+							} `json:"pageInfo"`
+						} `json:"closingIssuesReferences"`
+					} `json:"pullRequest"`
+				} `json:"repository"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(output, &payload); err != nil {
+			return issues, fmt.Errorf("parse gh pull request closing issue page output: %w", err)
+		}
+		connection := payload.Data.Repository.PullRequest.ClosingIssues
+		issues = append(issues, connection.Nodes...)
+		if !connection.PageInfo.HasNextPage || connection.PageInfo.EndCursor == "" {
+			return issues, nil
+		}
+		after = connection.PageInfo.EndCursor
+	}
+	return issues, nil
 }
 
 func (s CLIService) issueCommentCounts(ctx context.Context, repo string) (map[int]int, error) {

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -51,8 +51,9 @@ const (
 	ErrorNetwork ErrorKind = "network"
 	ErrorCommand ErrorKind = "command"
 
-	issueListFields = "number,title,state,url,body,labels,assignees,milestone,author,comments,updatedAt"
+	issueListFields = "number,title,state,url,body,labels,assignees,milestone,author,updatedAt"
 	listLimit       = "1000"
+	listLimitCount  = 1000
 	prListFields    = "number,title,state,url,headRefName,headRepositoryOwner,baseRefName,isDraft,updatedAt,author,reviewRequests,latestReviews,reviewDecision,body"
 
 	pullRequestClosingIssuesQuery = `
@@ -68,6 +69,24 @@ query($owner:String!, $name:String!, $after:String) {
             state
             url
           }
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}`
+
+	issueCommentCountsQuery = `
+query($owner:String!, $name:String!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    issues(first:100, after:$after, states:[OPEN, CLOSED], orderBy:{field:UPDATED_AT, direction:DESC}) {
+      nodes {
+        number
+        comments {
+          totalCount
         }
       }
       pageInfo {
@@ -203,13 +222,13 @@ func (s CLIService) Issues(ctx context.Context, repo string) ([]workbench.IssueR
 		Milestone *struct {
 			Title string `json:"title"`
 		} `json:"milestone"`
-		Author    ghUser          `json:"author"`
-		Comments  ghCommentsCount `json:"comments"`
-		UpdatedAt string          `json:"updatedAt"`
+		Author    ghUser `json:"author"`
+		UpdatedAt string `json:"updatedAt"`
 	}
 	if err := json.Unmarshal(output, &payload); err != nil {
 		return nil, fmt.Errorf("parse gh issue list output: %w", err)
 	}
+	commentCounts, _ := s.issueCommentCounts(ctx, repo)
 	issues := make([]workbench.IssueRef, 0, len(payload))
 	for _, issue := range payload {
 		issues = append(issues, workbench.IssueRef{
@@ -222,7 +241,7 @@ func (s CLIService) Issues(ctx context.Context, repo string) ([]workbench.IssueR
 			Assignees:     userLogins(issue.Assignees),
 			Milestone:     milestoneTitle(issue.Milestone),
 			AuthorLogin:   issue.Author.Login,
-			CommentsCount: int(issue.Comments),
+			CommentsCount: commentCounts[issue.Number],
 			UpdatedAt:     issue.UpdatedAt,
 			Certain:       true,
 		})
@@ -318,6 +337,57 @@ func (s CLIService) pullRequestClosingIssues(ctx context.Context, repo string) (
 	}
 }
 
+func (s CLIService) issueCommentCounts(ctx context.Context, repo string) (map[int]int, error) {
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" {
+		return nil, nil
+	}
+
+	counts := map[int]int{}
+	after := ""
+	fetched := 0
+	for {
+		output, err := s.runner().Run(ctx, "api", "graphql", "-f", "owner="+owner, "-f", "name="+name, "-f", "after="+after, "-f", "query="+issueCommentCountsQuery)
+		if err != nil {
+			return counts, err
+		}
+		var payload struct {
+			Data struct {
+				Repository struct {
+					Issues struct {
+						Nodes []struct {
+							Number   int `json:"number"`
+							Comments struct {
+								TotalCount int `json:"totalCount"`
+							} `json:"comments"`
+						} `json:"nodes"`
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
+					} `json:"issues"`
+				} `json:"repository"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(output, &payload); err != nil {
+			return counts, fmt.Errorf("parse gh issue comment counts output: %w", err)
+		}
+		for _, issue := range payload.Data.Repository.Issues.Nodes {
+			if issue.Number > 0 {
+				counts[issue.Number] = issue.Comments.TotalCount
+			}
+		}
+		fetched += len(payload.Data.Repository.Issues.Nodes)
+		if !payload.Data.Repository.Issues.PageInfo.HasNextPage || fetched >= listLimitCount {
+			return counts, nil
+		}
+		after = payload.Data.Repository.Issues.PageInfo.EndCursor
+		if after == "" {
+			return counts, nil
+		}
+	}
+}
+
 func (s CLIService) runner() Runner {
 	if s.Runner != nil {
 		return s.Runner
@@ -327,32 +397,6 @@ func (s CLIService) runner() Runner {
 
 type ghUser struct {
 	Login string `json:"login"`
-}
-
-type ghCommentsCount int
-
-func (c *ghCommentsCount) UnmarshalJSON(data []byte) error {
-	var count int
-	if err := json.Unmarshal(data, &count); err == nil {
-		*c = ghCommentsCount(count)
-		return nil
-	}
-
-	var comments []json.RawMessage
-	if err := json.Unmarshal(data, &comments); err == nil {
-		*c = ghCommentsCount(len(comments))
-		return nil
-	}
-
-	var connection struct {
-		TotalCount int `json:"totalCount"`
-	}
-	if err := json.Unmarshal(data, &connection); err == nil {
-		*c = ghCommentsCount(connection.TotalCount)
-		return nil
-	}
-
-	return nil
 }
 
 type ghLabel struct {

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -51,7 +51,7 @@ const (
 	ErrorNetwork ErrorKind = "network"
 	ErrorCommand ErrorKind = "command"
 
-	issueListFields = "number,title,state,url,body,labels,assignees,milestone,updatedAt"
+	issueListFields = "number,title,state,url,body,labels,assignees,milestone,author,comments,updatedAt"
 	listLimit       = "1000"
 	prListFields    = "number,title,state,url,headRefName,headRepositoryOwner,baseRefName,isDraft,updatedAt,author,reviewRequests,latestReviews,reviewDecision,body"
 
@@ -203,7 +203,9 @@ func (s CLIService) Issues(ctx context.Context, repo string) ([]workbench.IssueR
 		Milestone *struct {
 			Title string `json:"title"`
 		} `json:"milestone"`
-		UpdatedAt string `json:"updatedAt"`
+		Author    ghUser          `json:"author"`
+		Comments  ghCommentsCount `json:"comments"`
+		UpdatedAt string          `json:"updatedAt"`
 	}
 	if err := json.Unmarshal(output, &payload); err != nil {
 		return nil, fmt.Errorf("parse gh issue list output: %w", err)
@@ -211,16 +213,18 @@ func (s CLIService) Issues(ctx context.Context, repo string) ([]workbench.IssueR
 	issues := make([]workbench.IssueRef, 0, len(payload))
 	for _, issue := range payload {
 		issues = append(issues, workbench.IssueRef{
-			Number:    issue.Number,
-			Title:     issue.Title,
-			State:     strings.ToLower(issue.State),
-			URL:       issue.URL,
-			Body:      issue.Body,
-			Labels:    labelNames(issue.Labels),
-			Assignees: userLogins(issue.Assignees),
-			Milestone: milestoneTitle(issue.Milestone),
-			UpdatedAt: issue.UpdatedAt,
-			Certain:   true,
+			Number:        issue.Number,
+			Title:         issue.Title,
+			State:         strings.ToLower(issue.State),
+			URL:           issue.URL,
+			Body:          issue.Body,
+			Labels:        labelNames(issue.Labels),
+			Assignees:     userLogins(issue.Assignees),
+			Milestone:     milestoneTitle(issue.Milestone),
+			AuthorLogin:   issue.Author.Login,
+			CommentsCount: int(issue.Comments),
+			UpdatedAt:     issue.UpdatedAt,
+			Certain:       true,
 		})
 	}
 	return issues, nil
@@ -323,6 +327,32 @@ func (s CLIService) runner() Runner {
 
 type ghUser struct {
 	Login string `json:"login"`
+}
+
+type ghCommentsCount int
+
+func (c *ghCommentsCount) UnmarshalJSON(data []byte) error {
+	var count int
+	if err := json.Unmarshal(data, &count); err == nil {
+		*c = ghCommentsCount(count)
+		return nil
+	}
+
+	var comments []json.RawMessage
+	if err := json.Unmarshal(data, &comments); err == nil {
+		*c = ghCommentsCount(len(comments))
+		return nil
+	}
+
+	var connection struct {
+		TotalCount int `json:"totalCount"`
+	}
+	if err := json.Unmarshal(data, &connection); err == nil {
+		*c = ghCommentsCount(connection.TotalCount)
+		return nil
+	}
+
+	return nil
 }
 
 type ghLabel struct {

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -140,6 +140,22 @@ func TestCLIService_PullRequestsPreservesClosingIssueRepository(t *testing.T) {
 	}
 }
 
+func TestCLIService_PullRequestsUsesGraphQLClosingIssuesAsAuthoritative(t *testing.T) {
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("pr", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", prListFields):                             []byte(`[{"number":12,"title":"Add feature","state":"OPEN","url":"https://example.test/pr/12","author":{"login":"0maru"},"headRefName":"feature","headRepositoryOwner":{"login":"0maru"},"baseRefName":"main","isDraft":false,"updatedAt":"2026-05-03T12:00:00Z","reviewRequests":[],"latestReviews":[],"body":"<!-- Fixes #10 -->"}]`),
+		commandKey("api", "graphql", "-f", "owner=0maru", "-f", "name=gh-zen", "-f", "after=", "-f", "query="+pullRequestClosingIssuesQuery): []byte(`{"data":{"repository":{"pullRequests":{"nodes":[{"number":12,"closingIssuesReferences":{"nodes":[]}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`),
+	}}
+
+	got, err := (CLIService{Runner: runner}).PullRequests(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("expected pull requests to parse, got %v", err)
+	}
+	if len(got) != 1 || len(got[0].LinkedIssues) != 0 {
+		t.Fatalf("expected hidden Markdown references to be excluded by GraphQL, got %+v", got)
+	}
+}
+
 func TestLinkedIssuesFromBodyRequiresClosingKeywordForEachIssue(t *testing.T) {
 	body := "Fixes #1 and see #2. Resolves: #3, closes #1. Mentions #4."
 

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -234,6 +234,19 @@ func TestCLIService_IssuesWithOptionsDefersCommentCounts(t *testing.T) {
 	}
 }
 
+func TestCLIService_IssuesWithOptionsReportsCommentCountFailure(t *testing.T) {
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("issue", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", issueListFields): []byte(`[{"number":9,"title":"Config","state":"OPEN","url":"https://example.test/issues/9","body":"Issue details","labels":[],"assignees":[],"milestone":null,"author":{"login":"alice"},"updatedAt":"2026-05-03T12:00:00Z"}]`),
+	}}
+	service := CLIService{Runner: runner}
+
+	_, err := service.IssuesWithOptions(context.Background(), repo, workbench.IssueListOptions{IncludeCommentsCount: true})
+	if err == nil || !strings.Contains(err.Error(), "load issue comment counts") {
+		t.Fatalf("expected comment count failure to be reported, got %v", err)
+	}
+}
+
 func TestCLIService_CheckSummaryParsesGHOutput(t *testing.T) {
 	runner := &fakeRunner{output: []byte(`[{"name":"test","state":"SUCCESS"},{"name":"lint","state":"FAILURE"},{"name":"build","state":"PENDING"}]`)}
 	service := CLIService{Runner: runner}

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -119,10 +119,14 @@ func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
 }
 
 func TestCLIService_IssuesParsesGHOutput(t *testing.T) {
-	runner := &fakeRunner{output: []byte(`[{"number":9,"title":"Config","state":"OPEN","url":"https://example.test/issues/9","body":"Issue details","labels":[{"name":"enhancement"}],"assignees":[{"login":"0maru"}],"milestone":{"title":"v1"},"author":{"login":"alice"},"comments":3,"updatedAt":"2026-05-03T12:00:00Z"}]`)}
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("issue", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", issueListFields):                 []byte(`[{"number":9,"title":"Config","state":"OPEN","url":"https://example.test/issues/9","body":"Issue details","labels":[{"name":"enhancement"}],"assignees":[{"login":"0maru"}],"milestone":{"title":"v1"},"author":{"login":"alice"},"updatedAt":"2026-05-03T12:00:00Z"}]`),
+		commandKey("api", "graphql", "-f", "owner=0maru", "-f", "name=gh-zen", "-f", "after=", "-f", "query="+issueCommentCountsQuery): []byte(`{"data":{"repository":{"issues":{"nodes":[{"number":9,"comments":{"totalCount":3}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`),
+	}}
 	service := CLIService{Runner: runner}
 
-	got, err := service.Issues(context.Background(), "0maru/gh-zen")
+	got, err := service.Issues(context.Background(), repo)
 	if err != nil {
 		t.Fatalf("expected issues to parse, got %v", err)
 	}
@@ -143,11 +147,14 @@ func TestCLIService_IssuesParsesGHOutput(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected %+v, got %+v", want, got)
 	}
-	if !hasArgPair(runner.args, "--limit", listLimit) {
-		t.Fatalf("expected gh issue list limit, got %#v", runner.args)
+	if !hasArgPair(runner.calls[0], "--limit", listLimit) {
+		t.Fatalf("expected gh issue list limit, got %#v", runner.calls)
 	}
-	if !hasArgValue(runner.args, issueListFields) {
-		t.Fatalf("expected gh issue list to request issue detail fields, got %#v", runner.args)
+	if !hasArgValue(runner.calls[0], issueListFields) {
+		t.Fatalf("expected gh issue list to request issue detail fields, got %#v", runner.calls)
+	}
+	if strings.Contains(issueListFields, "comments") {
+		t.Fatalf("expected gh issue list not to request comment bodies, got %q", issueListFields)
 	}
 }
 
@@ -187,6 +194,7 @@ func TestCLIService_ProvidesDataForWorkbenchEnrichment(t *testing.T) {
 		commandKey("pr", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", prListFields):                  []byte(`[{"number":24,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/pull/24","author":{"login":"0maru"},"headRefName":"feature/issue-123-runtime","headRepositoryOwner":{"login":"0maru"},"baseRefName":"main","isDraft":false,"updatedAt":"2026-05-03T12:00:00Z","reviewDecision":"APPROVED","reviewRequests":[],"latestReviews":[],"body":"Closes #123"}]`),
 		commandKey("api", "graphql", "-f", "owner=0maru", "-f", "name=gh-zen", "-f", "after=", "-f", "query="+pullRequestClosingIssuesQuery): []byte(`{"data":{"repository":{"pullRequests":{"nodes":[{"number":24,"closingIssuesReferences":{"nodes":[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123"}]}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`),
 		commandKey("issue", "list", "--repo", repo.FullName(), "--state", "all", "--limit", listLimit, "--json", issueListFields):            []byte(`[{"number":123,"title":"Runtime pipeline","state":"OPEN","url":"https://example.test/issues/123","body":"Runtime issue","labels":[],"assignees":[],"milestone":null,"updatedAt":"2026-05-03T12:00:00Z"}]`),
+		commandKey("api", "graphql", "-f", "owner=0maru", "-f", "name=gh-zen", "-f", "after=", "-f", "query="+issueCommentCountsQuery):       []byte(`{"data":{"repository":{"issues":{"nodes":[{"number":123,"comments":{"totalCount":2}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`),
 		commandKey("pr", "checks", "feature/issue-123-runtime", "--repo", repo.FullName(), "--json", "name,state"):                           []byte(`[{"name":"test","state":"SUCCESS"},{"name":"lint","state":"SUCCESS"}]`),
 	}}
 	service := CLIService{Runner: runner}
@@ -221,8 +229,8 @@ func TestCLIService_ProvidesDataForWorkbenchEnrichment(t *testing.T) {
 	if items[0].Checks.State != workbench.CheckPassing || items[0].Checks.Passing != 2 {
 		t.Fatalf("expected CLI check data to enrich work item, got %+v", items[0])
 	}
-	if len(runner.calls) != 4 {
-		t.Fatalf("expected four gh calls, got %#v", runner.calls)
+	if len(runner.calls) != 5 {
+		t.Fatalf("expected five gh calls, got %#v", runner.calls)
 	}
 }
 

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -93,7 +93,7 @@ func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
 		BaseBranch:  "main",
 		UpdatedAt:   "2026-05-03T12:00:00Z",
 		LinkedIssues: []workbench.IssueRef{
-			{Number: 9, Title: "Issue", State: "open", URL: "https://example.test/issues/9", Certain: true},
+			{Number: 9, Repository: repo, Title: "Issue", State: "open", URL: "https://example.test/issues/9", Certain: true},
 		},
 		ReviewState: "review required",
 		ReviewRequests: []workbench.ReviewRequestRef{
@@ -118,13 +118,35 @@ func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
 	}
 }
 
+func TestCLIService_PullRequestsPreservesClosingIssueRepository(t *testing.T) {
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("pr", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", prListFields):                             []byte(`[{"number":12,"title":"Add feature","state":"OPEN","url":"https://example.test/pr/12","author":{"login":"0maru"},"headRefName":"feature","headRepositoryOwner":{"login":"0maru"},"baseRefName":"main","isDraft":false,"updatedAt":"2026-05-03T12:00:00Z","reviewRequests":[],"latestReviews":[],"body":"No fallback"}]`),
+		commandKey("api", "graphql", "-f", "owner=0maru", "-f", "name=gh-zen", "-f", "after=", "-f", "query="+pullRequestClosingIssuesQuery): []byte(`{"data":{"repository":{"pullRequests":{"nodes":[{"number":12,"closingIssuesReferences":{"nodes":[{"number":9,"title":"Local","state":"OPEN","url":"https://example.test/0maru/gh-zen/issues/9","repository":{"nameWithOwner":"0maru/gh-zen"}},{"number":9,"title":"External","state":"OPEN","url":"https://example.test/other/repo/issues/9","repository":{"nameWithOwner":"other/repo"}}]}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`),
+	}}
+
+	got, err := (CLIService{Runner: runner}).PullRequests(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("expected pull requests to parse, got %v", err)
+	}
+	if len(got) != 1 || len(got[0].LinkedIssues) != 2 {
+		t.Fatalf("expected both repository-qualified closing issues, got %+v", got)
+	}
+	if got[0].LinkedIssues[0].Repository != repo || got[0].LinkedIssues[1].Repository != "other/repo" {
+		t.Fatalf("expected closing issue repositories to be preserved, got %+v", got[0].LinkedIssues)
+	}
+	if !strings.Contains(pullRequestClosingIssuesQuery, "nameWithOwner") {
+		t.Fatalf("expected closing issue query to request repository identity, got %q", pullRequestClosingIssuesQuery)
+	}
+}
+
 func TestLinkedIssuesFromBodyRequiresClosingKeywordForEachIssue(t *testing.T) {
 	body := "Fixes #1 and see #2. Resolves: #3, closes #1. Mentions #4."
 
 	got := linkedIssuesFromBody("0maru/gh-zen", body)
 	want := []workbench.IssueRef{
-		{Number: 1, Certain: true},
-		{Number: 3, Certain: true},
+		{Number: 1, Repository: "0maru/gh-zen", Certain: true},
+		{Number: 3, Repository: "0maru/gh-zen", Certain: true},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected only explicit closing references %+v, got %+v", want, got)
@@ -141,8 +163,8 @@ func TestLinkedIssuesFromBodyAcceptsQualifiedReferencesForSameRepository(t *test
 
 	got := linkedIssuesFromBody("0maru/gh-zen", body)
 	want := []workbench.IssueRef{
-		{Number: 1, Certain: true},
-		{Number: 2, Certain: true},
+		{Number: 1, Repository: "0maru/gh-zen", Certain: true},
+		{Number: 2, Repository: "0maru/gh-zen", Certain: true},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected only same-repository closing references %+v, got %+v", want, got)
@@ -163,6 +185,7 @@ func TestCLIService_IssuesParsesGHOutput(t *testing.T) {
 	}
 	want := []workbench.IssueRef{{
 		Number:        9,
+		Repository:    repo,
 		Title:         "Config",
 		State:         "open",
 		URL:           "https://example.test/issues/9",
@@ -189,6 +212,25 @@ func TestCLIService_IssuesParsesGHOutput(t *testing.T) {
 	}
 	if !strings.Contains(issueCommentCountsQuery, "field:CREATED_AT") || strings.Contains(issueCommentCountsQuery, "field:UPDATED_AT") {
 		t.Fatalf("expected issue comment count query to match gh issue list ordering, got %q", issueCommentCountsQuery)
+	}
+}
+
+func TestCLIService_IssuesWithOptionsDefersCommentCounts(t *testing.T) {
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("issue", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", issueListFields): []byte(`[{"number":9,"title":"Config","state":"OPEN","url":"https://example.test/issues/9","body":"Issue details","labels":[],"assignees":[],"milestone":null,"author":{"login":"alice"},"updatedAt":"2026-05-03T12:00:00Z"}]`),
+	}}
+	service := CLIService{Runner: runner}
+
+	got, err := service.IssuesWithOptions(context.Background(), repo, workbench.IssueListOptions{})
+	if err != nil {
+		t.Fatalf("expected lightweight issues to parse, got %v", err)
+	}
+	if len(got) != 1 || got[0].Number != 9 || got[0].CommentsCount != 0 {
+		t.Fatalf("expected issue without comment count, got %+v", got)
+	}
+	if len(runner.calls) != 1 || runner.calls[0][0] != "issue" {
+		t.Fatalf("expected only gh issue list without GraphQL comment pagination, got %#v", runner.calls)
 	}
 }
 

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -121,13 +121,31 @@ func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
 func TestLinkedIssuesFromBodyRequiresClosingKeywordForEachIssue(t *testing.T) {
 	body := "Fixes #1 and see #2. Resolves: #3, closes #1. Mentions #4."
 
-	got := linkedIssuesFromBody(body)
+	got := linkedIssuesFromBody("0maru/gh-zen", body)
 	want := []workbench.IssueRef{
 		{Number: 1, Certain: true},
 		{Number: 3, Certain: true},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected only explicit closing references %+v, got %+v", want, got)
+	}
+}
+
+func TestLinkedIssuesFromBodyAcceptsQualifiedReferencesForSameRepository(t *testing.T) {
+	body := strings.Join([]string{
+		"Fixes 0maru/gh-zen#1.",
+		"Resolves https://github.com/0MARU/GH-ZEN/issues/2.",
+		"Closes other/repo#3.",
+		"Fixes https://github.com/other/repo/issues/4.",
+	}, " ")
+
+	got := linkedIssuesFromBody("0maru/gh-zen", body)
+	want := []workbench.IssueRef{
+		{Number: 1, Certain: true},
+		{Number: 2, Certain: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected only same-repository closing references %+v, got %+v", want, got)
 	}
 }
 

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -119,7 +119,7 @@ func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
 }
 
 func TestCLIService_IssuesParsesGHOutput(t *testing.T) {
-	runner := &fakeRunner{output: []byte(`[{"number":9,"title":"Config","state":"OPEN","url":"https://example.test/issues/9","body":"Issue details","labels":[{"name":"enhancement"}],"assignees":[{"login":"0maru"}],"milestone":{"title":"v1"},"updatedAt":"2026-05-03T12:00:00Z"}]`)}
+	runner := &fakeRunner{output: []byte(`[{"number":9,"title":"Config","state":"OPEN","url":"https://example.test/issues/9","body":"Issue details","labels":[{"name":"enhancement"}],"assignees":[{"login":"0maru"}],"milestone":{"title":"v1"},"author":{"login":"alice"},"comments":3,"updatedAt":"2026-05-03T12:00:00Z"}]`)}
 	service := CLIService{Runner: runner}
 
 	got, err := service.Issues(context.Background(), "0maru/gh-zen")
@@ -127,16 +127,18 @@ func TestCLIService_IssuesParsesGHOutput(t *testing.T) {
 		t.Fatalf("expected issues to parse, got %v", err)
 	}
 	want := []workbench.IssueRef{{
-		Number:    9,
-		Title:     "Config",
-		State:     "open",
-		URL:       "https://example.test/issues/9",
-		Body:      "Issue details",
-		Labels:    []string{"enhancement"},
-		Assignees: []string{"0maru"},
-		Milestone: "v1",
-		UpdatedAt: "2026-05-03T12:00:00Z",
-		Certain:   true,
+		Number:        9,
+		Title:         "Config",
+		State:         "open",
+		URL:           "https://example.test/issues/9",
+		Body:          "Issue details",
+		Labels:        []string{"enhancement"},
+		Assignees:     []string{"0maru"},
+		Milestone:     "v1",
+		AuthorLogin:   "alice",
+		CommentsCount: 3,
+		UpdatedAt:     "2026-05-03T12:00:00Z",
+		Certain:       true,
 	}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected %+v, got %+v", want, got)

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -156,6 +156,9 @@ func TestCLIService_IssuesParsesGHOutput(t *testing.T) {
 	if strings.Contains(issueListFields, "comments") {
 		t.Fatalf("expected gh issue list not to request comment bodies, got %q", issueListFields)
 	}
+	if !strings.Contains(issueCommentCountsQuery, "field:CREATED_AT") || strings.Contains(issueCommentCountsQuery, "field:UPDATED_AT") {
+		t.Fatalf("expected issue comment count query to match gh issue list ordering, got %q", issueCommentCountsQuery)
+	}
 }
 
 func TestCLIService_CheckSummaryParsesGHOutput(t *testing.T) {

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -118,6 +118,19 @@ func TestCLIService_PullRequestsParsesGHOutput(t *testing.T) {
 	}
 }
 
+func TestLinkedIssuesFromBodyRequiresClosingKeywordForEachIssue(t *testing.T) {
+	body := "Fixes #1 and see #2. Resolves: #3, closes #1. Mentions #4."
+
+	got := linkedIssuesFromBody(body)
+	want := []workbench.IssueRef{
+		{Number: 1, Certain: true},
+		{Number: 3, Certain: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected only explicit closing references %+v, got %+v", want, got)
+	}
+}
+
 func TestCLIService_IssuesParsesGHOutput(t *testing.T) {
 	repo := "0maru/gh-zen"
 	runner := &fakeRunnerByCommand{outputs: map[string][]byte{

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -46,6 +47,12 @@ func (r *fakeRunnerByCommand) Run(_ context.Context, args ...string) ([]byte, er
 		return nil, errors.New("unexpected gh command: " + key)
 	}
 	return output, nil
+}
+
+func closingIssuePullRequestPage(nodeCount int, hasNext bool, endCursor string) []byte {
+	node := `{"number":1,"closingIssuesReferences":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}}`
+	nodes := strings.TrimSuffix(strings.Repeat(node+",", nodeCount), ",")
+	return []byte(`{"data":{"repository":{"pullRequests":{"nodes":[` + nodes + `],"pageInfo":{"hasNextPage":` + strconv.FormatBool(hasNext) + `,"endCursor":"` + endCursor + `"}}}}}`)
 }
 
 func TestFakeService_ReturnsRepositorySummary(t *testing.T) {
@@ -156,6 +163,43 @@ func TestCLIService_PullRequestsUsesGraphQLClosingIssuesAsAuthoritative(t *testi
 	}
 }
 
+func TestCLIService_PullRequestsPaginatesClosingIssuesForEachPullRequest(t *testing.T) {
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("pr", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", prListFields):                                                               []byte(`[{"number":12,"title":"Add feature","state":"OPEN","url":"https://example.test/pr/12","headRefName":"feature","headRepositoryOwner":{"login":"0maru"},"baseRefName":"main","reviewRequests":[],"latestReviews":[],"body":""}]`),
+		commandKey("api", "graphql", "-f", "owner=0maru", "-f", "name=gh-zen", "-f", "after=", "-f", "query="+pullRequestClosingIssuesQuery):                                   []byte(`{"data":{"repository":{"pullRequests":{"nodes":[{"number":12,"closingIssuesReferences":{"nodes":[{"number":1,"title":"First","state":"OPEN","url":"https://example.test/issues/1"}],"pageInfo":{"hasNextPage":true,"endCursor":"issue-page-2"}}}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`),
+		commandKey("api", "graphql", "-f", "owner=0maru", "-f", "name=gh-zen", "-F", "number=12", "-f", "after=issue-page-2", "-f", "query="+pullRequestClosingIssuePageQuery): []byte(`{"data":{"repository":{"pullRequest":{"closingIssuesReferences":{"nodes":[{"number":101,"title":"Later","state":"CLOSED","url":"https://example.test/issues/101"}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}}`),
+	}}
+
+	got, err := (CLIService{Runner: runner}).PullRequests(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("expected closing issues to paginate, got %v", err)
+	}
+	if len(got) != 1 || len(got[0].LinkedIssues) != 2 || got[0].LinkedIssues[1].Number != 101 {
+		t.Fatalf("expected closing issue from the later page, got %+v", got)
+	}
+}
+
+func TestCLIService_PullRequestClosingIssuesStopsAtListLimit(t *testing.T) {
+	repo := "0maru/gh-zen"
+	outputs := map[string][]byte{}
+	after := ""
+	for page := 0; page < listLimitCount/100; page++ {
+		next := strconv.Itoa(page + 1)
+		outputs[commandKey("api", "graphql", "-f", "owner=0maru", "-f", "name=gh-zen", "-f", "after="+after, "-f", "query="+pullRequestClosingIssuesQuery)] = closingIssuePullRequestPage(100, true, next)
+		after = next
+	}
+	runner := &fakeRunnerByCommand{outputs: outputs}
+
+	_, err := (CLIService{Runner: runner}).pullRequestClosingIssues(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("expected closing issue pagination to stop cleanly, got %v", err)
+	}
+	if len(runner.calls) != listLimitCount/100 {
+		t.Fatalf("expected %d GraphQL pages for the PR list limit, got %d", listLimitCount/100, len(runner.calls))
+	}
+}
+
 func TestLinkedIssuesFromBodyRequiresClosingKeywordForEachIssue(t *testing.T) {
 	body := "Fixes #1 and see #2. Resolves: #3, closes #1. Mentions #4."
 
@@ -250,16 +294,19 @@ func TestCLIService_IssuesWithOptionsDefersCommentCounts(t *testing.T) {
 	}
 }
 
-func TestCLIService_IssuesWithOptionsReportsCommentCountFailure(t *testing.T) {
+func TestCLIService_IssuesWithOptionsPreservesIssuesAndReportsCommentCountFailure(t *testing.T) {
 	repo := "0maru/gh-zen"
 	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
 		commandKey("issue", "list", "--repo", repo, "--state", "all", "--limit", listLimit, "--json", issueListFields): []byte(`[{"number":9,"title":"Config","state":"OPEN","url":"https://example.test/issues/9","body":"Issue details","labels":[],"assignees":[],"milestone":null,"author":{"login":"alice"},"updatedAt":"2026-05-03T12:00:00Z"}]`),
 	}}
 	service := CLIService{Runner: runner}
 
-	_, err := service.IssuesWithOptions(context.Background(), repo, workbench.IssueListOptions{IncludeCommentsCount: true})
+	got, err := service.IssuesWithOptions(context.Background(), repo, workbench.IssueListOptions{IncludeCommentsCount: true})
 	if err == nil || !strings.Contains(err.Error(), "load issue comment counts") {
 		t.Fatalf("expected comment count failure to be reported, got %v", err)
+	}
+	if len(got) != 1 || got[0].Number != 9 || got[0].CommentsCount != 0 {
+		t.Fatalf("expected the successfully loaded issue with an unknown comment count, got %+v", got)
 	}
 }
 

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -200,6 +200,12 @@ func TestCLIService_PullRequestClosingIssuesStopsAtListLimit(t *testing.T) {
 	}
 }
 
+func TestCLIService_PullRequestClosingIssuesMatchesPullRequestListOrdering(t *testing.T) {
+	if !strings.Contains(pullRequestClosingIssuesQuery, "field:CREATED_AT") || strings.Contains(pullRequestClosingIssuesQuery, "field:UPDATED_AT") {
+		t.Fatalf("expected closing issue query to match gh pr list ordering, got %q", pullRequestClosingIssuesQuery)
+	}
+}
+
 func TestLinkedIssuesFromBodyRequiresClosingKeywordForEachIssue(t *testing.T) {
 	body := "Fixes #1 and see #2. Resolves: #3, closes #1. Mentions #4."
 

--- a/internal/localrepo/service_test.go
+++ b/internal/localrepo/service_test.go
@@ -332,6 +332,8 @@ func initTempGitRepo(t *testing.T) string {
 	runGit(t, dir, "init", "-b", "main")
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	runGit(t, dir, "config", "user.name", "Test User")
+	runGit(t, dir, "config", "commit.gpgsign", "false")
+	runGit(t, dir, "config", "tag.gpgsign", "false")
 	return dir
 }
 

--- a/internal/workbench/issue_link.go
+++ b/internal/workbench/issue_link.go
@@ -20,6 +20,16 @@ type IssueCheckDiscovery interface {
 	CheckSummary(ctx context.Context, repo string, ref string) (CheckSummary, error)
 }
 
+// IssueListOptions controls optional data that is expensive to load for every repository.
+type IssueListOptions struct {
+	IncludeCommentsCount bool
+}
+
+// IssueListDiscovery supports callers that can defer expensive issue metadata.
+type IssueListDiscovery interface {
+	IssuesWithOptions(ctx context.Context, repo string, opts IssueListOptions) ([]IssueRef, error)
+}
+
 // IssueCheckLinkService links issues and checks onto workbench items.
 type IssueCheckLinkService struct {
 	GitHub IssueCheckDiscovery
@@ -77,7 +87,7 @@ func LinkIssues(items []WorkItem, issues []IssueRef) []WorkItem {
 		if out[i].Issue != nil {
 			continue
 		}
-		if issue, ok := issueFromPullRequest(out[i].PullRequest); ok {
+		if issue, ok := issueFromPullRequest(out[i].PullRequest, out[i].Repo.FullName()); ok {
 			out[i].Issue = enrichIssue(issue, byNumber)
 			continue
 		}
@@ -130,12 +140,21 @@ func prefixedIssueNumbers(branch string) []int {
 	return numbers
 }
 
-func issueFromPullRequest(pr *PullRequestRef) (IssueRef, bool) {
+func issueFromPullRequest(pr *PullRequestRef, repo string) (IssueRef, bool) {
 	if pr == nil || len(pr.LinkedIssues) == 0 {
 		return IssueRef{}, false
 	}
-	issue := pr.LinkedIssues[0]
-	issue.Certain = len(pr.LinkedIssues) == 1
+	linkedIssues := make([]IssueRef, 0, len(pr.LinkedIssues))
+	for _, issue := range pr.LinkedIssues {
+		if issue.Repository == "" || strings.EqualFold(issue.Repository, repo) {
+			linkedIssues = append(linkedIssues, issue)
+		}
+	}
+	if len(linkedIssues) == 0 {
+		return IssueRef{}, false
+	}
+	issue := linkedIssues[0]
+	issue.Certain = len(linkedIssues) == 1
 	if issue.Source == IssueLinkSourceUnknown {
 		issue.Source = IssueLinkSourcePullRequest
 	}

--- a/internal/workbench/issue_link_test.go
+++ b/internal/workbench/issue_link_test.go
@@ -130,6 +130,23 @@ func TestLinkIssues_PreservesUncertainPullRequestMetadataSource(t *testing.T) {
 	}
 }
 
+func TestLinkIssues_IgnoresPullRequestIssuesFromOtherRepositories(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	items := []WorkItem{{
+		ID:   "feature",
+		Repo: repo,
+		PullRequest: &PullRequestRef{LinkedIssues: []IssueRef{
+			{Number: 10, Repository: "other/repo", Title: "External issue", Certain: true},
+			{Number: 11, Repository: repo.FullName(), Title: "Local issue", Certain: true},
+		}},
+	}}
+
+	got := LinkIssues(items, []IssueRef{{Number: 11, Repository: repo.FullName(), Title: "Local issue details", Certain: true}})
+	if got[0].Issue == nil || got[0].Issue.Number != 11 || got[0].Issue.Title != "Local issue details" {
+		t.Fatalf("expected only the local-repository closing issue to be linked, got %+v", got[0].Issue)
+	}
+}
+
 func TestLinkIssues_EnrichesBranchHeuristicFromIssueList(t *testing.T) {
 	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
 	items := []WorkItem{{

--- a/internal/workbench/local_service.go
+++ b/internal/workbench/local_service.go
@@ -23,6 +23,11 @@ type LocalWorkItemService struct {
 
 // WorkItems returns workbench items for local worktrees and branch refs.
 func (s LocalWorkItemService) WorkItems(ctx context.Context) []WorkItem {
+	items, _ := s.load(ctx)
+	return items
+}
+
+func (s LocalWorkItemService) load(ctx context.Context) ([]WorkItem, error) {
 	discovery := s.Discovery
 	if discovery == nil {
 		discovery = localrepo.Service{}
@@ -30,14 +35,14 @@ func (s LocalWorkItemService) WorkItems(ctx context.Context) []WorkItem {
 
 	worktrees, err := discovery.DiscoverWorktrees(ctx, s.RepoPath)
 	if err != nil {
-		return []WorkItem{localDiscoveryErrorItem(s.Repo, err)}
+		return []WorkItem{localDiscoveryErrorItem(s.Repo, err)}, err
 	}
 	branches, err := discovery.DiscoverBranches(ctx, s.RepoPath)
 	if err != nil {
-		return []WorkItem{localDiscoveryErrorItem(s.Repo, err)}
+		return []WorkItem{localDiscoveryErrorItem(s.Repo, err)}, err
 	}
 
-	return AssembleLocalWorkItems(s.Repo, worktrees, branches)
+	return AssembleLocalWorkItems(s.Repo, worktrees, branches), nil
 }
 
 // AssembleLocalWorkItems converts local discovery data into workbench work items.

--- a/internal/workbench/local_service_test.go
+++ b/internal/workbench/local_service_test.go
@@ -152,6 +152,8 @@ func initLocalServiceRepo(t *testing.T) string {
 	runLocalServiceGit(t, dir, "init", "-b", "main")
 	runLocalServiceGit(t, dir, "config", "user.email", "test@example.com")
 	runLocalServiceGit(t, dir, "config", "user.name", "Test User")
+	runLocalServiceGit(t, dir, "config", "commit.gpgsign", "false")
+	runLocalServiceGit(t, dir, "config", "tag.gpgsign", "false")
 	writeLocalServiceFile(t, filepath.Join(dir, "README.md"), "initial\n")
 	runLocalServiceGit(t, dir, "add", "README.md")
 	runLocalServiceGit(t, dir, "commit", "-m", "initial")

--- a/internal/workbench/runtime_loader.go
+++ b/internal/workbench/runtime_loader.go
@@ -47,25 +47,26 @@ func (l RuntimeLoader) Load(ctx context.Context) RuntimeLoadResult {
 	}
 
 	repoName := l.Repo.FullName()
+	var pullRequestErrors []error
+	subjects, err := reviewSubjects(ctx, l.GitHub)
+	if err != nil {
+		pullRequestErrors = append(pullRequestErrors, err)
+	}
+	result.ViewerSubject = subjects
+
 	prs, err := l.GitHub.PullRequests(ctx, repoName)
 	if err != nil {
-		items = append(cloneWorkItems(items), pullRequestDiscoveryErrorItem(l.Repo, err))
+		pullRequestErrors = append(pullRequestErrors, err)
 	} else {
-		var discoveryErrors []error
-		subjects, err := reviewSubjects(ctx, l.GitHub)
-		if err != nil {
-			discoveryErrors = append(discoveryErrors, err)
-		}
 		if !subjects.Empty() {
 			prs = ApplyReviewPerspective(prs, subjects)
 		}
 		result.PullRequests = append([]PullRequestRef(nil), prs...)
 		result.PullRequestsLoaded = true
-		result.ViewerSubject = subjects
 		items = LinkPullRequestsForRepo(l.Repo, items, prs)
-		if len(discoveryErrors) > 0 {
-			items = append(items, pullRequestDiscoveryErrorItem(l.Repo, errors.Join(discoveryErrors...)))
-		}
+	}
+	if len(pullRequestErrors) > 0 {
+		items = append(cloneWorkItems(items), pullRequestDiscoveryErrorItem(l.Repo, errors.Join(pullRequestErrors...)))
 	}
 
 	var discoveryErrors []error

--- a/internal/workbench/runtime_loader.go
+++ b/internal/workbench/runtime_loader.go
@@ -22,6 +22,7 @@ type RuntimeLoadResult struct {
 	Issues             []IssueRef
 	IssuesLoaded       bool
 	IssuesError        string
+	FailedCheckRefs    []string
 	ViewerSubject      ReviewSubjects
 }
 
@@ -93,6 +94,7 @@ func (l RuntimeLoader) Load(ctx context.Context) RuntimeLoadResult {
 		checks, err := l.GitHub.CheckSummary(ctx, repoName, ref)
 		if err != nil {
 			discoveryErrors = append(discoveryErrors, err)
+			result.FailedCheckRefs = append(result.FailedCheckRefs, ref)
 			if items[i].Checks.State == "" {
 				items[i].Checks = CheckSummary{State: CheckUnknown}
 			}

--- a/internal/workbench/runtime_loader.go
+++ b/internal/workbench/runtime_loader.go
@@ -1,6 +1,9 @@
 package workbench
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // GitHubWorkbenchDiscovery provides GitHub data needed by the runtime workbench loader.
 type GitHubWorkbenchDiscovery interface {
@@ -10,8 +13,13 @@ type GitHubWorkbenchDiscovery interface {
 
 // RuntimeLoadResult contains workbench data loaded for one repository.
 type RuntimeLoadResult struct {
-	Repo  RepoRef
-	Items []WorkItem
+	Repo               RepoRef
+	Items              []WorkItem
+	PullRequests       []PullRequestRef
+	PullRequestsLoaded bool
+	Issues             []IssueRef
+	IssuesLoaded       bool
+	ViewerSubject      ReviewSubjects
 }
 
 // RuntimeLoader composes local Git discovery with GitHub workbench enrichment.
@@ -30,15 +38,68 @@ func (l RuntimeLoader) Load(ctx context.Context) RuntimeLoadResult {
 		Discovery: l.Local,
 	}).WorkItems(ctx)
 
-	items = (PullRequestLinkService{
-		GitHub: l.GitHub,
-	}).LinkForRepo(ctx, l.Repo, items)
-	items = (IssueCheckLinkService{
-		GitHub: l.GitHub,
-	}).LinkForRepo(ctx, l.Repo, items)
-
-	return RuntimeLoadResult{
-		Repo:  l.Repo,
-		Items: items,
+	result := RuntimeLoadResult{Repo: l.Repo}
+	if l.GitHub == nil {
+		result.Items = items
+		return result
 	}
+
+	repoName := l.Repo.FullName()
+	prs, err := l.GitHub.PullRequests(ctx, repoName)
+	if err != nil {
+		items = append(cloneWorkItems(items), pullRequestDiscoveryErrorItem(l.Repo, err))
+	} else {
+		var discoveryErrors []error
+		subjects, err := reviewSubjects(ctx, l.GitHub)
+		if err != nil {
+			discoveryErrors = append(discoveryErrors, err)
+		}
+		if !subjects.Empty() {
+			prs = ApplyReviewPerspective(prs, subjects)
+		}
+		result.PullRequests = append([]PullRequestRef(nil), prs...)
+		result.PullRequestsLoaded = true
+		result.ViewerSubject = subjects
+		items = LinkPullRequestsForRepo(l.Repo, items, prs)
+		if len(discoveryErrors) > 0 {
+			items = append(items, pullRequestDiscoveryErrorItem(l.Repo, errors.Join(discoveryErrors...)))
+		}
+	}
+
+	var discoveryErrors []error
+	issues, err := l.GitHub.Issues(ctx, repoName)
+	if err != nil {
+		discoveryErrors = append(discoveryErrors, err)
+	} else {
+		result.Issues = append([]IssueRef(nil), issues...)
+		result.IssuesLoaded = true
+	}
+
+	items = LinkIssues(items, issues)
+	for i := range items {
+		if items[i].PullRequest == nil {
+			continue
+		}
+		ref := pullRequestCheckRef(items[i])
+		if ref == "" {
+			continue
+		}
+		checks, err := l.GitHub.CheckSummary(ctx, repoName, ref)
+		if err != nil {
+			discoveryErrors = append(discoveryErrors, err)
+			if items[i].Checks.State == "" {
+				items[i].Checks = CheckSummary{State: CheckUnknown}
+			}
+			continue
+		}
+		if checks.State != "" {
+			items[i].Checks = checks
+		}
+	}
+	if len(discoveryErrors) > 0 {
+		items = append(items, issueCheckDiscoveryErrorItem(l.Repo, errors.Join(discoveryErrors...)))
+	}
+
+	result.Items = items
+	return result
 }

--- a/internal/workbench/runtime_loader.go
+++ b/internal/workbench/runtime_loader.go
@@ -30,10 +30,11 @@ type RuntimeLoadResult struct {
 
 // RuntimeLoader composes local Git discovery with GitHub workbench enrichment.
 type RuntimeLoader struct {
-	Repo     RepoRef
-	RepoPath string
-	Local    LocalDiscovery
-	GitHub   GitHubWorkbenchDiscovery
+	Repo                      RepoRef
+	RepoPath                  string
+	Local                     LocalDiscovery
+	GitHub                    GitHubWorkbenchDiscovery
+	IncludeIssueCommentsCount bool
 }
 
 // Load returns workbench items for one repository without failing on partial GitHub discovery errors.
@@ -78,7 +79,7 @@ func (l RuntimeLoader) Load(ctx context.Context) RuntimeLoadResult {
 	}
 
 	var discoveryErrors []error
-	issues, err := l.GitHub.Issues(ctx, repoName)
+	issues, err := loadIssues(ctx, l.GitHub, repoName, l.IncludeIssueCommentsCount)
 	if err != nil {
 		discoveryErrors = append(discoveryErrors, err)
 		result.IssuesError = err.Error()
@@ -116,4 +117,11 @@ func (l RuntimeLoader) Load(ctx context.Context) RuntimeLoadResult {
 
 	result.Items = items
 	return result
+}
+
+func loadIssues(ctx context.Context, discovery GitHubWorkbenchDiscovery, repo string, includeComments bool) ([]IssueRef, error) {
+	if configurable, ok := discovery.(IssueListDiscovery); ok {
+		return configurable.IssuesWithOptions(ctx, repo, IssueListOptions{IncludeCommentsCount: includeComments})
+	}
+	return discovery.Issues(ctx, repo)
 }

--- a/internal/workbench/runtime_loader.go
+++ b/internal/workbench/runtime_loader.go
@@ -21,6 +21,7 @@ type RuntimeLoadResult struct {
 	IssuesRepo         RepoRef
 	Issues             []IssueRef
 	IssuesLoaded       bool
+	IssuesError        string
 	ViewerSubject      ReviewSubjects
 }
 
@@ -73,6 +74,7 @@ func (l RuntimeLoader) Load(ctx context.Context) RuntimeLoadResult {
 	issues, err := l.GitHub.Issues(ctx, repoName)
 	if err != nil {
 		discoveryErrors = append(discoveryErrors, err)
+		result.IssuesError = err.Error()
 	} else {
 		result.IssuesRepo = l.Repo
 		result.Issues = append([]IssueRef(nil), issues...)

--- a/internal/workbench/runtime_loader.go
+++ b/internal/workbench/runtime_loader.go
@@ -24,6 +24,7 @@ type RuntimeLoadResult struct {
 	IssuesError        string
 	FailedCheckRefs    []string
 	ViewerSubject      ReviewSubjects
+	ViewerSubjectError string
 }
 
 // RuntimeLoader composes local Git discovery with GitHub workbench enrichment.
@@ -53,6 +54,7 @@ func (l RuntimeLoader) Load(ctx context.Context) RuntimeLoadResult {
 	subjects, err := reviewSubjects(ctx, l.GitHub)
 	if err != nil {
 		pullRequestErrors = append(pullRequestErrors, err)
+		result.ViewerSubjectError = err.Error()
 	}
 	result.ViewerSubject = subjects
 

--- a/internal/workbench/runtime_loader.go
+++ b/internal/workbench/runtime_loader.go
@@ -18,6 +18,7 @@ type RuntimeLoadResult struct {
 	Items              []WorkItem
 	PullRequests       []PullRequestRef
 	PullRequestsLoaded bool
+	IssuesRepo         RepoRef
 	Issues             []IssueRef
 	IssuesLoaded       bool
 	ViewerSubject      ReviewSubjects
@@ -72,6 +73,7 @@ func (l RuntimeLoader) Load(ctx context.Context) RuntimeLoadResult {
 	if err != nil {
 		discoveryErrors = append(discoveryErrors, err)
 	} else {
+		result.IssuesRepo = l.Repo
 		result.Issues = append([]IssueRef(nil), issues...)
 		result.IssuesLoaded = true
 	}

--- a/internal/workbench/runtime_loader.go
+++ b/internal/workbench/runtime_loader.go
@@ -13,18 +13,19 @@ type GitHubWorkbenchDiscovery interface {
 
 // RuntimeLoadResult contains refreshed workbench data.
 type RuntimeLoadResult struct {
-	Repo               RepoRef
-	Repositories       []RepositorySummary
-	Items              []WorkItem
-	PullRequests       []PullRequestRef
-	PullRequestsLoaded bool
-	IssuesRepo         RepoRef
-	Issues             []IssueRef
-	IssuesLoaded       bool
-	IssuesError        string
-	FailedCheckRefs    []string
-	ViewerSubject      ReviewSubjects
-	ViewerSubjectError string
+	Repo                RepoRef
+	Repositories        []RepositorySummary
+	Items               []WorkItem
+	PullRequests        []PullRequestRef
+	PullRequestsLoaded  bool
+	IssuesRepo          RepoRef
+	Issues              []IssueRef
+	IssuesLoaded        bool
+	IssuesError         string
+	LocalDiscoveryError string
+	FailedCheckRefs     []string
+	ViewerSubject       ReviewSubjects
+	ViewerSubjectError  string
 }
 
 // RuntimeLoader composes local Git discovery with GitHub workbench enrichment.
@@ -37,13 +38,16 @@ type RuntimeLoader struct {
 
 // Load returns workbench items for one repository without failing on partial GitHub discovery errors.
 func (l RuntimeLoader) Load(ctx context.Context) RuntimeLoadResult {
-	items := (LocalWorkItemService{
+	items, localDiscoveryErr := (LocalWorkItemService{
 		Repo:      l.Repo,
 		RepoPath:  l.RepoPath,
 		Discovery: l.Local,
-	}).WorkItems(ctx)
+	}).load(ctx)
 
 	result := RuntimeLoadResult{Repo: l.Repo}
+	if localDiscoveryErr != nil {
+		result.LocalDiscoveryError = localDiscoveryErr.Error()
+	}
 	if l.GitHub == nil {
 		result.Items = items
 		return result

--- a/internal/workbench/runtime_loader.go
+++ b/internal/workbench/runtime_loader.go
@@ -83,7 +83,8 @@ func (l RuntimeLoader) Load(ctx context.Context) RuntimeLoadResult {
 	if err != nil {
 		discoveryErrors = append(discoveryErrors, err)
 		result.IssuesError = err.Error()
-	} else {
+	}
+	if issues != nil {
 		result.IssuesRepo = l.Repo
 		result.Issues = append([]IssueRef(nil), issues...)
 		result.IssuesLoaded = true

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -322,6 +322,9 @@ func TestRuntimeLoader_ContinuesWhenSingleCheckFails(t *testing.T) {
 	if second.Checks.State != CheckPassing || second.Checks.Passing != 2 {
 		t.Fatalf("expected later PR checks to be linked, got %+v", second.Checks)
 	}
+	if len(result.FailedCheckRefs) != 1 || result.FailedCheckRefs[0] != "first" {
+		t.Fatalf("expected failed check ref to be recorded, got %+v", result.FailedCheckRefs)
+	}
 	if !hasRuntimeErrorItem(result.Items, "issue and check discovery failed", "first checks failed") {
 		t.Fatalf("expected check discovery error item, got %+v", result.Items)
 	}

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -255,6 +255,9 @@ func TestRuntimeLoader_PreservesLocalItemsWhenGitHubFails(t *testing.T) {
 	if !hasRuntimeErrorItem(result.Items, "issue and check discovery failed", "network failed") {
 		t.Fatalf("expected issue and check discovery error item, got %+v", result.Items)
 	}
+	if !strings.Contains(result.IssuesError, "network failed") {
+		t.Fatalf("expected issue-specific error, got %q", result.IssuesError)
+	}
 }
 
 func TestRuntimeLoader_ReturnsLocalDiscoveryErrorItem(t *testing.T) {
@@ -321,6 +324,9 @@ func TestRuntimeLoader_ContinuesWhenSingleCheckFails(t *testing.T) {
 	}
 	if !hasRuntimeErrorItem(result.Items, "issue and check discovery failed", "first checks failed") {
 		t.Fatalf("expected check discovery error item, got %+v", result.Items)
+	}
+	if result.IssuesError != "" {
+		t.Fatalf("expected check failure not to set issue-specific error, got %q", result.IssuesError)
 	}
 }
 

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -170,6 +170,37 @@ func TestRuntimeLoader_ReturnsViewerSubjectWhenPullRequestsFail(t *testing.T) {
 	}
 }
 
+func TestRuntimeLoader_RecordsViewerSubjectFailure(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	result := RuntimeLoader{
+		Repo:     repo,
+		RepoPath: "/repo",
+		Local: fakeLocalDiscovery{
+			branches: []localrepo.Branch{{Name: "feature"}},
+		},
+		GitHub: fakeRuntimeGitHub{
+			subjectErr: errors.New("viewer unavailable"),
+			prs: []PullRequestRef{{
+				Number:     10,
+				State:      "open",
+				HeadOwner:  "0maru",
+				HeadBranch: "feature",
+			}},
+			issues: []IssueRef{},
+		},
+	}.Load(context.Background())
+
+	if !result.PullRequestsLoaded {
+		t.Fatalf("expected pull requests to remain loaded, got %+v", result)
+	}
+	if !strings.Contains(result.ViewerSubjectError, "viewer unavailable") {
+		t.Fatalf("expected viewer subject failure to be recorded, got %q", result.ViewerSubjectError)
+	}
+	if !hasRuntimeErrorItem(result.Items, "pull request discovery failed", "viewer unavailable") {
+		t.Fatalf("expected viewer subject error item, got %+v", result.Items)
+	}
+}
+
 func TestRuntimeLoader_AddsPullRequestBackedItems(t *testing.T) {
 	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
 	loader := RuntimeLoader{

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -144,6 +144,32 @@ func TestRuntimeLoader_ReturnsViewerSubjectForIssueFilters(t *testing.T) {
 	}
 }
 
+func TestRuntimeLoader_ReturnsViewerSubjectWhenPullRequestsFail(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	result := RuntimeLoader{
+		Repo:     repo,
+		RepoPath: "/repo",
+		Local: fakeLocalDiscovery{
+			branches: []localrepo.Branch{{Name: "main"}},
+		},
+		GitHub: fakeRuntimeGitHub{
+			prErr:    errors.New("pull requests unavailable"),
+			subjects: ReviewSubjects{Login: "0maru"},
+			issues:   []IssueRef{{Number: 75, Title: "Issue browsing", State: "open"}},
+		},
+	}.Load(context.Background())
+
+	if result.ViewerSubject.Login != "0maru" {
+		t.Fatalf("expected viewer subject despite pull request failure, got %+v", result.ViewerSubject)
+	}
+	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 75 {
+		t.Fatalf("expected issues to remain available, got loaded=%v issues=%+v", result.IssuesLoaded, result.Issues)
+	}
+	if !hasRuntimeErrorItem(result.Items, "pull request discovery failed", "pull requests unavailable") {
+		t.Fatalf("expected pull request error item, got %+v", result.Items)
+	}
+}
+
 func TestRuntimeLoader_AddsPullRequestBackedItems(t *testing.T) {
 	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
 	loader := RuntimeLoader{

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -100,6 +100,9 @@ func TestRuntimeLoader_LoadsLocalItemsAndGitHubEnrichment(t *testing.T) {
 	if result.Repo != repo {
 		t.Fatalf("expected repo %+v, got %+v", repo, result.Repo)
 	}
+	if result.LocalDiscoveryError != "" {
+		t.Fatalf("expected local discovery to succeed, got %q", result.LocalDiscoveryError)
+	}
 	if len(result.Items) != 1 {
 		t.Fatalf("expected one enriched item, got %+v", result.Items)
 	}
@@ -309,6 +312,9 @@ func TestRuntimeLoader_ReturnsLocalDiscoveryErrorItem(t *testing.T) {
 	}
 	if result.Items[0].Local == nil || !strings.Contains(result.Items[0].Local.Summary, "git failed") {
 		t.Fatalf("expected local discovery error summary, got %+v", result.Items[0].Local)
+	}
+	if !strings.Contains(result.LocalDiscoveryError, "git failed") {
+		t.Fatalf("expected local discovery error to be recorded, got %q", result.LocalDiscoveryError)
 	}
 }
 

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -103,6 +103,12 @@ func TestRuntimeLoader_LoadsLocalItemsAndGitHubEnrichment(t *testing.T) {
 	if len(result.Items) != 1 {
 		t.Fatalf("expected one enriched item, got %+v", result.Items)
 	}
+	if !result.PullRequestsLoaded || len(result.PullRequests) != 1 || result.PullRequests[0].Number != 24 {
+		t.Fatalf("expected raw pull requests in result, got loaded=%v prs=%+v", result.PullRequestsLoaded, result.PullRequests)
+	}
+	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 123 {
+		t.Fatalf("expected raw issues in result, got loaded=%v issues=%+v", result.IssuesLoaded, result.Issues)
+	}
 	item := result.Items[0]
 	if item.PullRequest == nil || item.PullRequest.Number != 24 || item.PullRequest.ReviewState != "approved" {
 		t.Fatalf("expected linked PR, got %+v", item.PullRequest)
@@ -112,6 +118,26 @@ func TestRuntimeLoader_LoadsLocalItemsAndGitHubEnrichment(t *testing.T) {
 	}
 	if item.Checks.State != CheckPassing || item.Checks.Passing != 2 {
 		t.Fatalf("expected passing checks, got %+v", item.Checks)
+	}
+}
+
+func TestRuntimeLoader_ReturnsViewerSubjectForIssueFilters(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	result := RuntimeLoader{
+		Repo:     repo,
+		RepoPath: "/repo",
+		Local: fakeLocalDiscovery{
+			branches: []localrepo.Branch{{Name: "main"}},
+		},
+		GitHub: fakeRuntimeGitHub{
+			subjects: ReviewSubjects{Login: "0maru"},
+			prs:      []PullRequestRef{},
+			issues:   []IssueRef{},
+		},
+	}.Load(context.Background())
+
+	if result.ViewerSubject.Login != "0maru" {
+		t.Fatalf("expected viewer subject to be returned, got %+v", result.ViewerSubject)
 	}
 }
 

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -109,6 +109,9 @@ func TestRuntimeLoader_LoadsLocalItemsAndGitHubEnrichment(t *testing.T) {
 	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 123 {
 		t.Fatalf("expected raw issues in result, got loaded=%v issues=%+v", result.IssuesLoaded, result.Issues)
 	}
+	if result.IssuesRepo != repo {
+		t.Fatalf("expected raw issue source repo %+v, got %+v", repo, result.IssuesRepo)
+	}
 	item := result.Items[0]
 	if item.PullRequest == nil || item.PullRequest.Number != 24 || item.PullRequest.ReviewState != "approved" {
 		t.Fatalf("expected linked PR, got %+v", item.PullRequest)

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -23,6 +23,16 @@ type fakeRuntimeGitHub struct {
 	checkErrs   map[string]error
 }
 
+type configurableIssueRuntimeGitHub struct {
+	fakeRuntimeGitHub
+	includeComments []bool
+}
+
+func (f *configurableIssueRuntimeGitHub) IssuesWithOptions(_ context.Context, _ string, opts IssueListOptions) ([]IssueRef, error) {
+	f.includeComments = append(f.includeComments, opts.IncludeCommentsCount)
+	return f.issues, f.issueErr
+}
+
 func (f fakeRuntimeGitHub) PullRequests(context.Context, string) ([]PullRequestRef, error) {
 	if f.prErr != nil {
 		return nil, f.prErr
@@ -124,6 +134,20 @@ func TestRuntimeLoader_LoadsLocalItemsAndGitHubEnrichment(t *testing.T) {
 	}
 	if item.Checks.State != CheckPassing || item.Checks.Passing != 2 {
 		t.Fatalf("expected passing checks, got %+v", item.Checks)
+	}
+}
+
+func TestRuntimeLoader_DefersIssueCommentsUnlessRequested(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	discovery := &configurableIssueRuntimeGitHub{fakeRuntimeGitHub: fakeRuntimeGitHub{
+		issues: []IssueRef{{Number: 75, Title: "Issue browsing", State: "open"}},
+	}}
+
+	RuntimeLoader{Repo: repo, RepoPath: "/repo", Local: fakeLocalDiscovery{}, GitHub: discovery}.Load(context.Background())
+	RuntimeLoader{Repo: repo, RepoPath: "/repo", Local: fakeLocalDiscovery{}, GitHub: discovery, IncludeIssueCommentsCount: true}.Load(context.Background())
+
+	if len(discovery.includeComments) != 2 || discovery.includeComments[0] || !discovery.includeComments[1] {
+		t.Fatalf("expected normal load to defer comments and issue-scoped load to include them, got %v", discovery.includeComments)
 	}
 }
 

--- a/internal/workbench/runtime_loader_test.go
+++ b/internal/workbench/runtime_loader_test.go
@@ -318,6 +318,30 @@ func TestRuntimeLoader_PreservesLocalItemsWhenGitHubFails(t *testing.T) {
 	}
 }
 
+func TestRuntimeLoader_PreservesPartialIssuesWhenMetadataFails(t *testing.T) {
+	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
+	github := &configurableIssueRuntimeGitHub{fakeRuntimeGitHub: fakeRuntimeGitHub{
+		issues:   []IssueRef{{Number: 75, Repository: repo.FullName(), Title: "Issue browser", Certain: true}},
+		issueErr: errors.New("comment counts failed"),
+	}}
+	loader := RuntimeLoader{
+		Repo:                      repo,
+		RepoPath:                  "/repo",
+		Local:                     fakeLocalDiscovery{},
+		GitHub:                    github,
+		IncludeIssueCommentsCount: true,
+	}
+
+	result := loader.Load(context.Background())
+
+	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 75 {
+		t.Fatalf("expected partial issues to remain loaded, got %+v", result)
+	}
+	if !strings.Contains(result.IssuesError, "comment counts failed") {
+		t.Fatalf("expected the metadata failure to be reported separately, got %q", result.IssuesError)
+	}
+}
+
 func TestRuntimeLoader_ReturnsLocalDiscoveryErrorItem(t *testing.T) {
 	repo := RepoRef{Owner: "0maru", Name: "gh-zen"}
 	loader := RuntimeLoader{

--- a/internal/workbench/types.go
+++ b/internal/workbench/types.go
@@ -32,17 +32,19 @@ type WorktreeRef struct {
 }
 
 type IssueRef struct {
-	Number    int
-	Title     string
-	State     string
-	URL       string
-	Body      string
-	Labels    []string
-	Assignees []string
-	Milestone string
-	UpdatedAt string
-	Certain   bool
-	Source    IssueLinkSource
+	Number        int
+	Title         string
+	State         string
+	URL           string
+	Body          string
+	Labels        []string
+	Assignees     []string
+	Milestone     string
+	AuthorLogin   string
+	CommentsCount int
+	UpdatedAt     string
+	Certain       bool
+	Source        IssueLinkSource
 }
 
 func (i IssueRef) Label() string {

--- a/internal/workbench/types.go
+++ b/internal/workbench/types.go
@@ -34,6 +34,7 @@ type WorktreeRef struct {
 
 type IssueRef struct {
 	Number        int
+	Repository    string
 	Title         string
 	State         string
 	URL           string

--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 		IssuesRepo:         selectedRawResult.IssuesRepo,
 		Issues:             selectedRawResult.Issues,
 		IssuesLoaded:       selectedRawResult.IssuesLoaded,
+		IssuesError:        selectedRawResult.IssuesError,
 		ViewerSubject:      selectedRawResult.ViewerSubject,
 	}
 }
@@ -155,6 +156,13 @@ func (r runtimeWorkbenchReloader) LoadIssues(ctx context.Context, repo workbench
 	if len(checkout.diagnostics) > 0 {
 		result.Items = append(result.Items, workbench.RepositoryPathErrorItem(checkout.repo, checkout.diagnostics))
 	}
+	result.Repositories = []workbench.RepositorySummary{workbench.SummarizeRepository(
+		checkout.repo,
+		checkout.path,
+		checkout.defaultBranch,
+		checkout.remotes,
+		result.Items,
+	)}
 	return result
 }
 

--- a/main.go
+++ b/main.go
@@ -101,18 +101,19 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 	}
 
 	return workbench.RuntimeLoadResult{
-		Repo:               repo,
-		Repositories:       summaries,
-		Items:              items,
-		PullRequests:       selectedRawResult.PullRequests,
-		PullRequestsLoaded: selectedRawResult.PullRequestsLoaded,
-		IssuesRepo:         selectedRawResult.IssuesRepo,
-		Issues:             selectedRawResult.Issues,
-		IssuesLoaded:       selectedRawResult.IssuesLoaded,
-		IssuesError:        selectedRawResult.IssuesError,
-		FailedCheckRefs:    append([]string(nil), selectedRawResult.FailedCheckRefs...),
-		ViewerSubject:      selectedRawResult.ViewerSubject,
-		ViewerSubjectError: selectedRawResult.ViewerSubjectError,
+		Repo:                repo,
+		Repositories:        summaries,
+		Items:               items,
+		PullRequests:        selectedRawResult.PullRequests,
+		PullRequestsLoaded:  selectedRawResult.PullRequestsLoaded,
+		IssuesRepo:          selectedRawResult.IssuesRepo,
+		Issues:              selectedRawResult.Issues,
+		IssuesLoaded:        selectedRawResult.IssuesLoaded,
+		IssuesError:         selectedRawResult.IssuesError,
+		LocalDiscoveryError: selectedRawResult.LocalDiscoveryError,
+		FailedCheckRefs:     append([]string(nil), selectedRawResult.FailedCheckRefs...),
+		ViewerSubject:       selectedRawResult.ViewerSubject,
+		ViewerSubjectError:  selectedRawResult.ViewerSubjectError,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -150,11 +150,13 @@ func (r runtimeWorkbenchReloader) LoadIssues(ctx context.Context, repo workbench
 		if pathError.Local != nil && pathError.Local.Summary != "" {
 			issuesError = pathError.Local.Summary
 		}
+		items := []workbench.WorkItem{pathError}
 		return workbench.RuntimeLoadResult{
-			Repo:        repo,
-			Items:       []workbench.WorkItem{pathError},
-			IssuesRepo:  repo,
-			IssuesError: issuesError,
+			Repo:         repo,
+			Items:        items,
+			Repositories: []workbench.RepositorySummary{workbench.SummarizeRepository(repo, "", "", nil, items)},
+			IssuesRepo:   repo,
+			IssuesError:  issuesError,
 		}
 	}
 	result := (workbench.RuntimeLoader{

--- a/main.go
+++ b/main.go
@@ -158,10 +158,11 @@ func (r runtimeWorkbenchReloader) LoadIssues(ctx context.Context, repo workbench
 		}
 	}
 	result := (workbench.RuntimeLoader{
-		Repo:     checkout.repo,
-		RepoPath: checkout.path,
-		Local:    r.local,
-		GitHub:   r.githubDiscovery(),
+		Repo:                      checkout.repo,
+		RepoPath:                  checkout.path,
+		Local:                     r.local,
+		GitHub:                    r.githubDiscovery(),
+		IncludeIssueCommentsCount: true,
 	}).Load(ctx)
 	if len(checkout.diagnostics) > 0 {
 		result.Items = append(result.Items, workbench.RepositoryPathErrorItem(checkout.repo, checkout.diagnostics))

--- a/main.go
+++ b/main.go
@@ -142,9 +142,16 @@ func loadStartupWorkbenchData(startupRepo config.StartupRepository, reloader app
 func (r runtimeWorkbenchReloader) LoadIssues(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
 	checkout := r.checkoutForRepository(ctx, repo)
 	if checkout.path == "" {
+		pathError := workbench.RepositoryPathErrorItem(repo, checkout.diagnostics)
+		issuesError := "repository path resolution failed"
+		if pathError.Local != nil && pathError.Local.Summary != "" {
+			issuesError = pathError.Local.Summary
+		}
 		return workbench.RuntimeLoadResult{
-			Repo:  repo,
-			Items: []workbench.WorkItem{workbench.RepositoryPathErrorItem(repo, checkout.diagnostics)},
+			Repo:        repo,
+			Items:       []workbench.WorkItem{pathError},
+			IssuesRepo:  repo,
+			IssuesError: issuesError,
 		}
 	}
 	result := (workbench.RuntimeLoader{

--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 		Issues:             selectedRawResult.Issues,
 		IssuesLoaded:       selectedRawResult.IssuesLoaded,
 		IssuesError:        selectedRawResult.IssuesError,
+		FailedCheckRefs:    append([]string(nil), selectedRawResult.FailedCheckRefs...),
 		ViewerSubject:      selectedRawResult.ViewerSubject,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 
 	items := []workbench.WorkItem{}
 	summaries := make([]workbench.RepositorySummary, 0, len(checkouts))
-	rawResultRepo, _ := r.requestedRepository(repo)
+	rawResultRepo, hasRawResultRepo := r.requestedRepository(repo)
 	selectedRawResult := workbench.RuntimeLoadResult{}
 	for _, checkout := range checkouts {
 		if checkout.path == "" {
@@ -77,7 +77,7 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 			Local:    local,
 			GitHub:   r.githubDiscovery(),
 		}).Load(ctx)
-		if checkout.repo == rawResultRepo {
+		if shouldUseRawResult(checkout.repo, rawResultRepo, hasRawResultRepo, selectedRawResult) {
 			selectedRawResult = result
 		}
 		items = append(items, result.Items...)
@@ -110,6 +110,13 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 		IssuesLoaded:       selectedRawResult.IssuesLoaded,
 		ViewerSubject:      selectedRawResult.ViewerSubject,
 	}
+}
+
+func shouldUseRawResult(checkoutRepo workbench.RepoRef, rawResultRepo workbench.RepoRef, hasRawResultRepo bool, current workbench.RuntimeLoadResult) bool {
+	if hasRawResultRepo {
+		return repoFullNameKey(checkoutRepo) == repoFullNameKey(rawResultRepo)
+	}
+	return current.Repo == (workbench.RepoRef{})
 }
 
 func loadStartupWorkbenchData(startupRepo config.StartupRepository, reloader app.WorkbenchReloader) app.WorkbenchData {

--- a/main.go
+++ b/main.go
@@ -63,6 +63,8 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 
 	items := []workbench.WorkItem{}
 	summaries := make([]workbench.RepositorySummary, 0, len(checkouts))
+	rawResultRepo, _ := r.requestedRepository(repo)
+	selectedRawResult := workbench.RuntimeLoadResult{}
 	for _, checkout := range checkouts {
 		if checkout.path == "" {
 			items = append(items, workbench.RepositoryPathErrorItem(checkout.repo, checkout.diagnostics))
@@ -75,6 +77,9 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 			Local:    local,
 			GitHub:   r.githubDiscovery(),
 		}).Load(ctx)
+		if checkout.repo == rawResultRepo {
+			selectedRawResult = result
+		}
 		items = append(items, result.Items...)
 		if len(checkout.diagnostics) > 0 {
 			items = append(items, workbench.RepositoryPathErrorItem(checkout.repo, checkout.diagnostics))
@@ -96,9 +101,14 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 	}
 
 	return workbench.RuntimeLoadResult{
-		Repo:         repo,
-		Repositories: summaries,
-		Items:        items,
+		Repo:               repo,
+		Repositories:       summaries,
+		Items:              items,
+		PullRequests:       selectedRawResult.PullRequests,
+		PullRequestsLoaded: selectedRawResult.PullRequestsLoaded,
+		Issues:             selectedRawResult.Issues,
+		IssuesLoaded:       selectedRawResult.IssuesLoaded,
+		ViewerSubject:      selectedRawResult.ViewerSubject,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -126,6 +126,9 @@ func loadStartupWorkbenchData(startupRepo config.StartupRepository, reloader app
 		ActionsLoader:  app.NewGitHubActionsLoader(github.CLIService{}),
 		InitialLoading: reloader != nil,
 	}
+	if issueReloader, ok := reloader.(app.IssueReloader); ok {
+		data.IssueReloader = issueReloader
+	}
 	repo, ok := repoRefFromFullName(startupRepo.Repo)
 	if !ok {
 		return data
@@ -133,6 +136,26 @@ func loadStartupWorkbenchData(startupRepo config.StartupRepository, reloader app
 
 	data.Repos = []workbench.RepoRef{repo}
 	return data
+}
+
+func (r runtimeWorkbenchReloader) LoadIssues(ctx context.Context, repo workbench.RepoRef) workbench.RuntimeLoadResult {
+	checkout := r.checkoutForRepository(ctx, repo)
+	if checkout.path == "" {
+		return workbench.RuntimeLoadResult{
+			Repo:  repo,
+			Items: []workbench.WorkItem{workbench.RepositoryPathErrorItem(repo, checkout.diagnostics)},
+		}
+	}
+	result := (workbench.RuntimeLoader{
+		Repo:     checkout.repo,
+		RepoPath: checkout.path,
+		Local:    r.local,
+		GitHub:   r.githubDiscovery(),
+	}).Load(ctx)
+	if len(checkout.diagnostics) > 0 {
+		result.Items = append(result.Items, workbench.RepositoryPathErrorItem(checkout.repo, checkout.diagnostics))
+	}
+	return result
 }
 
 type repositoryCheckout struct {

--- a/main.go
+++ b/main.go
@@ -112,6 +112,7 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 		IssuesError:        selectedRawResult.IssuesError,
 		FailedCheckRefs:    append([]string(nil), selectedRawResult.FailedCheckRefs...),
 		ViewerSubject:      selectedRawResult.ViewerSubject,
+		ViewerSubjectError: selectedRawResult.ViewerSubjectError,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -106,6 +106,7 @@ func (r runtimeWorkbenchReloader) Load(ctx context.Context, repo workbench.RepoR
 		Items:              items,
 		PullRequests:       selectedRawResult.PullRequests,
 		PullRequestsLoaded: selectedRawResult.PullRequestsLoaded,
+		IssuesRepo:         selectedRawResult.IssuesRepo,
 		Issues:             selectedRawResult.Issues,
 		IssuesLoaded:       selectedRawResult.IssuesLoaded,
 		ViewerSubject:      selectedRawResult.ViewerSubject,

--- a/main_test.go
+++ b/main_test.go
@@ -273,6 +273,27 @@ func TestRuntimeWorkbenchReloaderLoadsIssuesForOnlyRequestedRepo(t *testing.T) {
 	}
 }
 
+func TestRuntimeWorkbenchReloaderLoadIssuesReportsMissingCheckout(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "missing-repo"}
+	cfg := config.Defaults()
+	cfg.Repos.Roots = []string{t.TempDir()}
+
+	result := (runtimeWorkbenchReloader{config: cfg}).LoadIssues(context.Background(), repo)
+
+	if result.IssuesLoaded {
+		t.Fatalf("expected issues not to be loaded, got %+v", result)
+	}
+	if result.IssuesRepo != repo {
+		t.Fatalf("expected issue error source %+v, got %+v", repo, result.IssuesRepo)
+	}
+	if !strings.Contains(result.IssuesError, "no local checkout found") {
+		t.Fatalf("expected checkout diagnostic in issue error, got %q", result.IssuesError)
+	}
+	if len(result.Items) != 1 || !strings.HasPrefix(result.Items[0].ID, "repository-path-error:") {
+		t.Fatalf("expected repository path error item, got %+v", result.Items)
+	}
+}
+
 func TestRuntimeWorkbenchReloaderPropagatesFirstRepoRawDataForZeroRepoStartup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("uses temporary Git repositories")

--- a/main_test.go
+++ b/main_test.go
@@ -215,6 +215,9 @@ func TestRuntimeWorkbenchReloaderPropagatesSelectedRepoRawData(t *testing.T) {
 	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 123 {
 		t.Fatalf("expected selected repo issues to propagate, got loaded=%v issues=%+v", result.IssuesLoaded, result.Issues)
 	}
+	if result.IssuesRepo != repo {
+		t.Fatalf("expected selected repo issue source %+v, got %+v", repo, result.IssuesRepo)
+	}
 	if result.ViewerSubject.Login != "0maru" {
 		t.Fatalf("expected viewer subject to propagate, got %+v", result.ViewerSubject)
 	}
@@ -250,6 +253,9 @@ func TestRuntimeWorkbenchReloaderPropagatesFirstRepoRawDataForZeroRepoStartup(t 
 	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 75 {
 		t.Fatalf("expected first discovered repo issues to propagate, got loaded=%v issues=%+v", result.IssuesLoaded, result.Issues)
 	}
+	if result.IssuesRepo != repo {
+		t.Fatalf("expected first discovered repo issue source %+v, got %+v", repo, result.IssuesRepo)
+	}
 }
 
 func TestRuntimeWorkbenchReloaderPropagatesRequestedRepoRawDataCaseInsensitively(t *testing.T) {
@@ -282,6 +288,9 @@ func TestRuntimeWorkbenchReloaderPropagatesRequestedRepoRawDataCaseInsensitively
 	result := reloader.Load(context.Background(), requestedRepo)
 	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 82 {
 		t.Fatalf("expected requested repo issues to propagate case-insensitively, got loaded=%v issues=%+v", result.IssuesLoaded, result.Issues)
+	}
+	if result.IssuesRepo != discoveredRepo {
+		t.Fatalf("expected discovered repo issue source %+v, got %+v", discoveredRepo, result.IssuesRepo)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -260,8 +260,8 @@ func TestRuntimeWorkbenchReloaderLoadsIssuesForOnlyRequestedRepo(t *testing.T) {
 	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 75 {
 		t.Fatalf("expected requested repo issues, got loaded=%v issues=%+v", result.IssuesLoaded, result.Issues)
 	}
-	if len(result.Repositories) != 0 {
-		t.Fatalf("expected repo-scoped reload not to replace repository summaries, got %+v", result.Repositories)
+	if len(result.Repositories) != 1 || result.Repositories[0].Repo != dotfilesRepo {
+		t.Fatalf("expected one repo-scoped repository summary, got %+v", result.Repositories)
 	}
 	for _, call := range calls {
 		if strings.Contains(call, ghZenRepo.FullName()) {

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,7 @@ type fakeMainGitHub struct {
 	prsByRepo    map[string][]workbench.PullRequestRef
 	issuesByRepo map[string][]workbench.IssueRef
 	checks       map[string]workbench.CheckSummary
+	subjects     workbench.ReviewSubjects
 }
 
 func (f fakeMainGitHub) PullRequests(_ context.Context, repo string) ([]workbench.PullRequestRef, error) {
@@ -32,6 +33,10 @@ func (f fakeMainGitHub) CheckSummary(_ context.Context, repo string, ref string)
 		return summary, nil
 	}
 	return workbench.CheckSummary{State: workbench.CheckUnknown}, nil
+}
+
+func (f fakeMainGitHub) ViewerReviewSubjects(context.Context) (workbench.ReviewSubjects, error) {
+	return f.subjects, nil
 }
 
 func TestRepoRefFromFullName(t *testing.T) {
@@ -164,6 +169,54 @@ func TestRuntimeWorkbenchReloaderDiscoversConfiguredRoots(t *testing.T) {
 			strings.Contains(item.Local.Summary, "not accessible")
 	}) {
 		t.Fatalf("expected missing root diagnostic item while preserving work, got %+v", result.Items)
+	}
+}
+
+func TestRuntimeWorkbenchReloaderPropagatesSelectedRepoRawData(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	ghZenPath := filepath.Join(root, "0maru", "gh-zen")
+	initRuntimeRepo(t, ghZenPath, "https://github.com/0maru/gh-zen.git")
+
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	cfg := config.Defaults()
+	cfg.Repos.Roots = []string{root}
+	reloader := runtimeWorkbenchReloader{
+		config: cfg,
+		github: fakeMainGitHub{
+			prsByRepo: map[string][]workbench.PullRequestRef{
+				repo.FullName(): {{
+					Number:     81,
+					Title:      "Issue browsing",
+					State:      "open",
+					HeadOwner:  "0maru",
+					HeadBranch: "feature/issues",
+				}},
+			},
+			issuesByRepo: map[string][]workbench.IssueRef{
+				repo.FullName(): {{
+					Number:  123,
+					Title:   "Raw issue",
+					State:   "open",
+					Certain: true,
+				}},
+			},
+			subjects: workbench.ReviewSubjects{Login: "0maru"},
+		},
+	}
+
+	result := reloader.Load(context.Background(), repo)
+	if !result.PullRequestsLoaded || len(result.PullRequests) != 1 || result.PullRequests[0].Number != 81 {
+		t.Fatalf("expected selected repo pull requests to propagate, got loaded=%v prs=%+v", result.PullRequestsLoaded, result.PullRequests)
+	}
+	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 123 {
+		t.Fatalf("expected selected repo issues to propagate, got loaded=%v issues=%+v", result.IssuesLoaded, result.Issues)
+	}
+	if result.ViewerSubject.Login != "0maru" {
+		t.Fatalf("expected viewer subject to propagate, got %+v", result.ViewerSubject)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,6 +20,7 @@ type fakeMainGitHub struct {
 	issuesByRepo map[string][]workbench.IssueRef
 	checks       map[string]workbench.CheckSummary
 	subjects     workbench.ReviewSubjects
+	subjectErr   error
 	calls        *[]string
 }
 
@@ -44,7 +46,7 @@ func (f fakeMainGitHub) CheckSummary(_ context.Context, repo string, ref string)
 }
 
 func (f fakeMainGitHub) ViewerReviewSubjects(context.Context) (workbench.ReviewSubjects, error) {
-	return f.subjects, nil
+	return f.subjects, f.subjectErr
 }
 
 func TestRepoRefFromFullName(t *testing.T) {
@@ -228,6 +230,31 @@ func TestRuntimeWorkbenchReloaderPropagatesSelectedRepoRawData(t *testing.T) {
 	}
 	if result.ViewerSubject.Login != "0maru" {
 		t.Fatalf("expected viewer subject to propagate, got %+v", result.ViewerSubject)
+	}
+}
+
+func TestRuntimeWorkbenchReloaderPropagatesViewerSubjectError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses a temporary Git repository")
+	}
+
+	root := t.TempDir()
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	initRuntimeRepo(t, filepath.Join(root, repo.Owner, repo.Name), "https://github.com/0maru/gh-zen.git")
+	cfg := config.Defaults()
+	cfg.Repos.Roots = []string{root}
+	reloader := runtimeWorkbenchReloader{
+		config: cfg,
+		github: fakeMainGitHub{
+			prsByRepo:    map[string][]workbench.PullRequestRef{repo.FullName(): {}},
+			issuesByRepo: map[string][]workbench.IssueRef{repo.FullName(): {}},
+			subjectErr:   errors.New("viewer unavailable"),
+		},
+	}
+
+	result := reloader.Load(context.Background(), repo)
+	if !strings.Contains(result.ViewerSubjectError, "viewer unavailable") {
+		t.Fatalf("expected viewer subject failure to propagate, got %q", result.ViewerSubjectError)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -18,13 +19,20 @@ type fakeMainGitHub struct {
 	issuesByRepo map[string][]workbench.IssueRef
 	checks       map[string]workbench.CheckSummary
 	subjects     workbench.ReviewSubjects
+	calls        *[]string
 }
 
 func (f fakeMainGitHub) PullRequests(_ context.Context, repo string) ([]workbench.PullRequestRef, error) {
+	if f.calls != nil {
+		*f.calls = append(*f.calls, "pull_requests:"+repo)
+	}
 	return append([]workbench.PullRequestRef(nil), f.prsByRepo[repo]...), nil
 }
 
 func (f fakeMainGitHub) Issues(_ context.Context, repo string) ([]workbench.IssueRef, error) {
+	if f.calls != nil {
+		*f.calls = append(*f.calls, "issues:"+repo)
+	}
 	return append([]workbench.IssueRef(nil), f.issuesByRepo[repo]...), nil
 }
 
@@ -220,6 +228,48 @@ func TestRuntimeWorkbenchReloaderPropagatesSelectedRepoRawData(t *testing.T) {
 	}
 	if result.ViewerSubject.Login != "0maru" {
 		t.Fatalf("expected viewer subject to propagate, got %+v", result.ViewerSubject)
+	}
+}
+
+func TestRuntimeWorkbenchReloaderLoadsIssuesForOnlyRequestedRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	ghZenRepo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	dotfilesRepo := workbench.RepoRef{Owner: "0maru", Name: "dotfiles"}
+	initRuntimeRepo(t, filepath.Join(root, ghZenRepo.Owner, ghZenRepo.Name), "https://github.com/0maru/gh-zen.git")
+	initRuntimeRepo(t, filepath.Join(root, dotfilesRepo.Owner, dotfilesRepo.Name), "https://github.com/0maru/dotfiles.git")
+
+	calls := []string{}
+	cfg := config.Defaults()
+	cfg.Repos.Roots = []string{root}
+	reloader := runtimeWorkbenchReloader{
+		config: cfg,
+		github: fakeMainGitHub{
+			issuesByRepo: map[string][]workbench.IssueRef{
+				dotfilesRepo.FullName(): {{Number: 75, Title: "Issue browsing", State: "open"}},
+			},
+			calls: &calls,
+		},
+	}
+
+	result := reloader.LoadIssues(context.Background(), dotfilesRepo)
+
+	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 75 {
+		t.Fatalf("expected requested repo issues, got loaded=%v issues=%+v", result.IssuesLoaded, result.Issues)
+	}
+	if len(result.Repositories) != 0 {
+		t.Fatalf("expected repo-scoped reload not to replace repository summaries, got %+v", result.Repositories)
+	}
+	for _, call := range calls {
+		if strings.Contains(call, ghZenRepo.FullName()) {
+			t.Fatalf("expected no GitHub calls for unrelated repo, got %+v", calls)
+		}
+	}
+	if !slices.Contains(calls, "pull_requests:"+dotfilesRepo.FullName()) || !slices.Contains(calls, "issues:"+dotfilesRepo.FullName()) {
+		t.Fatalf("expected requested repo GitHub calls, got %+v", calls)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -220,6 +220,71 @@ func TestRuntimeWorkbenchReloaderPropagatesSelectedRepoRawData(t *testing.T) {
 	}
 }
 
+func TestRuntimeWorkbenchReloaderPropagatesFirstRepoRawDataForZeroRepoStartup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	ghZenPath := filepath.Join(root, "0maru", "gh-zen")
+	initRuntimeRepo(t, ghZenPath, "https://github.com/0maru/gh-zen.git")
+
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	cfg := config.Defaults()
+	cfg.Repos.Roots = []string{root}
+	reloader := runtimeWorkbenchReloader{
+		config: cfg,
+		github: fakeMainGitHub{
+			issuesByRepo: map[string][]workbench.IssueRef{
+				repo.FullName(): {{
+					Number:  75,
+					Title:   "Discovered issue",
+					State:   "open",
+					Certain: true,
+				}},
+			},
+		},
+	}
+
+	result := reloader.Load(context.Background(), workbench.RepoRef{})
+	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 75 {
+		t.Fatalf("expected first discovered repo issues to propagate, got loaded=%v issues=%+v", result.IssuesLoaded, result.Issues)
+	}
+}
+
+func TestRuntimeWorkbenchReloaderPropagatesRequestedRepoRawDataCaseInsensitively(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses temporary Git repositories")
+	}
+
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "Owner", "Repo")
+	initRuntimeRepo(t, repoPath, "https://github.com/Owner/Repo.git")
+
+	discoveredRepo := workbench.RepoRef{Owner: "Owner", Name: "Repo"}
+	requestedRepo := workbench.RepoRef{Owner: "owner", Name: "repo"}
+	cfg := config.Defaults()
+	cfg.Repos.Roots = []string{root}
+	reloader := runtimeWorkbenchReloader{
+		config: cfg,
+		github: fakeMainGitHub{
+			issuesByRepo: map[string][]workbench.IssueRef{
+				discoveredRepo.FullName(): {{
+					Number:  82,
+					Title:   "Case-preserved issue",
+					State:   "open",
+					Certain: true,
+				}},
+			},
+		},
+	}
+
+	result := reloader.Load(context.Background(), requestedRepo)
+	if !result.IssuesLoaded || len(result.Issues) != 1 || result.Issues[0].Number != 82 {
+		t.Fatalf("expected requested repo issues to propagate case-insensitively, got loaded=%v issues=%+v", result.IssuesLoaded, result.Issues)
+	}
+}
+
 func requireRepositorySummary(t *testing.T, summaries []workbench.RepositorySummary, repo workbench.RepoRef) workbench.RepositorySummary {
 	t.Helper()
 	for _, summary := range summaries {

--- a/main_test.go
+++ b/main_test.go
@@ -319,6 +319,13 @@ func TestRuntimeWorkbenchReloaderLoadIssuesReportsMissingCheckout(t *testing.T) 
 	if len(result.Items) != 1 || !strings.HasPrefix(result.Items[0].ID, "repository-path-error:") {
 		t.Fatalf("expected repository path error item, got %+v", result.Items)
 	}
+	if len(result.Repositories) != 1 || result.Repositories[0].Repo != repo {
+		t.Fatalf("expected missing checkout summary for %+v, got %+v", repo, result.Repositories)
+	}
+	summary := result.Repositories[0]
+	if summary.Path != "" || summary.ActiveWorktreeCount != 0 || summary.OpenPullRequestCount != 0 || summary.OpenIssueCount != 0 || summary.FailingCheckCount != 0 {
+		t.Fatalf("expected missing checkout summary to clear stale repository state, got %+v", summary)
+	}
 }
 
 func TestRuntimeWorkbenchReloaderPropagatesFirstRepoRawDataForZeroRepoStartup(t *testing.T) {


### PR DESCRIPTION
## Summary

- Implements 0-107.

## Source

- Linear: https://linear.app/0maru/issue/0-107/gh-zen-add-first-class-issue-browsing
- Source type: github_issue
- Source key: 0maru/gh-zen#75
- Source URL: https://github.com/0maru/gh-zen/issues/75
- Closes 0maru/gh-zen#75

## Target

- Repository: gh-zen
- Base branch: main

## Verification

- See the Symphony/Codex run output and Linear issue comments.
