### PR TITLE
[gh-zen] #77 Add GitHub Actions browsing view (workflow runs / jobs / annotations / on-demand logs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Run it with:
 gh zen
 ```
 
+Inside `gh zen`, press `a` to browse GitHub Actions workflow runs for the
+selected repository and `w` to return to the repository workbench.
+
 ## Development
 
 Install local hooks:

--- a/docs/validation/github-actions-smoke.md
+++ b/docs/validation/github-actions-smoke.md
@@ -1,0 +1,52 @@
+# GitHub Actions Smoke Validation
+
+This manual smoke test verifies the read-only GitHub Actions browser. Real
+GitHub API validation remains opt-in because it needs authenticated `gh` state
+and repositories with representative workflow runs.
+
+## Prerequisites
+
+- `gh auth status` succeeds for an account that can read the target repository.
+- The target repository is cloned locally and has an `origin` remote on
+  `github.com`.
+- The repository has recent workflow runs. Ideally include at least one
+  successful run, one failed run, and one in-progress or queued run.
+- Optional: the failed run has job annotations and failed logs.
+
+## Local Extension Smoke Test
+
+1. From this repository, run `make build`.
+2. Install the local extension with `gh extension install . --force`.
+3. Change into a real GitHub checkout, for example
+   `cd ~/workspaces/github.com/0maru/gh-zen`.
+4. Run `gh zen`.
+5. Press `a` to switch to GitHub Actions mode.
+6. Confirm the middle pane is titled `Runs` and lists workflow runs for the
+   selected repository.
+7. Move between runs with `j` and `k`. Confirm the preview updates with
+   workflow metadata, commit SHA, timing, jobs, and failure summary.
+8. Confirm moving focus does not automatically load logs.
+9. Press `L` on a failed run. Confirm failed logs appear in the preview only
+   after the explicit keypress.
+10. Press `o` to open the selected run in the browser.
+11. Press `y` to copy the run URL, and `Y` to copy the run ID.
+12. Press `r` to refresh workflow runs.
+13. Exercise in-memory filters:
+    - `s` cycles status.
+    - `c` cycles conclusion.
+    - `b` cycles branch.
+    - `n` cycles workflow name.
+    - `e` cycles event.
+    - `u` cycles actor.
+    - `x` clears all filters.
+14. Press `w` to return to the repository workbench.
+
+## Opt-In Large Validation
+
+Large tests that touch authenticated GitHub behavior must stay opt-in:
+
+```sh
+GH_ZEN_LARGE_TESTS=1 make test-large
+```
+
+Do not require large tests for normal `make check` or pre-push validation.

--- a/internal/app/actions_filter.go
+++ b/internal/app/actions_filter.go
@@ -1,0 +1,154 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/0maru/gh-zen/internal/workbench"
+)
+
+type actionsFilter struct {
+	Status     string
+	Conclusion string
+	Branch     string
+	Workflow   string
+	Event      string
+	Actor      string
+}
+
+func (f actionsFilter) active() bool {
+	return f.Status != "" ||
+		f.Conclusion != "" ||
+		f.Branch != "" ||
+		f.Workflow != "" ||
+		f.Event != "" ||
+		f.Actor != ""
+}
+
+func (f actionsFilter) describe() string {
+	parts := []string{}
+	if f.Status != "" {
+		parts = append(parts, "status="+f.Status)
+	}
+	if f.Conclusion != "" {
+		parts = append(parts, "conclusion="+f.Conclusion)
+	}
+	if f.Branch != "" {
+		parts = append(parts, "branch="+f.Branch)
+	}
+	if f.Workflow != "" {
+		parts = append(parts, "workflow="+f.Workflow)
+	}
+	if f.Event != "" {
+		parts = append(parts, "event="+f.Event)
+	}
+	if f.Actor != "" {
+		parts = append(parts, "actor="+f.Actor)
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, ", ")
+}
+
+func filterWorkflowRuns(runs []workbench.WorkflowRunRef, filter actionsFilter) []workbench.WorkflowRunRef {
+	out := make([]workbench.WorkflowRunRef, 0, len(runs))
+	for _, run := range runs {
+		if matchesActionsFilter(run, filter) {
+			out = append(out, run)
+		}
+	}
+	return out
+}
+
+func matchesActionsFilter(run workbench.WorkflowRunRef, filter actionsFilter) bool {
+	return filterStringMatches(filter.Status, run.Status) &&
+		filterStringMatches(filter.Conclusion, run.Conclusion) &&
+		filterStringMatches(filter.Branch, run.Branch) &&
+		filterStringMatches(filter.Workflow, run.WorkflowName) &&
+		filterStringMatches(filter.Event, run.Event) &&
+		filterStringMatches(filter.Actor, run.Actor)
+}
+
+func filterStringMatches(filter string, value string) bool {
+	return filter == "" || strings.EqualFold(filter, value)
+}
+
+type actionsFilterField int
+
+const (
+	actionsFilterFieldStatus actionsFilterField = iota
+	actionsFilterFieldConclusion
+	actionsFilterFieldBranch
+	actionsFilterFieldWorkflow
+	actionsFilterFieldEvent
+	actionsFilterFieldActor
+)
+
+func (m *model) cycleActionsFilter(field actionsFilterField) {
+	runs := m.actions.runs
+	switch field {
+	case actionsFilterFieldStatus:
+		m.actions.filter.Status = nextActionsFilterValue(m.actions.filter.Status, actionFilterValues(runs, func(run workbench.WorkflowRunRef) string {
+			return run.Status
+		}))
+	case actionsFilterFieldConclusion:
+		m.actions.filter.Conclusion = nextActionsFilterValue(m.actions.filter.Conclusion, actionFilterValues(runs, func(run workbench.WorkflowRunRef) string {
+			return run.Conclusion
+		}))
+	case actionsFilterFieldBranch:
+		m.actions.filter.Branch = nextActionsFilterValue(m.actions.filter.Branch, actionFilterValues(runs, func(run workbench.WorkflowRunRef) string {
+			return run.Branch
+		}))
+	case actionsFilterFieldWorkflow:
+		m.actions.filter.Workflow = nextActionsFilterValue(m.actions.filter.Workflow, actionFilterValues(runs, func(run workbench.WorkflowRunRef) string {
+			return run.WorkflowName
+		}))
+	case actionsFilterFieldEvent:
+		m.actions.filter.Event = nextActionsFilterValue(m.actions.filter.Event, actionFilterValues(runs, func(run workbench.WorkflowRunRef) string {
+			return run.Event
+		}))
+	case actionsFilterFieldActor:
+		m.actions.filter.Actor = nextActionsFilterValue(m.actions.filter.Actor, actionFilterValues(runs, func(run workbench.WorkflowRunRef) string {
+			return run.Actor
+		}))
+	}
+	m.actions.selectedRun = 0
+	m.statusMessage = fmt.Sprintf("Actions filters: %s", m.actions.filter.describe())
+}
+
+func actionFilterValues(runs []workbench.WorkflowRunRef, value func(workbench.WorkflowRunRef) string) []string {
+	seen := map[string]bool{}
+	values := []string{}
+	for _, run := range runs {
+		v := strings.TrimSpace(value(run))
+		if v == "" {
+			continue
+		}
+		key := strings.ToLower(v)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		values = append(values, v)
+	}
+	return values
+}
+
+func nextActionsFilterValue(current string, values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	if current == "" {
+		return values[0]
+	}
+	for i, value := range values {
+		if strings.EqualFold(value, current) {
+			if i == len(values)-1 {
+				return ""
+			}
+			return values[i+1]
+		}
+	}
+	return values[0]
+}

--- a/internal/app/actions_loader.go
+++ b/internal/app/actions_loader.go
@@ -53,7 +53,7 @@ func (l githubActionsLoader) LoadRunPreview(ctx context.Context, repo workbench.
 	for _, job := range jobs {
 		jobAnnotations, err := l.service.JobAnnotations(ctx, repo.FullName(), job.ID)
 		if err != nil {
-			return ActionsRunPreview{Run: detail, Jobs: jobs, Annotations: annotations}, err
+			continue
 		}
 		if len(jobAnnotations) > 0 {
 			annotations[job.ID] = jobAnnotations

--- a/internal/app/actions_loader.go
+++ b/internal/app/actions_loader.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"context"
+
+	"github.com/0maru/gh-zen/internal/github"
+	"github.com/0maru/gh-zen/internal/workbench"
+)
+
+const defaultWorkflowRunLimit = 30
+
+// ActionsLoader loads GitHub Actions data for the selected repository.
+type ActionsLoader interface {
+	LoadRuns(ctx context.Context, repo workbench.RepoRef) ([]workbench.WorkflowRunRef, error)
+	LoadRunPreview(ctx context.Context, repo workbench.RepoRef, run workbench.WorkflowRunRef) (ActionsRunPreview, error)
+	LoadRunLogs(ctx context.Context, repo workbench.RepoRef, run workbench.WorkflowRunRef, opts github.LogFetchOptions) (workbench.WorkflowLog, error)
+}
+
+// ActionsRunPreview contains the lightweight details shown when a run is focused.
+type ActionsRunPreview struct {
+	Run         workbench.WorkflowRunRef
+	Jobs        []workbench.WorkflowJobRef
+	Annotations map[int64][]workbench.AnnotationRef
+}
+
+type githubActionsLoader struct {
+	service github.Service
+	limit   int
+}
+
+// NewGitHubActionsLoader adapts the GitHub service boundary for the TUI.
+func NewGitHubActionsLoader(service github.Service) ActionsLoader {
+	return githubActionsLoader{service: service, limit: defaultWorkflowRunLimit}
+}
+
+func (l githubActionsLoader) LoadRuns(ctx context.Context, repo workbench.RepoRef) ([]workbench.WorkflowRunRef, error) {
+	return l.service.WorkflowRuns(ctx, repo.FullName(), github.WorkflowRunListOptions{Limit: l.limit})
+}
+
+func (l githubActionsLoader) LoadRunPreview(ctx context.Context, repo workbench.RepoRef, run workbench.WorkflowRunRef) (ActionsRunPreview, error) {
+	detail, err := l.service.WorkflowRun(ctx, repo.FullName(), run.ID)
+	if err != nil {
+		return ActionsRunPreview{}, err
+	}
+	if detail.ID == 0 {
+		detail = run
+	}
+	jobs, err := l.service.WorkflowRunJobs(ctx, repo.FullName(), run.ID)
+	if err != nil {
+		return ActionsRunPreview{Run: detail}, err
+	}
+	annotations := map[int64][]workbench.AnnotationRef{}
+	for _, job := range jobs {
+		jobAnnotations, err := l.service.JobAnnotations(ctx, repo.FullName(), job.ID)
+		if err != nil {
+			return ActionsRunPreview{Run: detail, Jobs: jobs, Annotations: annotations}, err
+		}
+		if len(jobAnnotations) > 0 {
+			annotations[job.ID] = jobAnnotations
+		}
+	}
+	return ActionsRunPreview{
+		Run:         detail,
+		Jobs:        jobs,
+		Annotations: annotations,
+	}, nil
+}
+
+func (l githubActionsLoader) LoadRunLogs(ctx context.Context, repo workbench.RepoRef, run workbench.WorkflowRunRef, opts github.LogFetchOptions) (workbench.WorkflowLog, error) {
+	return l.service.WorkflowRunLogs(ctx, repo.FullName(), run.ID, opts)
+}
+
+type fakeActionsLoader struct {
+	runs        []workbench.WorkflowRunRef
+	jobs        map[int64][]workbench.WorkflowJobRef
+	annotations map[int64][]workbench.AnnotationRef
+	logs        map[int64]workbench.WorkflowLog
+}
+
+func newFakeActionsLoader() ActionsLoader {
+	return fakeActionsLoader{
+		runs:        workbench.FakeWorkflowRuns(),
+		jobs:        workbench.FakeWorkflowJobs(),
+		annotations: workbench.FakeWorkflowAnnotations(),
+		logs:        workbench.FakeWorkflowLogs(),
+	}
+}
+
+func (l fakeActionsLoader) LoadRuns(context.Context, workbench.RepoRef) ([]workbench.WorkflowRunRef, error) {
+	return append([]workbench.WorkflowRunRef(nil), l.runs...), nil
+}
+
+func (l fakeActionsLoader) LoadRunPreview(_ context.Context, _ workbench.RepoRef, run workbench.WorkflowRunRef) (ActionsRunPreview, error) {
+	detail := run
+	for _, candidate := range l.runs {
+		if candidate.ID == run.ID {
+			detail = candidate
+			break
+		}
+	}
+	jobs := cloneActionJobs(l.jobs[run.ID])
+	annotations := map[int64][]workbench.AnnotationRef{}
+	for _, job := range jobs {
+		if jobAnnotations := l.annotations[job.ID]; len(jobAnnotations) > 0 {
+			annotations[job.ID] = append([]workbench.AnnotationRef(nil), jobAnnotations...)
+		}
+	}
+	return ActionsRunPreview{Run: detail, Jobs: jobs, Annotations: annotations}, nil
+}
+
+func (l fakeActionsLoader) LoadRunLogs(_ context.Context, _ workbench.RepoRef, run workbench.WorkflowRunRef, opts github.LogFetchOptions) (workbench.WorkflowLog, error) {
+	if log, ok := l.logs[run.ID]; ok {
+		log.Lines = append([]string(nil), log.Lines...)
+		return log, nil
+	}
+	return workbench.WorkflowLog{RunID: run.ID, Failed: opts.FailedOnly}, nil
+}
+
+func cloneActionJobs(jobs []workbench.WorkflowJobRef) []workbench.WorkflowJobRef {
+	out := append([]workbench.WorkflowJobRef(nil), jobs...)
+	for i := range out {
+		out[i].Steps = append([]workbench.WorkflowStepRef(nil), out[i].Steps...)
+	}
+	return out
+}

--- a/internal/app/actions_view.go
+++ b/internal/app/actions_view.go
@@ -1,0 +1,591 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/0maru/gh-zen/internal/github"
+	"github.com/0maru/gh-zen/internal/workbench"
+)
+
+const maxPreviewLogLines = 20
+
+type appMode int
+
+const (
+	modeWorkbench appMode = iota
+	modeActions
+)
+
+type actionsState struct {
+	repo                 workbench.RepoRef
+	runs                 []workbench.WorkflowRunRef
+	selectedRun          int
+	loading              bool
+	loadError            string
+	filter               actionsFilter
+	activeLoadRequest    actionsLoadRequest
+	nextLoadRequestID    int
+	preview              actionsPreviewState
+	nextPreviewRequestID int
+	activeLogRequest     actionsLogRequest
+	nextLogRequestID     int
+	logLoading           bool
+	logsByRunID          map[int64]workbench.WorkflowLog
+}
+
+type actionsPreviewState struct {
+	status       previewStatus
+	requestID    int
+	focusedRunID int64
+	loaded       ActionsRunPreview
+	errorMessage string
+}
+
+type actionsLoadRequest struct {
+	requestID int
+	repo      workbench.RepoRef
+	status    string
+}
+
+type actionsLoadMsg struct {
+	request actionsLoadRequest
+	runs    []workbench.WorkflowRunRef
+	err     error
+}
+
+type actionsPreviewRequest struct {
+	requestID int
+	repo      workbench.RepoRef
+	run       workbench.WorkflowRunRef
+}
+
+type actionsPreviewMsg struct {
+	request actionsPreviewRequest
+	preview ActionsRunPreview
+	err     error
+}
+
+type actionsLogRequest struct {
+	requestID int
+	repo      workbench.RepoRef
+	run       workbench.WorkflowRunRef
+	opts      github.LogFetchOptions
+	status    string
+}
+
+type actionsLogMsg struct {
+	request actionsLogRequest
+	log     workbench.WorkflowLog
+	err     error
+}
+
+func (m *model) switchMode(mode appMode) tea.Cmd {
+	if m.mode == mode {
+		return nil
+	}
+	m.mode = mode
+	switch mode {
+	case modeActions:
+		m.focusedPane = paneWorkItems
+		m.viewSelected = false
+		m.statusMessage = "Loading workflow runs..."
+		return m.startActionsLoadForSelectedRepo("Loading workflow runs...")
+	default:
+		m.focusedPane = paneWorkItems
+		return m.startPreviewLoadForCurrentItem()
+	}
+}
+
+func (m *model) refreshActionsData() tea.Cmd {
+	cmd := m.startActionsLoadForSelectedRepo("Reloading workflow runs...")
+	if cmd == nil {
+		m.statusMessage = "Actions refresh unavailable"
+	}
+	return cmd
+}
+
+func (m *model) startActionsLoadForSelectedRepo(status string) tea.Cmd {
+	if m.actionsLoader == nil {
+		return nil
+	}
+	repo, ok := m.selectedRepoRef()
+	if !ok {
+		m.actions.runs = nil
+		m.actions.loading = false
+		m.actions.preview = actionsPreviewState{status: previewEmpty}
+		return nil
+	}
+	m.actions.nextLoadRequestID++
+	request := actionsLoadRequest{
+		requestID: m.actions.nextLoadRequestID,
+		repo:      repo,
+		status:    status,
+	}
+	m.actions.activeLoadRequest = request
+	m.actions.loading = true
+	m.actions.loadError = ""
+	m.statusMessage = status
+	return m.actionsLoadCommand(request)
+}
+
+func (m model) actionsLoadCommand(request actionsLoadRequest) tea.Cmd {
+	return func() tea.Msg {
+		runs, err := m.actionsLoader.LoadRuns(context.Background(), request.repo)
+		return actionsLoadMsg{request: request, runs: runs, err: err}
+	}
+}
+
+func (m *model) handleActionsLoad(msg actionsLoadMsg) tea.Cmd {
+	if msg.request != m.actions.activeLoadRequest {
+		return nil
+	}
+	repo, ok := m.selectedRepoRef()
+	if !ok || repo != msg.request.repo {
+		m.actions.loading = false
+		if m.statusMessage == msg.request.status {
+			m.statusMessage = ""
+		}
+		return nil
+	}
+	m.actions.loading = false
+	if msg.err != nil {
+		m.actions.loadError = msg.err.Error()
+		m.statusMessage = "Workflow runs load failed"
+		return nil
+	}
+
+	selectedRunID := int64(0)
+	if run, ok := m.selectedWorkflowRun(); ok {
+		selectedRunID = run.ID
+	}
+	m.actions.runs = append([]workbench.WorkflowRunRef(nil), msg.runs...)
+	m.actions.repo = msg.request.repo
+	m.actions.loadError = ""
+	m.restoreSelectedWorkflowRun(selectedRunID)
+	if m.statusMessage == msg.request.status {
+		m.statusMessage = ""
+	}
+	return m.startActionsPreviewForCurrentRun()
+}
+
+func (m *model) startActionsPreviewIfFocusedRunChanged() tea.Cmd {
+	run, ok := m.selectedWorkflowRun()
+	if !ok || run.ID == 0 {
+		m.actions.preview = actionsPreviewState{status: previewEmpty}
+		return nil
+	}
+	if run.ID == m.actions.preview.focusedRunID {
+		return nil
+	}
+	return m.startActionsPreviewForCurrentRun()
+}
+
+func (m *model) startActionsPreviewForCurrentRun() tea.Cmd {
+	run, ok := m.selectedWorkflowRun()
+	if !ok || run.ID == 0 {
+		m.actions.preview = actionsPreviewState{status: previewEmpty}
+		return nil
+	}
+	if m.actionsLoader == nil {
+		m.actions.preview = actionsPreviewState{status: previewEmpty}
+		return nil
+	}
+	repo, ok := m.selectedRepoRef()
+	if !ok {
+		m.actions.preview = actionsPreviewState{status: previewEmpty}
+		return nil
+	}
+	m.actions.nextPreviewRequestID++
+	request := actionsPreviewRequest{
+		requestID: m.actions.nextPreviewRequestID,
+		repo:      repo,
+		run:       run,
+	}
+	m.actions.preview = actionsPreviewState{
+		status:       previewLoading,
+		requestID:    request.requestID,
+		focusedRunID: run.ID,
+	}
+	return m.actionsPreviewCommand(request)
+}
+
+func (m model) actionsPreviewCommand(request actionsPreviewRequest) tea.Cmd {
+	return func() tea.Msg {
+		preview, err := m.actionsLoader.LoadRunPreview(context.Background(), request.repo, request.run)
+		return actionsPreviewMsg{request: request, preview: preview, err: err}
+	}
+}
+
+func (m *model) handleActionsPreview(msg actionsPreviewMsg) {
+	if msg.request.requestID != m.actions.preview.requestID || msg.request.run.ID != m.actions.preview.focusedRunID {
+		return
+	}
+	next := actionsPreviewState{
+		requestID:    msg.request.requestID,
+		focusedRunID: msg.request.run.ID,
+	}
+	if msg.err != nil {
+		next.status = previewError
+		next.errorMessage = msg.err.Error()
+	} else {
+		next.status = previewLoaded
+		next.loaded = msg.preview
+		if next.loaded.Run.ID == 0 {
+			next.loaded.Run = msg.request.run
+		}
+	}
+	m.actions.preview = next
+}
+
+func (m *model) fetchActionsLogs() tea.Cmd {
+	if m.actionsLoader == nil {
+		m.statusMessage = "Actions logs unavailable"
+		return nil
+	}
+	repo, ok := m.selectedRepoRef()
+	if !ok {
+		m.statusMessage = "No repository selected"
+		return nil
+	}
+	run, ok := m.selectedWorkflowRun()
+	if !ok {
+		m.statusMessage = "No workflow run selected"
+		return nil
+	}
+	m.actions.nextLogRequestID++
+	request := actionsLogRequest{
+		requestID: m.actions.nextLogRequestID,
+		repo:      repo,
+		run:       run,
+		opts:      github.LogFetchOptions{FailedOnly: true},
+		status:    "Loading failed logs for " + run.NumberLabel() + "...",
+	}
+	m.actions.activeLogRequest = request
+	m.actions.logLoading = true
+	m.statusMessage = request.status
+	return m.actionsLogCommand(request)
+}
+
+func (m model) actionsLogCommand(request actionsLogRequest) tea.Cmd {
+	return func() tea.Msg {
+		log, err := m.actionsLoader.LoadRunLogs(context.Background(), request.repo, request.run, request.opts)
+		return actionsLogMsg{request: request, log: log, err: err}
+	}
+}
+
+func (m *model) handleActionsLog(msg actionsLogMsg) {
+	if msg.request != m.actions.activeLogRequest {
+		return
+	}
+	m.actions.logLoading = false
+	if msg.err != nil {
+		m.statusMessage = fmt.Sprintf("Workflow log load failed: %v", msg.err)
+		return
+	}
+	if m.actions.logsByRunID == nil {
+		m.actions.logsByRunID = map[int64]workbench.WorkflowLog{}
+	}
+	m.actions.logsByRunID[msg.request.run.ID] = msg.log
+	m.statusMessage = "Loaded failed logs for " + msg.request.run.NumberLabel()
+}
+
+func (m model) visibleWorkflowRuns() []workbench.WorkflowRunRef {
+	repo, ok := m.selectedRepoRef()
+	if !ok || repo != m.actions.repo {
+		return nil
+	}
+	return filterWorkflowRuns(m.actions.runs, m.actions.filter)
+}
+
+func (m model) selectedWorkflowRun() (workbench.WorkflowRunRef, bool) {
+	runs := m.visibleWorkflowRuns()
+	if len(runs) == 0 || m.actions.selectedRun < 0 || m.actions.selectedRun >= len(runs) {
+		return workbench.WorkflowRunRef{}, false
+	}
+	return runs[m.actions.selectedRun], true
+}
+
+func (m *model) moveWorkflowRunSelection(delta int) {
+	runs := m.visibleWorkflowRuns()
+	if len(runs) == 0 {
+		m.actions.selectedRun = 0
+		return
+	}
+	m.actions.selectedRun = clamp(m.actions.selectedRun+delta, 0, len(runs)-1)
+}
+
+func (m *model) jumpWorkflowRunSelection(toEnd bool) {
+	runs := m.visibleWorkflowRuns()
+	if len(runs) == 0 {
+		m.actions.selectedRun = 0
+		return
+	}
+	if toEnd {
+		m.actions.selectedRun = len(runs) - 1
+		return
+	}
+	m.actions.selectedRun = 0
+}
+
+func (m *model) restoreSelectedWorkflowRun(runID int64) {
+	runs := m.visibleWorkflowRuns()
+	if len(runs) == 0 {
+		m.actions.selectedRun = 0
+		return
+	}
+	if runID != 0 {
+		for i, run := range runs {
+			if run.ID == runID {
+				m.actions.selectedRun = i
+				return
+			}
+		}
+	}
+	m.actions.selectedRun = clamp(m.actions.selectedRun, 0, len(runs)-1)
+}
+
+func (m model) actionsRunLines(width int, focused bool) []string {
+	runs := m.visibleWorkflowRuns()
+	if len(runs) == 0 {
+		return []string{m.emptyActionsRunLine()}
+	}
+	lines := []string{}
+	if m.actions.filter.active() {
+		lines = append(lines, truncate("  filters: "+m.actions.filter.describe(), width))
+	}
+	for i, run := range runs {
+		marker := selectionMarker(i == m.actions.selectedRun, focused)
+		workflow := run.WorkflowName
+		if workflow == "" {
+			workflow = "workflow"
+		}
+		branch := run.Branch
+		if branch == "" {
+			branch = "unknown"
+		}
+		row := fmt.Sprintf("%s %-11s %-12s %-14s %s", marker, run.StatusLabel(), workflow, branch, run.Title)
+		lines = append(lines, truncate(row, width))
+	}
+	return lines
+}
+
+func (m model) emptyActionsRunLine() string {
+	if m.actions.loading {
+		return "  loading workflow runs..."
+	}
+	if m.actions.loadError != "" {
+		return "  workflow runs failed: " + m.actions.loadError
+	}
+	if m.actions.filter.active() {
+		return "  no workflow runs match filters"
+	}
+	return "  no workflow runs"
+}
+
+func (m model) actionsPreviewLines(width int) []string {
+	switch m.actions.preview.status {
+	case previewLoading:
+		return m.actionsPreviewStatusLines(width, "Loading run details...")
+	case previewLoaded:
+		if m.actions.preview.loaded.Run.ID != m.actions.preview.focusedRunID {
+			return m.actionsPreviewStatusLines(width, "Loading run details...")
+		}
+		log, logLoaded := m.actions.logsByRunID[m.actions.preview.focusedRunID]
+		return workflowRunPreviewLines(m.actions.preview.loaded, log, logLoaded, m.actions.logLoading, width)
+	case previewEmpty:
+		if _, ok := m.selectedWorkflowRun(); !ok {
+			return []string{"  no workflow run selected"}
+		}
+		return m.actionsPreviewStatusLines(width, "No run details")
+	case previewError:
+		lines := m.actionsPreviewStatusLines(width, "Run details failed")
+		if m.actions.preview.errorMessage != "" {
+			lines = append(lines, truncate("Error: "+m.actions.preview.errorMessage, width))
+		}
+		return lines
+	default:
+		if _, ok := m.selectedWorkflowRun(); !ok {
+			return []string{"  no workflow run selected"}
+		}
+		return m.actionsPreviewStatusLines(width, "Run details idle")
+	}
+}
+
+func (m model) actionsPreviewStatusLines(width int, status string) []string {
+	lines := []string{truncate(status, width)}
+	if run, ok := m.selectedWorkflowRun(); ok {
+		lines = append(lines, truncate("Run: "+run.Label(), width))
+	}
+	return lines
+}
+
+func workflowRunPreviewLines(preview ActionsRunPreview, log workbench.WorkflowLog, logLoaded bool, logLoading bool, width int) []string {
+	run := preview.Run
+	lines := []string{
+		truncate("Workflow: "+valueOrUnknown(run.WorkflowName), width),
+		truncate("Title: "+valueOrUnknown(run.Title), width),
+		truncate("Run: "+run.NumberLabel()+" ("+strconvFormatInt(run.ID)+")", width),
+		truncate("Status: "+run.StatusLabel(), width),
+		truncate("Branch: "+valueOrUnknown(run.Branch), width),
+		truncate("Event: "+valueOrUnknown(run.Event), width),
+		truncate("Actor: "+valueOrUnknown(run.Actor), width),
+		truncate("Commit: "+valueOrUnknown(run.ShortSHA()), width),
+		truncate("Created: "+formatActionTime(run.CreatedAt), width),
+		truncate("Updated: "+formatActionTime(run.UpdatedAt), width),
+	}
+	if run.URL != "" {
+		lines = append(lines, truncate("URL: "+run.URL, width))
+	}
+	lines = append(lines, truncate("Failure summary: "+workflowFailureSummary(preview), width))
+	if len(preview.Jobs) > 0 {
+		lines = append(lines, "Jobs:")
+		for _, job := range preview.Jobs {
+			line := fmt.Sprintf("  %s %s", job.StatusLabel(), job.Label())
+			if duration := actionDuration(job.StartedAt, job.CompletedAt); duration != "" {
+				line += " " + duration
+			}
+			lines = append(lines, truncate(line, width))
+			for _, step := range job.Steps {
+				if !isFailureConclusion(step.Conclusion) {
+					continue
+				}
+				lines = append(lines, truncate(fmt.Sprintf("    failed step: %s", valueOrUnknown(step.Name)), width))
+			}
+		}
+	}
+	annotationLines := workflowAnnotationLines(preview.Annotations, width)
+	if len(annotationLines) > 0 {
+		lines = append(lines, "Annotations:")
+		lines = append(lines, annotationLines...)
+	}
+	if logLoading {
+		lines = append(lines, "Logs: loading failed logs...")
+	}
+	if logLoaded {
+		lines = append(lines, workflowLogPreviewLines(log, width)...)
+	}
+	return lines
+}
+
+func workflowFailureSummary(preview ActionsRunPreview) string {
+	failedJobs := 0
+	failedSteps := 0
+	annotations := 0
+	for _, job := range preview.Jobs {
+		if isFailureConclusion(job.Conclusion) {
+			failedJobs++
+		}
+		for _, step := range job.Steps {
+			if isFailureConclusion(step.Conclusion) {
+				failedSteps++
+			}
+		}
+		annotations += len(preview.Annotations[job.ID])
+	}
+	parts := []string{}
+	if failedJobs > 0 {
+		parts = append(parts, pluralize(failedJobs, "failed job"))
+	}
+	if failedSteps > 0 {
+		parts = append(parts, pluralize(failedSteps, "failed step"))
+	}
+	if annotations > 0 {
+		parts = append(parts, pluralize(annotations, "annotation"))
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, ", ")
+}
+
+func workflowAnnotationLines(annotationsByJob map[int64][]workbench.AnnotationRef, width int) []string {
+	lines := []string{}
+	jobIDs := make([]int64, 0, len(annotationsByJob))
+	for jobID := range annotationsByJob {
+		jobIDs = append(jobIDs, jobID)
+	}
+	sort.Slice(jobIDs, func(i, j int) bool {
+		return jobIDs[i] < jobIDs[j]
+	})
+	for _, jobID := range jobIDs {
+		annotations := annotationsByJob[jobID]
+		for _, annotation := range annotations {
+			line := "  " + annotation.Label()
+			if annotation.Level != "" {
+				line += " [" + annotation.Level + "]"
+			}
+			lines = append(lines, truncate(line, width))
+			if annotation.Message != "" {
+				lines = append(lines, truncate("    "+annotation.Message, width))
+			}
+		}
+	}
+	return lines
+}
+
+func workflowLogPreviewLines(log workbench.WorkflowLog, width int) []string {
+	label := "Logs"
+	if log.Failed {
+		label = "Failed logs"
+	}
+	lines := []string{fmt.Sprintf("%s (%d lines):", label, len(log.Lines))}
+	start := 0
+	if len(log.Lines) > maxPreviewLogLines {
+		start = len(log.Lines) - maxPreviewLogLines
+		lines[0] = fmt.Sprintf("%s (%d lines, showing last %d):", label, len(log.Lines), maxPreviewLogLines)
+	}
+	for _, line := range log.Lines[start:] {
+		lines = append(lines, truncate("  "+line, width))
+	}
+	return lines
+}
+
+func isFailureConclusion(value string) bool {
+	value = strings.ToLower(value)
+	return strings.Contains(value, "fail") ||
+		strings.Contains(value, "error") ||
+		strings.Contains(value, "cancel") ||
+		strings.Contains(value, "timed_out") ||
+		strings.Contains(value, "startup_failure")
+}
+
+func actionDuration(start time.Time, end time.Time) string {
+	if start.IsZero() || end.IsZero() || end.Before(start) {
+		return ""
+	}
+	return "(" + end.Sub(start).Round(time.Second).String() + ")"
+}
+
+func formatActionTime(value time.Time) string {
+	if value.IsZero() {
+		return "unknown"
+	}
+	return value.UTC().Format("2006-01-02 15:04 UTC")
+}
+
+func valueOrUnknown(value string) string {
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}
+
+func strconvFormatInt(value int64) string {
+	if value == 0 {
+		return "unknown"
+	}
+	return fmt.Sprintf("%d", value)
+}
+
+func pluralize(count int, label string) string {
+	if count == 1 {
+		return fmt.Sprintf("%d %s", count, label)
+	}
+	return fmt.Sprintf("%d %ss", count, label)
+}

--- a/internal/app/actions_view.go
+++ b/internal/app/actions_view.go
@@ -121,6 +121,10 @@ func (m *model) startActionsLoadForSelectedRepo(status string) tea.Cmd {
 		m.actions.preview = actionsPreviewState{status: previewEmpty}
 		return nil
 	}
+	if m.actions.repo != repo {
+		m.actions.preview = actionsPreviewState{status: previewEmpty}
+		m.actions.logsByRunID = nil
+	}
 	m.actions.nextLoadRequestID++
 	request := actionsLoadRequest{
 		requestID: m.actions.nextLoadRequestID,

--- a/internal/app/actions_view_test.go
+++ b/internal/app/actions_view_test.go
@@ -27,6 +27,15 @@ type recordingActionsLoader struct {
 	logCalls     []github.LogFetchOptions
 }
 
+type annotationErrorService struct {
+	github.FakeService
+	err error
+}
+
+func (s annotationErrorService) JobAnnotations(context.Context, string, int64) ([]workbench.AnnotationRef, error) {
+	return nil, s.err
+}
+
 func (l *recordingActionsLoader) LoadRuns(_ context.Context, repo workbench.RepoRef) ([]workbench.WorkflowRunRef, error) {
 	l.runCalls = append(l.runCalls, repo)
 	if l.runErr != nil {
@@ -181,6 +190,30 @@ func TestActionsMode_LoadsRunsAndPreview(t *testing.T) {
 	}
 }
 
+func TestGitHubActionsLoader_KeepsPreviewWhenAnnotationsFail(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	run := workbench.FakeWorkflowRuns()[0]
+	jobs := workbench.FakeWorkflowJobs()[run.ID]
+	loader := NewGitHubActionsLoader(annotationErrorService{
+		FakeService: github.FakeService{
+			WorkflowRunsByRepo: map[string][]workbench.WorkflowRunRef{repo.FullName(): {run}},
+			JobsByRunID:        map[int64][]workbench.WorkflowJobRef{run.ID: jobs},
+		},
+		err: errors.New("annotations unavailable"),
+	})
+
+	got, err := loader.LoadRunPreview(context.Background(), repo, run)
+	if err != nil {
+		t.Fatalf("expected annotation errors not to fail preview, got %v", err)
+	}
+	if got.Run.ID != run.ID || len(got.Jobs) != len(jobs) {
+		t.Fatalf("expected run and jobs to remain available, got %+v", got)
+	}
+	if len(got.Annotations) != 0 {
+		t.Fatalf("expected failed annotations to be omitted, got %+v", got.Annotations)
+	}
+}
+
 func TestActionsMode_MovingRunLoadsPreviewButNotLogs(t *testing.T) {
 	runs := workbench.FakeWorkflowRuns()
 	jobs := workbench.FakeWorkflowJobs()
@@ -268,6 +301,46 @@ func TestActionsMode_StaleLoadResultIsDiscarded(t *testing.T) {
 	mm := got.(model)
 	if len(mm.actions.runs) != 0 {
 		t.Fatalf("expected stale result not to set runs, got %+v", mm.actions.runs)
+	}
+}
+
+func TestActionsMode_NewRepoLoadClearsStalePreview(t *testing.T) {
+	repos := []workbench.RepoRef{
+		{Owner: "0maru", Name: "gh-zen"},
+		{Owner: "0maru", Name: "skills"},
+	}
+	runs := workbench.FakeWorkflowRuns()
+	loader := &recordingActionsLoader{runs: runs}
+	mm := newModelWithRuntimeData(config.Defaults(), repos[0].FullName(), WorkbenchData{
+		Repos:         repos,
+		ActionsLoader: loader,
+	}, fakeDelayedPreviewLoader(0))
+	mm.mode = modeActions
+	mm.actions.repo = repos[0]
+	mm.actions.runs = runs
+	mm.actions.preview = actionsPreviewState{
+		status:       previewLoaded,
+		focusedRunID: runs[0].ID,
+		loaded:       ActionsRunPreview{Run: runs[0]},
+	}
+	mm.actions.logsByRunID = map[int64]workbench.WorkflowLog{
+		runs[0].ID: {RunID: runs[0].ID, Lines: []string{"stale"}},
+	}
+	mm.selectedRepo = 1
+
+	cmd := mm.startActionsLoadForSelectedRepo("Loading workflow runs...")
+	if cmd == nil {
+		t.Fatalf("expected actions load command")
+	}
+	if mm.actions.preview.status != previewEmpty {
+		t.Fatalf("expected stale preview to clear, got %+v", mm.actions.preview)
+	}
+	if len(mm.actions.logsByRunID) != 0 {
+		t.Fatalf("expected stale logs to clear, got %+v", mm.actions.logsByRunID)
+	}
+	msg := requireActionsLoadMsg(t, cmd)
+	if msg.request.repo != repos[1] {
+		t.Fatalf("expected load request for new repo, got %+v", msg.request.repo)
 	}
 }
 

--- a/internal/app/actions_view_test.go
+++ b/internal/app/actions_view_test.go
@@ -1,0 +1,320 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/0maru/gh-zen/internal/config"
+	"github.com/0maru/gh-zen/internal/github"
+	"github.com/0maru/gh-zen/internal/workbench"
+)
+
+type recordingActionsLoader struct {
+	runs         []workbench.WorkflowRunRef
+	previews     map[int64]ActionsRunPreview
+	logs         map[int64]workbench.WorkflowLog
+	runErr       error
+	previewErr   error
+	logErr       error
+	runCalls     []workbench.RepoRef
+	previewCalls []int64
+	logCalls     []github.LogFetchOptions
+}
+
+func (l *recordingActionsLoader) LoadRuns(_ context.Context, repo workbench.RepoRef) ([]workbench.WorkflowRunRef, error) {
+	l.runCalls = append(l.runCalls, repo)
+	if l.runErr != nil {
+		return nil, l.runErr
+	}
+	return append([]workbench.WorkflowRunRef(nil), l.runs...), nil
+}
+
+func (l *recordingActionsLoader) LoadRunPreview(_ context.Context, _ workbench.RepoRef, run workbench.WorkflowRunRef) (ActionsRunPreview, error) {
+	l.previewCalls = append(l.previewCalls, run.ID)
+	if l.previewErr != nil {
+		return ActionsRunPreview{}, l.previewErr
+	}
+	if preview, ok := l.previews[run.ID]; ok {
+		return preview, nil
+	}
+	return ActionsRunPreview{Run: run}, nil
+}
+
+func (l *recordingActionsLoader) LoadRunLogs(_ context.Context, _ workbench.RepoRef, run workbench.WorkflowRunRef, opts github.LogFetchOptions) (workbench.WorkflowLog, error) {
+	l.logCalls = append(l.logCalls, opts)
+	if l.logErr != nil {
+		return workbench.WorkflowLog{}, l.logErr
+	}
+	if log, ok := l.logs[run.ID]; ok {
+		log.Lines = append([]string(nil), log.Lines...)
+		return log, nil
+	}
+	return workbench.WorkflowLog{RunID: run.ID, Failed: opts.FailedOnly}, nil
+}
+
+func requireActionsLoadMsg(t *testing.T, cmd tea.Cmd) actionsLoadMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatalf("expected actions load command, got nil")
+	}
+	msg := cmd()
+	result, ok := msg.(actionsLoadMsg)
+	if !ok {
+		t.Fatalf("expected actionsLoadMsg, got %T", msg)
+	}
+	return result
+}
+
+func requireActionsPreviewMsg(t *testing.T, cmd tea.Cmd) actionsPreviewMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatalf("expected actions preview command, got nil")
+	}
+	msg := cmd()
+	result, ok := msg.(actionsPreviewMsg)
+	if !ok {
+		t.Fatalf("expected actionsPreviewMsg, got %T", msg)
+	}
+	return result
+}
+
+func requireActionsLogMsg(t *testing.T, cmd tea.Cmd) actionsLogMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatalf("expected actions log command, got nil")
+	}
+	msg := cmd()
+	result, ok := msg.(actionsLogMsg)
+	if !ok {
+		t.Fatalf("expected actionsLogMsg, got %T", msg)
+	}
+	return result
+}
+
+func testActionsModel(loader ActionsLoader) model {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	return newModelWithRuntimeData(config.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:         []workbench.RepoRef{repo},
+		ActionsLoader: loader,
+	}, fakeDelayedPreviewLoader(0))
+}
+
+func TestActionsFilter_MatchesAllDimensions(t *testing.T) {
+	runs := []workbench.WorkflowRunRef{
+		{ID: 1, Status: "completed", Conclusion: "success", Branch: "main", WorkflowName: "CI", Event: "push", Actor: "0maru"},
+		{ID: 2, Status: "completed", Conclusion: "failure", Branch: "feature", WorkflowName: "CI", Event: "pull_request", Actor: "teammate"},
+		{ID: 3, Status: "in_progress", Branch: "main", WorkflowName: "Release", Event: "workflow_dispatch", Actor: "0maru"},
+	}
+	cases := []struct {
+		name   string
+		filter actionsFilter
+		want   []int64
+	}{
+		{name: "empty", filter: actionsFilter{}, want: []int64{1, 2, 3}},
+		{name: "status", filter: actionsFilter{Status: "completed"}, want: []int64{1, 2}},
+		{name: "conclusion", filter: actionsFilter{Conclusion: "failure"}, want: []int64{2}},
+		{name: "branch", filter: actionsFilter{Branch: "main"}, want: []int64{1, 3}},
+		{name: "workflow", filter: actionsFilter{Workflow: "Release"}, want: []int64{3}},
+		{name: "event", filter: actionsFilter{Event: "pull_request"}, want: []int64{2}},
+		{name: "actor", filter: actionsFilter{Actor: "0maru"}, want: []int64{1, 3}},
+		{name: "combined", filter: actionsFilter{Status: "completed", Conclusion: "success", Branch: "main", Workflow: "CI", Event: "push", Actor: "0maru"}, want: []int64{1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterWorkflowRuns(runs, tc.filter)
+			gotIDs := make([]int64, 0, len(got))
+			for _, run := range got {
+				gotIDs = append(gotIDs, run.ID)
+			}
+			if !reflect.DeepEqual(gotIDs, tc.want) {
+				t.Fatalf("expected run IDs %+v, got %+v", tc.want, gotIDs)
+			}
+		})
+	}
+}
+
+func TestActionsMode_LoadsRunsAndPreview(t *testing.T) {
+	runs := workbench.FakeWorkflowRuns()
+	loader := &recordingActionsLoader{
+		runs: runs,
+		previews: map[int64]ActionsRunPreview{
+			runs[0].ID: {
+				Run:  runs[0],
+				Jobs: workbench.FakeWorkflowJobs()[runs[0].ID],
+			},
+		},
+	}
+	start := testActionsModel(loader)
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd == nil {
+		t.Fatalf("expected actions load command")
+	}
+	msg := requireActionsLoadMsg(t, cmd)
+	got, cmd = got.(model).Update(msg)
+	if cmd == nil {
+		t.Fatalf("expected run preview command after load")
+	}
+	got, _ = got.(model).Update(requireActionsPreviewMsg(t, cmd))
+	mm := got.(model)
+
+	if mm.mode != modeActions {
+		t.Fatalf("expected actions mode, got %v", mm.mode)
+	}
+	if len(loader.runCalls) != 1 || loader.runCalls[0].FullName() != "0maru/gh-zen" {
+		t.Fatalf("expected one run load for repo, got %+v", loader.runCalls)
+	}
+	if len(loader.previewCalls) != 1 || loader.previewCalls[0] != runs[0].ID {
+		t.Fatalf("expected preview load for first run, got %+v", loader.previewCalls)
+	}
+	if len(loader.logCalls) != 0 {
+		t.Fatalf("expected focus preview not to fetch logs, got %+v", loader.logCalls)
+	}
+	if lines := strings.Join(mm.actionsPreviewLines(120), "\n"); !strings.Contains(lines, "Workflow: CI") || !strings.Contains(lines, "Failure summary: none") {
+		t.Fatalf("expected run preview lines, got:\n%s", lines)
+	}
+}
+
+func TestActionsMode_MovingRunLoadsPreviewButNotLogs(t *testing.T) {
+	runs := workbench.FakeWorkflowRuns()
+	jobs := workbench.FakeWorkflowJobs()
+	loader := &recordingActionsLoader{
+		runs: runs,
+		previews: map[int64]ActionsRunPreview{
+			runs[0].ID: {Run: runs[0], Jobs: jobs[runs[0].ID]},
+			runs[1].ID: {Run: runs[1], Jobs: jobs[runs[1].ID], Annotations: workbench.FakeWorkflowAnnotations()},
+		},
+	}
+	start := testActionsModel(loader)
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	got, cmd = got.(model).Update(requireActionsLoadMsg(t, cmd))
+	got, _ = got.(model).Update(requireActionsPreviewMsg(t, cmd))
+
+	got, cmd = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if cmd == nil {
+		t.Fatalf("expected preview command after moving to next run")
+	}
+	got, _ = got.(model).Update(requireActionsPreviewMsg(t, cmd))
+	mm := got.(model)
+
+	if len(loader.previewCalls) != 2 || loader.previewCalls[1] != runs[1].ID {
+		t.Fatalf("expected second preview load for run %d, got %+v", runs[1].ID, loader.previewCalls)
+	}
+	if len(loader.logCalls) != 0 {
+		t.Fatalf("expected movement not to fetch logs, got %+v", loader.logCalls)
+	}
+	lines := strings.Join(mm.actionsPreviewLines(120), "\n")
+	if !strings.Contains(lines, "Failure summary: 1 failed job, 1 failed step, 1 annotation") {
+		t.Fatalf("expected failure summary, got:\n%s", lines)
+	}
+}
+
+func TestActionsMode_FetchLogsIsExplicit(t *testing.T) {
+	runs := workbench.FakeWorkflowRuns()
+	loader := &recordingActionsLoader{
+		runs: runs,
+		previews: map[int64]ActionsRunPreview{
+			runs[0].ID: {Run: runs[0]},
+		},
+		logs: map[int64]workbench.WorkflowLog{
+			runs[0].ID: {RunID: runs[0].ID, Failed: true, Lines: []string{"job\tstep\tfailed line"}},
+		},
+	}
+	start := testActionsModel(loader)
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	got, cmd = got.(model).Update(requireActionsLoadMsg(t, cmd))
+	got, _ = got.(model).Update(requireActionsPreviewMsg(t, cmd))
+
+	got, cmd = got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'L'}})
+	if cmd == nil {
+		t.Fatalf("expected explicit log command")
+	}
+	got, _ = got.(model).Update(requireActionsLogMsg(t, cmd))
+	mm := got.(model)
+
+	if len(loader.logCalls) != 1 || !loader.logCalls[0].FailedOnly {
+		t.Fatalf("expected one failed-only log call, got %+v", loader.logCalls)
+	}
+	if lines := strings.Join(mm.actionsPreviewLines(120), "\n"); !strings.Contains(lines, "Failed logs (1 lines):") || !strings.Contains(lines, "failed line") {
+		t.Fatalf("expected loaded logs in preview, got:\n%s", lines)
+	}
+}
+
+func TestActionsMode_StaleLoadResultIsDiscarded(t *testing.T) {
+	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
+	runs := workbench.FakeWorkflowRuns()
+	loader := &recordingActionsLoader{runs: runs}
+	start := newModelWithRuntimeData(config.Defaults(), repo.FullName(), WorkbenchData{
+		Repos:         []workbench.RepoRef{repo},
+		ActionsLoader: loader,
+	}, fakeDelayedPreviewLoader(0))
+	got, firstCmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	first := requireActionsLoadMsg(t, firstCmd)
+	got, secondCmd := got.(model).Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if secondCmd == nil {
+		t.Fatalf("expected second actions load command")
+	}
+
+	got, cmd := got.(model).Update(first)
+	if cmd != nil {
+		t.Fatalf("expected stale actions load to skip preview command, got %T", cmd)
+	}
+	mm := got.(model)
+	if len(mm.actions.runs) != 0 {
+		t.Fatalf("expected stale result not to set runs, got %+v", mm.actions.runs)
+	}
+}
+
+func TestActionsMode_OpenCopyRunActions(t *testing.T) {
+	run := workbench.WorkflowRunRef{
+		ID:        12345,
+		RunNumber: 88,
+		URL:       "https://github.com/0maru/gh-zen/actions/runs/12345",
+		CreatedAt: time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC),
+	}
+	loader := &recordingActionsLoader{runs: []workbench.WorkflowRunRef{run}}
+	start := testActionsModel(loader)
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	got, cmd = got.(model).Update(requireActionsLoadMsg(t, cmd))
+	got, _ = got.(model).Update(requireActionsPreviewMsg(t, cmd))
+	runner := &fakeActionRunner{}
+	mm := got.(model)
+	mm.actionRunner = runner
+
+	for _, key := range []rune{'o', 'y', 'Y'} {
+		updated, actionCmd := mm.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{key}})
+		if actionCmd == nil {
+			t.Fatalf("expected action command for %q", string(key))
+		}
+		updated, _ = updated.(model).Update(actionCmd())
+		mm = updated.(model)
+	}
+	if !reflect.DeepEqual(runner.opened, []string{run.URL}) {
+		t.Fatalf("expected opened run URL, got %+v", runner.opened)
+	}
+	if !reflect.DeepEqual(runner.copied, []string{run.URL, "12345"}) {
+		t.Fatalf("expected copied run URL and ID, got %+v", runner.copied)
+	}
+}
+
+func TestActionsMode_LoadErrorIsNonFatal(t *testing.T) {
+	loader := &recordingActionsLoader{runErr: errors.New("gh auth failed")}
+	start := testActionsModel(loader)
+
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	got, _ = got.(model).Update(requireActionsLoadMsg(t, cmd))
+	mm := got.(model)
+
+	if mm.mode != modeActions {
+		t.Fatalf("expected to remain in actions mode")
+	}
+	if !strings.Contains(strings.Join(mm.actionsRunLines(120, true), "\n"), "gh auth failed") {
+		t.Fatalf("expected load error in actions list, got %+v", mm.actionsRunLines(120, true))
+	}
+}

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -9,22 +9,34 @@ import (
 type actionID string
 
 const (
-	actionMoveDown          actionID = "move_down"
-	actionMoveUp            actionID = "move_up"
-	actionJumpTop           actionID = "jump_top"
-	actionJumpBottom        actionID = "jump_bottom"
-	actionFocusNextPane     actionID = "focus_next_pane"
-	actionFocusPreviousPane actionID = "focus_previous_pane"
-	actionFocusPane1        actionID = "focus_pane_1"
-	actionFocusPane2        actionID = "focus_pane_2"
-	actionFocusPane3        actionID = "focus_pane_3"
-	actionToggleHelp        actionID = "toggle_help"
-	actionRefresh           actionID = "refresh"
-	actionOpenPullRequest   actionID = "open_pr"
-	actionOpenIssue         actionID = "open_issue"
-	actionCopyURL           actionID = "copy_url"
-	actionCopyWorktreePath  actionID = "copy_worktree_path"
-	actionQuit              actionID = "quit"
+	actionMoveDown             actionID = "move_down"
+	actionMoveUp               actionID = "move_up"
+	actionJumpTop              actionID = "jump_top"
+	actionJumpBottom           actionID = "jump_bottom"
+	actionFocusNextPane        actionID = "focus_next_pane"
+	actionFocusPreviousPane    actionID = "focus_previous_pane"
+	actionFocusPane1           actionID = "focus_pane_1"
+	actionFocusPane2           actionID = "focus_pane_2"
+	actionFocusPane3           actionID = "focus_pane_3"
+	actionToggleHelp           actionID = "toggle_help"
+	actionRefresh              actionID = "refresh"
+	actionShowActions          actionID = "show_actions"
+	actionShowWorkbench        actionID = "show_workbench"
+	actionOpenPullRequest      actionID = "open_pr"
+	actionOpenIssue            actionID = "open_issue"
+	actionCopyURL              actionID = "copy_url"
+	actionCopyWorktreePath     actionID = "copy_worktree_path"
+	actionOpenWorkflowRun      actionID = "open_workflow_run"
+	actionCopyWorkflowRunID    actionID = "copy_workflow_run_id"
+	actionFetchWorkflowRunLogs actionID = "fetch_workflow_run_logs"
+	actionFilterStatus         actionID = "filter_status"
+	actionFilterConclusion     actionID = "filter_conclusion"
+	actionFilterBranch         actionID = "filter_branch"
+	actionFilterWorkflow       actionID = "filter_workflow"
+	actionFilterEvent          actionID = "filter_event"
+	actionFilterActor          actionID = "filter_actor"
+	actionClearFilters         actionID = "clear_filters"
+	actionQuit                 actionID = "quit"
 )
 
 type actionBinding struct {
@@ -33,22 +45,34 @@ type actionBinding struct {
 }
 
 type workbenchKeyMap struct {
-	MoveDown          key.Binding
-	MoveUp            key.Binding
-	JumpTop           key.Binding
-	JumpBottom        key.Binding
-	FocusNextPane     key.Binding
-	FocusPreviousPane key.Binding
-	FocusPane1        key.Binding
-	FocusPane2        key.Binding
-	FocusPane3        key.Binding
-	ToggleHelp        key.Binding
-	Refresh           key.Binding
-	OpenPullRequest   key.Binding
-	OpenIssue         key.Binding
-	CopyURL           key.Binding
-	CopyWorktreePath  key.Binding
-	Quit              key.Binding
+	MoveDown             key.Binding
+	MoveUp               key.Binding
+	JumpTop              key.Binding
+	JumpBottom           key.Binding
+	FocusNextPane        key.Binding
+	FocusPreviousPane    key.Binding
+	FocusPane1           key.Binding
+	FocusPane2           key.Binding
+	FocusPane3           key.Binding
+	ToggleHelp           key.Binding
+	Refresh              key.Binding
+	ShowActions          key.Binding
+	ShowWorkbench        key.Binding
+	OpenPullRequest      key.Binding
+	OpenIssue            key.Binding
+	CopyURL              key.Binding
+	CopyWorktreePath     key.Binding
+	OpenWorkflowRun      key.Binding
+	CopyWorkflowRunID    key.Binding
+	FetchWorkflowRunLogs key.Binding
+	FilterStatus         key.Binding
+	FilterConclusion     key.Binding
+	FilterBranch         key.Binding
+	FilterWorkflow       key.Binding
+	FilterEvent          key.Binding
+	FilterActor          key.Binding
+	ClearFilters         key.Binding
+	Quit                 key.Binding
 }
 
 type contextualHelpKeyMap struct {
@@ -110,6 +134,14 @@ func DefaultKeyMap() workbenchKeyMap {
 			key.WithKeys("r"),
 			key.WithHelp("r", "refresh"),
 		),
+		ShowActions: key.NewBinding(
+			key.WithKeys("a"),
+			key.WithHelp("a", "actions"),
+		),
+		ShowWorkbench: key.NewBinding(
+			key.WithKeys("w"),
+			key.WithHelp("w", "workbench"),
+		),
 		OpenPullRequest: key.NewBinding(
 			key.WithKeys("p"),
 			key.WithHelp("p", "open PR"),
@@ -126,6 +158,46 @@ func DefaultKeyMap() workbenchKeyMap {
 			key.WithKeys("Y"),
 			key.WithHelp("Y", "copy path"),
 		),
+		OpenWorkflowRun: key.NewBinding(
+			key.WithKeys("o"),
+			key.WithHelp("o", "open run"),
+		),
+		CopyWorkflowRunID: key.NewBinding(
+			key.WithKeys("Y"),
+			key.WithHelp("Y", "copy run ID"),
+		),
+		FetchWorkflowRunLogs: key.NewBinding(
+			key.WithKeys("L"),
+			key.WithHelp("L", "failed logs"),
+		),
+		FilterStatus: key.NewBinding(
+			key.WithKeys("s"),
+			key.WithHelp("s", "status"),
+		),
+		FilterConclusion: key.NewBinding(
+			key.WithKeys("c"),
+			key.WithHelp("c", "conclusion"),
+		),
+		FilterBranch: key.NewBinding(
+			key.WithKeys("b"),
+			key.WithHelp("b", "branch"),
+		),
+		FilterWorkflow: key.NewBinding(
+			key.WithKeys("n"),
+			key.WithHelp("n", "workflow"),
+		),
+		FilterEvent: key.NewBinding(
+			key.WithKeys("e"),
+			key.WithHelp("e", "event"),
+		),
+		FilterActor: key.NewBinding(
+			key.WithKeys("u"),
+			key.WithHelp("u", "actor"),
+		),
+		ClearFilters: key.NewBinding(
+			key.WithKeys("x"),
+			key.WithHelp("x", "clear filters"),
+		),
 		Quit: key.NewBinding(
 			key.WithKeys("q", "esc", "ctrl+c"),
 			key.WithHelp("q", "quit"),
@@ -133,8 +205,8 @@ func DefaultKeyMap() workbenchKeyMap {
 	}
 }
 
-func (k workbenchKeyMap) actionBindings() []actionBinding {
-	return []actionBinding{
+func (k workbenchKeyMap) actionBindings(mode appMode) []actionBinding {
+	common := []actionBinding{
 		{id: actionQuit, binding: k.Quit},
 		{id: actionToggleHelp, binding: k.ToggleHelp},
 		{id: actionFocusNextPane, binding: k.FocusNextPane},
@@ -147,22 +219,49 @@ func (k workbenchKeyMap) actionBindings() []actionBinding {
 		{id: actionJumpTop, binding: k.JumpTop},
 		{id: actionJumpBottom, binding: k.JumpBottom},
 		{id: actionRefresh, binding: k.Refresh},
-		{id: actionOpenPullRequest, binding: k.OpenPullRequest},
-		{id: actionOpenIssue, binding: k.OpenIssue},
-		{id: actionCopyURL, binding: k.CopyURL},
-		{id: actionCopyWorktreePath, binding: k.CopyWorktreePath},
 	}
+	if mode == modeActions {
+		return append(common,
+			actionBinding{id: actionShowWorkbench, binding: k.ShowWorkbench},
+			actionBinding{id: actionOpenWorkflowRun, binding: k.OpenWorkflowRun},
+			actionBinding{id: actionCopyURL, binding: k.CopyURL},
+			actionBinding{id: actionCopyWorkflowRunID, binding: k.CopyWorkflowRunID},
+			actionBinding{id: actionFetchWorkflowRunLogs, binding: k.FetchWorkflowRunLogs},
+			actionBinding{id: actionFilterStatus, binding: k.FilterStatus},
+			actionBinding{id: actionFilterConclusion, binding: k.FilterConclusion},
+			actionBinding{id: actionFilterBranch, binding: k.FilterBranch},
+			actionBinding{id: actionFilterWorkflow, binding: k.FilterWorkflow},
+			actionBinding{id: actionFilterEvent, binding: k.FilterEvent},
+			actionBinding{id: actionFilterActor, binding: k.FilterActor},
+			actionBinding{id: actionClearFilters, binding: k.ClearFilters},
+		)
+	}
+	return append(common,
+		actionBinding{id: actionShowActions, binding: k.ShowActions},
+		actionBinding{id: actionOpenPullRequest, binding: k.OpenPullRequest},
+		actionBinding{id: actionOpenIssue, binding: k.OpenIssue},
+		actionBinding{id: actionCopyURL, binding: k.CopyURL},
+		actionBinding{id: actionCopyWorktreePath, binding: k.CopyWorktreePath},
+	)
 }
 
-func (k workbenchKeyMap) contextualHelp(focus paneFocus, visiblePanes []paneFocus) contextualHelpKeyMap {
+func (k workbenchKeyMap) contextualHelp(mode appMode, focus paneFocus, visiblePanes []paneFocus) contextualHelpKeyMap {
 	paneNumbers := k.visiblePaneBinding(visiblePanes)
 	paneKeys := combinedBinding("pane", k.FocusPreviousPane, k.FocusNextPane)
 	system := []key.Binding{k.ToggleHelp, k.Quit}
-	actions := []key.Binding{k.OpenPullRequest, k.OpenIssue, k.CopyURL, k.CopyWorktreePath, k.Refresh}
+	actions := []key.Binding{k.ShowActions, k.OpenPullRequest, k.OpenIssue, k.CopyURL, k.CopyWorktreePath, k.Refresh}
+	if mode == modeActions {
+		actions = []key.Binding{k.ShowWorkbench, k.OpenWorkflowRun, k.CopyURL, k.CopyWorkflowRunID, k.FetchWorkflowRunLogs, k.Refresh}
+		system = []key.Binding{k.ToggleHelp, k.Quit}
+	}
 	panes := []key.Binding{k.FocusPreviousPane, k.FocusNextPane, paneNumbers}
 
 	short := []key.Binding{paneNumbers, paneKeys, k.ToggleHelp, k.Quit}
 	full := [][]key.Binding{panes, actions, system}
+	if mode == modeActions {
+		filters := []key.Binding{k.FilterStatus, k.FilterConclusion, k.FilterBranch, k.FilterWorkflow, k.FilterEvent, k.FilterActor, k.ClearFilters}
+		full = [][]key.Binding{panes, actions, filters, system}
+	}
 
 	if focus == paneRepositories || focus == paneWorkItems {
 		move := combinedBinding("move", k.MoveDown, k.MoveUp)

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -69,6 +69,7 @@ func (p paneFocus) borderLabel() string {
 type model struct {
 	width                int
 	height               int
+	mode                 appMode
 	repos                []workbench.RepoRef
 	selectedRepo         int
 	selectedView         int
@@ -86,6 +87,8 @@ type model struct {
 	nextReloadRequestID  int
 	activeReloadRequest  workbenchReloadRequest
 	workbenchFilter      cfgpkg.WorkbenchFilter
+	actions              actionsState
+	actionsLoader        ActionsLoader
 	actionRunner         actionRunner
 	statusMessage        string
 	styles               Styles
@@ -98,6 +101,7 @@ type WorkbenchData struct {
 	Repos          []workbench.RepoRef
 	WorkItems      []workbench.WorkItem
 	Reloader       WorkbenchReloader
+	ActionsLoader  ActionsLoader
 	InitialLoading bool
 	Demo           bool
 }
@@ -176,6 +180,10 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 	if data.Demo {
 		source = workbenchDataDemo
 	}
+	actionsLoader := data.ActionsLoader
+	if actionsLoader == nil && data.Demo {
+		actionsLoader = newFakeActionsLoader()
+	}
 	m := model{
 		repos:             cloneRepoRefs(data.Repos),
 		workItems:         cloneWorkItems(data.WorkItems),
@@ -183,6 +191,7 @@ func newModelWithRuntimeData(cfg cfgpkg.Config, startupRepo string, data Workben
 		previewLoader:     loader,
 		workbenchReloader: data.Reloader,
 		workbenchFilter:   cfg.Workbench.Filter,
+		actionsLoader:     actionsLoader,
 		actionRunner:      systemActionRunner{},
 		styles:            DefaultStyles(),
 		keys:              DefaultKeyMap(),
@@ -215,6 +224,21 @@ func (m model) Init() tea.Cmd {
 	var cmds []tea.Cmd
 	if m.workbenchLoading && m.activeReloadRequest.requestID != 0 {
 		cmds = append(cmds, m.workbenchReloadCommand(m.activeReloadRequest))
+	}
+	if m.mode == modeActions && m.actions.loading && m.actions.activeLoadRequest.requestID != 0 {
+		cmds = append(cmds, m.actionsLoadCommand(m.actions.activeLoadRequest))
+	}
+	if m.mode == modeActions && m.actions.preview.status == previewLoading && m.actions.preview.requestID != 0 {
+		if run, ok := m.selectedWorkflowRun(); ok && run.ID == m.actions.preview.focusedRunID {
+			repo, repoOK := m.selectedRepoRef()
+			if repoOK {
+				cmds = append(cmds, m.actionsPreviewCommand(actionsPreviewRequest{
+					requestID: m.actions.preview.requestID,
+					repo:      repo,
+					run:       run,
+				}))
+			}
+		}
 	}
 	if m.preview.status != previewLoading || m.previewLoader == nil {
 		return batchCommands(cmds...)
@@ -262,6 +286,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case workbenchReloadMsg:
 		return m, m.handleWorkbenchReload(msg)
+	case actionsLoadMsg:
+		return m, m.handleActionsLoad(msg)
+	case actionsPreviewMsg:
+		m.handleActionsPreview(msg)
+		return m, nil
+	case actionsLogMsg:
+		m.handleActionsLog(msg)
+		return m, nil
 	case tea.KeyMsg:
 		if action, ok := m.matchedAction(msg); ok {
 			return m, m.handleAction(action)
@@ -340,7 +372,7 @@ func (m *model) handlePreviewResult(msg previewResultMsg) {
 }
 
 func (m model) matchedAction(msg tea.KeyMsg) (actionID, bool) {
-	for _, binding := range m.keys.actionBindings() {
+	for _, binding := range m.keys.actionBindings(m.mode) {
 		if key.Matches(msg, binding.binding) {
 			return binding.id, true
 		}
@@ -354,6 +386,10 @@ func (m *model) handleAction(action actionID) tea.Cmd {
 		return tea.Quit
 	case actionToggleHelp:
 		m.help.ShowAll = !m.help.ShowAll
+	case actionShowActions:
+		return m.switchMode(modeActions)
+	case actionShowWorkbench:
+		return m.switchMode(modeWorkbench)
 	case actionFocusNextPane:
 		m.focusNextPane()
 	case actionFocusPreviousPane:
@@ -366,17 +402,20 @@ func (m *model) handleAction(action actionID) tea.Cmd {
 		m.focusPaneByNumber(3)
 	case actionMoveDown:
 		m.moveFocusedSelection(1)
-		return m.startPreviewLoadIfFocusedItemChanged()
+		return m.startFocusedPreviewOrLoad()
 	case actionMoveUp:
 		m.moveFocusedSelection(-1)
-		return m.startPreviewLoadIfFocusedItemChanged()
+		return m.startFocusedPreviewOrLoad()
 	case actionJumpTop:
 		m.jumpFocusedSelection(false)
-		return m.startPreviewLoadIfFocusedItemChanged()
+		return m.startFocusedPreviewOrLoad()
 	case actionJumpBottom:
 		m.jumpFocusedSelection(true)
-		return m.startPreviewLoadIfFocusedItemChanged()
+		return m.startFocusedPreviewOrLoad()
 	case actionRefresh:
+		if m.mode == modeActions {
+			return m.refreshActionsData()
+		}
 		cmd := m.refreshWorkbenchData()
 		if cmd == nil {
 			m.statusMessage = "Refresh unavailable"
@@ -388,11 +427,48 @@ func (m *model) handleAction(action actionID) tea.Cmd {
 	case actionOpenIssue:
 		return m.openIssue()
 	case actionCopyURL:
+		if m.mode == modeActions {
+			return m.copyWorkflowRunURL()
+		}
 		return m.copyURL()
 	case actionCopyWorktreePath:
 		return m.copyWorktreePath()
+	case actionOpenWorkflowRun:
+		return m.openWorkflowRun()
+	case actionCopyWorkflowRunID:
+		return m.copyWorkflowRunID()
+	case actionFetchWorkflowRunLogs:
+		return m.fetchActionsLogs()
+	case actionFilterStatus:
+		return m.applyActionsFilter(actionsFilterFieldStatus)
+	case actionFilterConclusion:
+		return m.applyActionsFilter(actionsFilterFieldConclusion)
+	case actionFilterBranch:
+		return m.applyActionsFilter(actionsFilterFieldBranch)
+	case actionFilterWorkflow:
+		return m.applyActionsFilter(actionsFilterFieldWorkflow)
+	case actionFilterEvent:
+		return m.applyActionsFilter(actionsFilterFieldEvent)
+	case actionFilterActor:
+		return m.applyActionsFilter(actionsFilterFieldActor)
+	case actionClearFilters:
+		return m.clearActionsFilters()
 	}
 	return nil
+}
+
+func (m *model) startFocusedPreviewOrLoad() tea.Cmd {
+	if m.mode != modeActions {
+		return m.startPreviewLoadIfFocusedItemChanged()
+	}
+	switch m.activePane() {
+	case paneRepositories:
+		return m.startActionsLoadForSelectedRepo("Loading workflow runs...")
+	case paneWorkItems:
+		return m.startActionsPreviewIfFocusedRunChanged()
+	default:
+		return nil
+	}
 }
 
 func (m *model) openPullRequest() tea.Cmd {
@@ -460,6 +536,77 @@ func (m *model) copyWorktreePath() tea.Cmd {
 	return m.actionCommand("Copied worktree path", "Copy worktree path failed", func(ctx context.Context) error {
 		return m.runner().Copy(ctx, item.Worktree.Path)
 	})
+}
+
+func (m *model) openWorkflowRun() tea.Cmd {
+	run, ok := m.selectedWorkflowRun()
+	if !ok {
+		m.statusMessage = "No workflow run selected"
+		return nil
+	}
+	if run.URL == "" {
+		m.statusMessage = "No run URL for selected workflow run"
+		return nil
+	}
+	label := run.NumberLabel()
+	m.statusMessage = "Opening " + label + "..."
+	return m.actionCommand("Opened "+label, "Open workflow run failed", func(ctx context.Context) error {
+		return m.runner().Open(ctx, run.URL)
+	})
+}
+
+func (m *model) copyWorkflowRunURL() tea.Cmd {
+	run, ok := m.selectedWorkflowRun()
+	if !ok {
+		m.statusMessage = "No workflow run selected"
+		return nil
+	}
+	if run.URL == "" {
+		m.statusMessage = "No run URL for selected workflow run"
+		return nil
+	}
+	m.statusMessage = "Copying run URL..."
+	return m.actionCommand("Copied run URL", "Copy run URL failed", func(ctx context.Context) error {
+		return m.runner().Copy(ctx, run.URL)
+	})
+}
+
+func (m *model) copyWorkflowRunID() tea.Cmd {
+	run, ok := m.selectedWorkflowRun()
+	if !ok {
+		m.statusMessage = "No workflow run selected"
+		return nil
+	}
+	if run.ID == 0 {
+		m.statusMessage = "No run ID for selected workflow run"
+		return nil
+	}
+	m.statusMessage = "Copying run ID..."
+	return m.actionCommand("Copied run ID", "Copy run ID failed", func(ctx context.Context) error {
+		return m.runner().Copy(ctx, fmt.Sprintf("%d", run.ID))
+	})
+}
+
+func (m *model) applyActionsFilter(field actionsFilterField) tea.Cmd {
+	if m.mode != modeActions {
+		return nil
+	}
+	m.cycleActionsFilter(field)
+	return m.startActionsPreviewForCurrentRun()
+}
+
+func (m *model) clearActionsFilters() tea.Cmd {
+	if m.mode != modeActions {
+		return nil
+	}
+	if !m.actions.filter.active() {
+		m.statusMessage = "Actions filters: none"
+		return nil
+	}
+	m.actions.filter = actionsFilter{}
+	m.actions.selectedRun = 0
+	m.statusMessage = "Actions filters cleared"
+	return m.startActionsPreviewForCurrentRun()
 }
 
 func (m *model) actionCommand(success string, failure string, run func(context.Context) error) tea.Cmd {
@@ -638,6 +785,10 @@ func (m *model) moveFocusedSelection(delta int) {
 	case paneRepositories:
 		m.moveRepoSelection(delta)
 	case paneWorkItems:
+		if m.mode == modeActions {
+			m.moveWorkflowRunSelection(delta)
+			return
+		}
 		m.moveWorkItemSelection(delta)
 	}
 }
@@ -652,6 +803,10 @@ func (m *model) jumpFocusedSelection(toEnd bool) {
 		}
 		m.setRepoPaneIndex(0)
 	case paneWorkItems:
+		if m.mode == modeActions {
+			m.jumpWorkflowRunSelection(toEnd)
+			return
+		}
 		items := m.visibleWorkItems()
 		if toEnd {
 			if len(items) > 0 {
@@ -692,6 +847,9 @@ func (m *model) moveWorkItemSelection(delta int) {
 }
 
 func (m model) repoPaneEntryCount() int {
+	if m.mode == modeActions {
+		return len(m.repos)
+	}
 	return len(m.repos) + len(repoViews)
 }
 
@@ -713,6 +871,12 @@ func (m *model) setRepoPaneIndex(index int) {
 	}
 
 	index = clamp(index, 0, count-1)
+	if m.mode == modeActions {
+		m.selectedRepo = index
+		m.viewSelected = false
+		m.actions.selectedRun = 0
+		return
+	}
 	if index < len(m.repos) {
 		m.selectedRepo = index
 		m.viewSelected = false
@@ -932,9 +1096,9 @@ func (m model) renderFull(width int) string {
 	focus := m.activePane()
 
 	left := m.repoLines(paneTextWidth(repoPaneWidth), focus == paneRepositories)
-	middle := m.workItemLines(paneTextWidth(workItemPaneWidth), focus == paneWorkItems)
-	right := m.previewLines(paneTextWidth(rightWidth))
-	out := m.headerLines("gh-zen  repository workbench", width)
+	middle := m.middlePaneLines(paneTextWidth(workItemPaneWidth), focus == paneWorkItems)
+	right := m.previewPaneLines(paneTextWidth(rightWidth))
+	out := m.headerLines(m.headerTitle(false), width)
 	bodyHeight := m.frameBodyHeight(max(len(left), max(len(middle), len(right))), len(out))
 
 	body := lipgloss.JoinHorizontal(
@@ -952,10 +1116,10 @@ func (m model) renderFull(width int) string {
 func (m model) renderCompact(width int) string {
 	contentWidth := max(width-paneBorderWidth, 0)
 	focus := m.activePane()
-	out := m.headerLines("gh-zen workbench", width)
+	out := m.headerLines(m.headerTitle(true), width)
 
-	workLines := m.workItemLines(paneTextWidth(contentWidth), focus == paneWorkItems)
-	previewLines := m.previewLines(paneTextWidth(contentWidth))
+	workLines := m.middlePaneLines(paneTextWidth(contentWidth), focus == paneWorkItems)
+	previewLines := m.previewPaneLines(paneTextWidth(contentWidth))
 	workHeight := len(workLines)
 	previewHeight := len(previewLines)
 	if m.height > 0 {
@@ -972,6 +1136,33 @@ func (m model) renderCompact(width int) string {
 	return strings.Join(out, "\n") + "\n"
 }
 
+func (m model) headerTitle(compact bool) string {
+	if m.mode == modeActions {
+		if compact {
+			return "gh-zen actions"
+		}
+		return "gh-zen  GitHub Actions"
+	}
+	if compact {
+		return "gh-zen workbench"
+	}
+	return "gh-zen  repository workbench"
+}
+
+func (m model) middlePaneLines(width int, focused bool) []string {
+	if m.mode == modeActions {
+		return m.actionsRunLines(width, focused)
+	}
+	return m.workItemLines(width, focused)
+}
+
+func (m model) previewPaneLines(width int) []string {
+	if m.mode == modeActions {
+		return m.actionsPreviewLines(width)
+	}
+	return m.previewLines(width)
+}
+
 func (m model) repoLines(width int, focused bool) []string {
 	lines := []string{}
 	if len(m.repos) == 0 {
@@ -981,6 +1172,9 @@ func (m model) repoLines(width int, focused bool) []string {
 			marker := selectionMarker(!m.viewSelected && i == m.selectedRepo, focused)
 			lines = append(lines, truncate(fmt.Sprintf("%s %s", marker, repo.FullName()), width))
 		}
+	}
+	if m.mode == modeActions {
+		return lines
 	}
 	lines = append(lines, "", "Views")
 	for i, view := range repoViews {
@@ -1065,9 +1259,9 @@ func (m model) headerLines(title string, width int) []string {
 // keymapLines keeps the active pane affordances visible near the title.
 func (m model) keymapLines(width int) []string {
 	focus := m.activePane()
-	prefix := focus.label() + " keys: "
+	prefix := m.paneLabel(focus) + " keys: "
 	helpWidth := max(width-lipgloss.Width(prefix), 0)
-	helpView := m.styledHelp(helpWidth).View(m.keys.contextualHelp(focus, m.paneOrder()))
+	helpView := m.styledHelp(helpWidth).View(m.keys.contextualHelp(m.mode, focus, m.paneOrder()))
 	lines := strings.Split(helpView, "\n")
 	indent := strings.Repeat(" ", lipgloss.Width(prefix))
 
@@ -1169,9 +1363,37 @@ func paneTextWidth(width int) int {
 func (m model) paneHeading(pane paneFocus) string {
 	number, ok := m.paneNumber(pane)
 	if !ok {
-		return pane.borderLabel()
+		return m.paneBorderLabel(pane)
 	}
-	return fmt.Sprintf("%s[%d]", pane.borderLabel(), number)
+	return fmt.Sprintf("%s[%d]", m.paneBorderLabel(pane), number)
+}
+
+func (m model) paneLabel(pane paneFocus) string {
+	if m.mode == modeActions {
+		switch pane {
+		case paneRepositories:
+			return "Repositories"
+		case panePreview:
+			return "Preview"
+		default:
+			return "Runs"
+		}
+	}
+	return pane.label()
+}
+
+func (m model) paneBorderLabel(pane paneFocus) string {
+	if m.mode == modeActions {
+		switch pane {
+		case paneRepositories:
+			return "Repositories"
+		case panePreview:
+			return "Preview"
+		default:
+			return "Runs"
+		}
+	}
+	return pane.borderLabel()
 }
 
 func (m model) paneNumber(pane paneFocus) (int, bool) {

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -614,7 +614,7 @@ func TestUpdate_QuitOnQuitKeys(t *testing.T) {
 
 func TestUpdate_NonQuitKey_NoCommand(t *testing.T) {
 	start := newModel()
-	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	got, cmd := start.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
 	if cmd != nil {
 		t.Fatalf("expected nil cmd for non-quit key, got %T", cmd)
 	}

--- a/internal/app/testdata/TestView_Actions_Loaded.golden
+++ b/internal/app/testdata/TestView_Actions_Loaded.golden
@@ -1,0 +1,18 @@
+gh-zen  GitHub Actions
+Runs keys: j/k move  g/G jump  [1]/[2]/[3] pane  h/l pane  ? help  q quit
+┌─Repositories[1]───────┐ ┌─Runs[2]─────────────────────────────────┐ ┌─Preview[3]─────────────────┐
+│ * 0maru/gh-zen        │ │ > success     CI           main        ~│ │ Workflow: CI               │
+│   0maru/dotfiles      │ │   failure     CI           feat/config-~│ │ Title: Set up GitHub CLI e~│
+│                       │ │   in_progress Release      main        ~│ │ Run: run #77 (1001)        │
+│                       │ │                                         │ │ Status: success            │
+│                       │ │                                         │ │ Branch: main               │
+│                       │ │                                         │ │ Event: push                │
+│                       │ │                                         │ │ Actor: 0maru               │
+│                       │ │                                         │ │ Commit: 3da43e7            │
+│                       │ │                                         │ │ Created: 2026-06-20 12:00 ~│
+│                       │ │                                         │ │ Updated: 2026-06-20 12:04 ~│
+│                       │ │                                         │ │ URL: https://github.com/0m~│
+│                       │ │                                         │ │ Failure summary: none      │
+│                       │ │                                         │ │ Jobs:                      │
+│                       │ │                                         │ │   success test (4m0s)      │
+└───────────────────────┘ └─────────────────────────────────────────┘ └────────────────────────────┘

--- a/internal/app/view_test.go
+++ b/internal/app/view_test.go
@@ -46,6 +46,15 @@ func TestView_Initial(t *testing.T) {
 	requireEqualGolden(t, []byte(newModel().View()))
 }
 
+func TestView_Actions_Loaded(t *testing.T) {
+	m := newModel()
+	got, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	got, cmd = got.(model).Update(requireActionsLoadMsg(t, cmd))
+	got, _ = got.(model).Update(requireActionsPreviewMsg(t, cmd))
+
+	requireEqualGolden(t, []byte(got.(model).View()))
+}
+
 func TestView_Compact_HidesRepositoryPane(t *testing.T) {
 	m := newModel()
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 50, Height: 20})
@@ -122,6 +131,19 @@ func TestView_FullHelpShowsContextualActions(t *testing.T) {
 	}
 	if !strings.Contains(got, "p open PR") || !strings.Contains(got, "r refresh") {
 		t.Fatalf("expected preview full help to keep actions, got:\n%s", got)
+	}
+
+	m = newModel()
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	updated, cmd = updated.(model).Update(requireActionsLoadMsg(t, cmd))
+	updated, _ = updated.(model).Update(requireActionsPreviewMsg(t, cmd))
+	actionsModel := updated.(model)
+	actionsModel.help.ShowAll = true
+	got = ansi.Strip(actionsModel.View())
+	for _, want := range []string{"w workbench", "o open run", "Y copy run ID", "L failed logs", "s status", "x clear filters"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected actions full help to include %q, got:\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/github/fake.go
+++ b/internal/github/fake.go
@@ -13,6 +13,12 @@ type FakeService struct {
 	IssuesByRepo       map[string][]workbench.IssueRef
 	Checks             map[string]workbench.CheckSummary
 	ReviewSubjects     workbench.ReviewSubjects
+	WorkflowRunsByRepo map[string][]workbench.WorkflowRunRef
+	WorkflowRunsByID   map[int64]workbench.WorkflowRunRef
+	JobsByRunID        map[int64][]workbench.WorkflowJobRef
+	AnnotationsByJobID map[int64][]workbench.AnnotationRef
+	LogsByRunID        map[int64]workbench.WorkflowLog
+	LogsByJobID        map[int64]workbench.WorkflowLog
 	Err                error
 }
 
@@ -67,6 +73,61 @@ func (f FakeService) ViewerReviewSubjects(context.Context) (workbench.ReviewSubj
 	return f.ReviewSubjects, nil
 }
 
+func (f FakeService) WorkflowRuns(_ context.Context, repo string, opts WorkflowRunListOptions) ([]workbench.WorkflowRunRef, error) {
+	if f.Err != nil {
+		return nil, f.Err
+	}
+	runs := append([]workbench.WorkflowRunRef(nil), f.WorkflowRunsByRepo[repo]...)
+	if opts.Limit > 0 && len(runs) > opts.Limit {
+		runs = runs[:opts.Limit]
+	}
+	return runs, nil
+}
+
+func (f FakeService) WorkflowRun(_ context.Context, repo string, runID int64) (workbench.WorkflowRunRef, error) {
+	if f.Err != nil {
+		return workbench.WorkflowRunRef{}, f.Err
+	}
+	if run, ok := f.WorkflowRunsByID[runID]; ok {
+		return run, nil
+	}
+	for _, run := range f.WorkflowRunsByRepo[repo] {
+		if run.ID == runID {
+			return run, nil
+		}
+	}
+	return workbench.WorkflowRunRef{}, nil
+}
+
+func (f FakeService) WorkflowRunJobs(_ context.Context, _ string, runID int64) ([]workbench.WorkflowJobRef, error) {
+	if f.Err != nil {
+		return nil, f.Err
+	}
+	return cloneWorkflowJobs(f.JobsByRunID[runID]), nil
+}
+
+func (f FakeService) JobAnnotations(_ context.Context, _ string, jobID int64) ([]workbench.AnnotationRef, error) {
+	if f.Err != nil {
+		return nil, f.Err
+	}
+	return append([]workbench.AnnotationRef(nil), f.AnnotationsByJobID[jobID]...), nil
+}
+
+func (f FakeService) WorkflowRunLogs(_ context.Context, _ string, runID int64, opts LogFetchOptions) (workbench.WorkflowLog, error) {
+	if f.Err != nil {
+		return workbench.WorkflowLog{}, f.Err
+	}
+	if opts.JobID != nil {
+		if log, ok := f.LogsByJobID[*opts.JobID]; ok {
+			return cloneWorkflowLog(log), nil
+		}
+	}
+	if log, ok := f.LogsByRunID[runID]; ok {
+		return cloneWorkflowLog(log), nil
+	}
+	return workbench.WorkflowLog{RunID: runID, Failed: opts.FailedOnly}, nil
+}
+
 func (f FakeService) PullRequestsForRepo(repo string) ([]workbench.PullRequestRef, error) {
 	if f.Err != nil {
 		return nil, f.Err
@@ -86,4 +147,17 @@ func fakeCheckSummary(checks map[string]workbench.CheckSummary, key string) work
 		return summary
 	}
 	return workbench.CheckSummary{State: workbench.CheckUnknown}
+}
+
+func cloneWorkflowJobs(jobs []workbench.WorkflowJobRef) []workbench.WorkflowJobRef {
+	out := append([]workbench.WorkflowJobRef(nil), jobs...)
+	for i := range out {
+		out[i].Steps = append([]workbench.WorkflowStepRef(nil), out[i].Steps...)
+	}
+	return out
+}
+
+func cloneWorkflowLog(log workbench.WorkflowLog) workbench.WorkflowLog {
+	log.Lines = append([]string(nil), log.Lines...)
+	return log
 }

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/0maru/gh-zen/internal/workbench"
 )
@@ -20,6 +21,11 @@ type Service interface {
 	Issues(ctx context.Context, repo string) ([]workbench.IssueRef, error)
 	CheckSummary(ctx context.Context, repo string, ref string) (workbench.CheckSummary, error)
 	ViewerReviewSubjects(ctx context.Context) (workbench.ReviewSubjects, error)
+	WorkflowRuns(ctx context.Context, repo string, opts WorkflowRunListOptions) ([]workbench.WorkflowRunRef, error)
+	WorkflowRun(ctx context.Context, repo string, runID int64) (workbench.WorkflowRunRef, error)
+	WorkflowRunJobs(ctx context.Context, repo string, runID int64) ([]workbench.WorkflowJobRef, error)
+	JobAnnotations(ctx context.Context, repo string, jobID int64) ([]workbench.AnnotationRef, error)
+	WorkflowRunLogs(ctx context.Context, repo string, runID int64, opts LogFetchOptions) (workbench.WorkflowLog, error)
 }
 
 // RepositorySummary contains lightweight GitHub data for a repository refresh.
@@ -40,6 +46,18 @@ type CLIService struct {
 	Runner Runner
 }
 
+// WorkflowRunListOptions controls workflow run list size.
+type WorkflowRunListOptions struct {
+	Limit int
+}
+
+// LogFetchOptions controls explicit workflow log fetches.
+type LogFetchOptions struct {
+	FailedOnly bool
+	JobID      *int64
+	TailLines  int
+}
+
 // GHRunner executes the gh binary.
 type GHRunner struct{}
 
@@ -51,9 +69,14 @@ const (
 	ErrorNetwork ErrorKind = "network"
 	ErrorCommand ErrorKind = "command"
 
-	issueListFields = "number,title,state,url,body,labels,assignees,milestone,updatedAt"
-	listLimit       = "1000"
-	prListFields    = "number,title,state,url,headRefName,headRepositoryOwner,baseRefName,isDraft,updatedAt,author,reviewRequests,latestReviews,reviewDecision,body"
+	issueListFields  = "number,title,state,url,body,labels,assignees,milestone,updatedAt"
+	listLimit        = "1000"
+	prListFields     = "number,title,state,url,headRefName,headRepositoryOwner,baseRefName,isDraft,updatedAt,author,reviewRequests,latestReviews,reviewDecision,body"
+	runListFields    = "databaseId,number,name,workflowName,headBranch,event,status,conclusion,headSha,displayTitle,url,createdAt,updatedAt"
+	runViewFields    = "databaseId,number,name,workflowName,headBranch,event,status,conclusion,headSha,displayTitle,url,createdAt,updatedAt"
+	runJobsFields    = "jobs"
+	runListLimit     = 30
+	logTailLineLimit = 500
 
 	pullRequestClosingIssuesQuery = `
 query($owner:String!, $name:String!, $after:String) {
@@ -265,6 +288,124 @@ func (s CLIService) ViewerReviewSubjects(ctx context.Context) (workbench.ReviewS
 	return subjects, nil
 }
 
+// WorkflowRuns loads recent GitHub Actions workflow runs through gh.
+func (s CLIService) WorkflowRuns(ctx context.Context, repo string, opts WorkflowRunListOptions) ([]workbench.WorkflowRunRef, error) {
+	limit := workflowRunLimit(opts)
+	output, err := s.runner().Run(ctx, "run", "list", "--repo", repo, "--limit", strconv.Itoa(limit), "--json", runListFields)
+	if err != nil {
+		return nil, err
+	}
+	var payload []ghWorkflowRun
+	if err := json.Unmarshal(output, &payload); err != nil {
+		return nil, fmt.Errorf("parse gh run list output: %w", err)
+	}
+	runs := make([]workbench.WorkflowRunRef, 0, len(payload))
+	for _, run := range payload {
+		runs = append(runs, workflowRunRef(run))
+	}
+	actors := workflowRunActors(ctx, s, repo, limit)
+	for i := range runs {
+		if runs[i].Actor == "" {
+			runs[i].Actor = actors[runs[i].ID]
+		}
+	}
+	return runs, nil
+}
+
+// WorkflowRun loads one workflow run summary through gh.
+func (s CLIService) WorkflowRun(ctx context.Context, repo string, runID int64) (workbench.WorkflowRunRef, error) {
+	output, err := s.runner().Run(ctx, "run", "view", strconv.FormatInt(runID, 10), "--repo", repo, "--json", runViewFields)
+	if err != nil {
+		return workbench.WorkflowRunRef{}, err
+	}
+	var payload ghWorkflowRun
+	if err := json.Unmarshal(output, &payload); err != nil {
+		return workbench.WorkflowRunRef{}, fmt.Errorf("parse gh run view output: %w", err)
+	}
+	run := workflowRunRef(payload)
+	if run.Actor == "" {
+		run.Actor = workflowRunActor(ctx, s, repo, run.ID)
+	}
+	return run, nil
+}
+
+// WorkflowRunJobs loads jobs for one workflow run through gh.
+func (s CLIService) WorkflowRunJobs(ctx context.Context, repo string, runID int64) ([]workbench.WorkflowJobRef, error) {
+	output, err := s.runner().Run(ctx, "run", "view", strconv.FormatInt(runID, 10), "--repo", repo, "--json", runJobsFields)
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Jobs []ghWorkflowJob `json:"jobs"`
+	}
+	if err := json.Unmarshal(output, &payload); err != nil {
+		return nil, fmt.Errorf("parse gh run jobs output: %w", err)
+	}
+	jobs := make([]workbench.WorkflowJobRef, 0, len(payload.Jobs))
+	for _, job := range payload.Jobs {
+		jobs = append(jobs, workflowJobRef(job))
+	}
+	return jobs, nil
+}
+
+// JobAnnotations loads check-run annotations for one workflow job through gh api.
+func (s CLIService) JobAnnotations(ctx context.Context, repo string, jobID int64) ([]workbench.AnnotationRef, error) {
+	output, err := s.runner().Run(ctx, "api", fmt.Sprintf("repos/%s/check-runs/%d/annotations", repo, jobID))
+	if err != nil {
+		return nil, err
+	}
+	var payload []ghAnnotation
+	if err := json.Unmarshal(output, &payload); err != nil {
+		return nil, fmt.Errorf("parse gh job annotations output: %w", err)
+	}
+	annotations := make([]workbench.AnnotationRef, 0, len(payload))
+	for _, annotation := range payload {
+		annotations = append(annotations, workbench.AnnotationRef{
+			Path:      annotation.Path,
+			StartLine: annotation.StartLine,
+			EndLine:   annotation.EndLine,
+			Level:     strings.ToLower(annotation.Level),
+			Title:     annotation.Title,
+			Message:   annotation.Message,
+		})
+	}
+	return annotations, nil
+}
+
+// WorkflowRunLogs fetches logs only when the caller explicitly requests them.
+func (s CLIService) WorkflowRunLogs(ctx context.Context, repo string, runID int64, opts LogFetchOptions) (workbench.WorkflowLog, error) {
+	args := []string{"run", "view", strconv.FormatInt(runID, 10), "--repo", repo}
+	if opts.JobID != nil {
+		args = append(args, "--job", strconv.FormatInt(*opts.JobID, 10))
+	}
+	if opts.FailedOnly {
+		args = append(args, "--log-failed")
+	} else {
+		args = append(args, "--log")
+	}
+	output, err := s.runner().Run(ctx, args...)
+	if err != nil {
+		return workbench.WorkflowLog{}, err
+	}
+	lines := logLines(string(output))
+	tailLimit := opts.TailLines
+	if tailLimit <= 0 {
+		tailLimit = logTailLineLimit
+	}
+	if len(lines) > tailLimit {
+		lines = lines[len(lines)-tailLimit:]
+	}
+	log := workbench.WorkflowLog{
+		RunID:  runID,
+		Failed: opts.FailedOnly,
+		Lines:  lines,
+	}
+	if opts.JobID != nil {
+		log.JobID = *opts.JobID
+	}
+	return log, nil
+}
+
 func (s CLIService) pullRequestClosingIssues(ctx context.Context, repo string) (map[int][]workbench.IssueRef, error) {
 	owner, name, ok := strings.Cut(repo, "/")
 	if !ok || owner == "" || name == "" {
@@ -346,6 +487,166 @@ type ghReviewRequest struct {
 type ghPullReviewItem struct {
 	Author ghUser `json:"author"`
 	State  string `json:"state"`
+}
+
+type ghWorkflowRun struct {
+	DatabaseID      int64     `json:"databaseId"`
+	ID              int64     `json:"id"`
+	Number          int       `json:"number"`
+	Name            string    `json:"name"`
+	WorkflowName    string    `json:"workflowName"`
+	HeadBranch      string    `json:"headBranch"`
+	Event           string    `json:"event"`
+	Status          string    `json:"status"`
+	Conclusion      string    `json:"conclusion"`
+	Actor           ghUser    `json:"actor"`
+	TriggeringActor ghUser    `json:"triggering_actor"`
+	HeadSHA         string    `json:"headSha"`
+	DisplayTitle    string    `json:"displayTitle"`
+	URL             string    `json:"url"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
+}
+
+type ghWorkflowJob struct {
+	DatabaseID  int64            `json:"databaseId"`
+	ID          int64            `json:"id"`
+	Name        string           `json:"name"`
+	Status      string           `json:"status"`
+	Conclusion  string           `json:"conclusion"`
+	StartedAt   time.Time        `json:"startedAt"`
+	CompletedAt time.Time        `json:"completedAt"`
+	Steps       []ghWorkflowStep `json:"steps"`
+	URL         string           `json:"url"`
+}
+
+type ghWorkflowStep struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+	Number     int    `json:"number"`
+}
+
+type ghAnnotation struct {
+	Path      string `json:"path"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+	Level     string `json:"annotation_level"`
+	Title     string `json:"title"`
+	Message   string `json:"message"`
+}
+
+type ghActionsRunsResponse struct {
+	WorkflowRuns []ghWorkflowRun `json:"workflow_runs"`
+}
+
+func workflowRunLimit(opts WorkflowRunListOptions) int {
+	if opts.Limit > 0 {
+		return opts.Limit
+	}
+	return runListLimit
+}
+
+func workflowRunRef(run ghWorkflowRun) workbench.WorkflowRunRef {
+	id := run.DatabaseID
+	if id == 0 {
+		id = run.ID
+	}
+	workflowName := run.WorkflowName
+	if workflowName == "" {
+		workflowName = run.Name
+	}
+	actor := run.Actor.Login
+	if actor == "" {
+		actor = run.TriggeringActor.Login
+	}
+	return workbench.WorkflowRunRef{
+		ID:           id,
+		RunNumber:    run.Number,
+		WorkflowName: workflowName,
+		Branch:       run.HeadBranch,
+		Event:        strings.ToLower(run.Event),
+		Status:       strings.ToLower(run.Status),
+		Conclusion:   strings.ToLower(run.Conclusion),
+		Actor:        actor,
+		HeadSHA:      run.HeadSHA,
+		Title:        run.DisplayTitle,
+		URL:          run.URL,
+		CreatedAt:    run.CreatedAt,
+		UpdatedAt:    run.UpdatedAt,
+	}
+}
+
+func workflowJobRef(job ghWorkflowJob) workbench.WorkflowJobRef {
+	id := job.DatabaseID
+	if id == 0 {
+		id = job.ID
+	}
+	steps := make([]workbench.WorkflowStepRef, 0, len(job.Steps))
+	for _, step := range job.Steps {
+		steps = append(steps, workbench.WorkflowStepRef{
+			Name:       step.Name,
+			Status:     strings.ToLower(step.Status),
+			Conclusion: strings.ToLower(step.Conclusion),
+			Number:     step.Number,
+		})
+	}
+	return workbench.WorkflowJobRef{
+		ID:          id,
+		Name:        job.Name,
+		Status:      strings.ToLower(job.Status),
+		Conclusion:  strings.ToLower(job.Conclusion),
+		StartedAt:   job.StartedAt,
+		CompletedAt: job.CompletedAt,
+		Steps:       steps,
+		URL:         job.URL,
+	}
+}
+
+func workflowRunActors(ctx context.Context, s CLIService, repo string, limit int) map[int64]string {
+	actors := map[int64]string{}
+	if repo == "" {
+		return actors
+	}
+	output, err := s.runner().Run(ctx, "api", "repos/"+repo+"/actions/runs", "--method", "GET", "-f", fmt.Sprintf("per_page=%d", limit))
+	if err != nil {
+		return actors
+	}
+	var payload ghActionsRunsResponse
+	if err := json.Unmarshal(output, &payload); err != nil {
+		return actors
+	}
+	for _, run := range payload.WorkflowRuns {
+		ref := workflowRunRef(run)
+		if ref.ID == 0 || ref.Actor == "" {
+			continue
+		}
+		actors[ref.ID] = ref.Actor
+	}
+	return actors
+}
+
+func workflowRunActor(ctx context.Context, s CLIService, repo string, runID int64) string {
+	if repo == "" || runID == 0 {
+		return ""
+	}
+	output, err := s.runner().Run(ctx, "api", fmt.Sprintf("repos/%s/actions/runs/%d", repo, runID))
+	if err != nil {
+		return ""
+	}
+	var payload ghWorkflowRun
+	if err := json.Unmarshal(output, &payload); err != nil {
+		return ""
+	}
+	return workflowRunRef(payload).Actor
+}
+
+func logLines(value string) []string {
+	value = strings.TrimRight(value, "\n")
+	if value == "" {
+		return nil
+	}
+	return strings.Split(value, "\n")
 }
 
 func linkedIssues(closingIssues []workbench.IssueRef, body string) []workbench.IssueRef {

--- a/internal/github/service.go
+++ b/internal/github/service.go
@@ -350,12 +350,12 @@ func (s CLIService) WorkflowRunJobs(ctx context.Context, repo string, runID int6
 
 // JobAnnotations loads check-run annotations for one workflow job through gh api.
 func (s CLIService) JobAnnotations(ctx context.Context, repo string, jobID int64) ([]workbench.AnnotationRef, error) {
-	output, err := s.runner().Run(ctx, "api", fmt.Sprintf("repos/%s/check-runs/%d/annotations", repo, jobID))
+	output, err := s.runner().Run(ctx, "api", fmt.Sprintf("repos/%s/check-runs/%d/annotations", repo, jobID), "--paginate", "--slurp")
 	if err != nil {
 		return nil, err
 	}
-	var payload []ghAnnotation
-	if err := json.Unmarshal(output, &payload); err != nil {
+	payload, err := parseAnnotationPages(output)
+	if err != nil {
 		return nil, fmt.Errorf("parse gh job annotations output: %w", err)
 	}
 	annotations := make([]workbench.AnnotationRef, 0, len(payload))
@@ -368,6 +368,26 @@ func (s CLIService) JobAnnotations(ctx context.Context, repo string, jobID int64
 			Title:     annotation.Title,
 			Message:   annotation.Message,
 		})
+	}
+	return annotations, nil
+}
+
+func parseAnnotationPages(output []byte) ([]ghAnnotation, error) {
+	var pages [][]ghAnnotation
+	if err := json.Unmarshal(output, &pages); err == nil {
+		count := 0
+		for _, page := range pages {
+			count += len(page)
+		}
+		annotations := make([]ghAnnotation, 0, count)
+		for _, page := range pages {
+			annotations = append(annotations, page...)
+		}
+		return annotations, nil
+	}
+	var annotations []ghAnnotation
+	if err := json.Unmarshal(output, &annotations); err != nil {
+		return nil, err
 	}
 	return annotations, nil
 }

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -179,6 +179,130 @@ func TestCLIService_ViewerReviewSubjectsParsesGHOutput(t *testing.T) {
 	}
 }
 
+func TestCLIService_WorkflowRunsParsesGHOutputAndActorFallback(t *testing.T) {
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("run", "list", "--repo", repo, "--limit", "2", "--json", runListFields):      []byte(`[{"databaseId":101,"number":77,"workflowName":"CI","headBranch":"main","event":"push","status":"completed","conclusion":"success","headSha":"abcdef1234567890","displayTitle":"Build main","url":"https://example.test/runs/101","createdAt":"2026-06-20T12:00:00Z","updatedAt":"2026-06-20T12:04:00Z"},{"databaseId":102,"number":78,"name":"Fallback name","headBranch":"feature","event":"pull_request","status":"completed","conclusion":"failure","headSha":"1234567890abcdef","displayTitle":"Build feature","url":"https://example.test/runs/102","createdAt":"2026-06-20T13:00:00Z","updatedAt":"2026-06-20T13:08:00Z"}]`),
+		commandKey("api", "repos/"+repo+"/actions/runs", "--method", "GET", "-f", "per_page=2"): []byte(`{"workflow_runs":[{"id":101,"triggering_actor":{"login":"0maru"}},{"id":102,"actor":{"login":"teammate"}}]}`),
+	}}
+	service := CLIService{Runner: runner}
+
+	got, err := service.WorkflowRuns(context.Background(), repo, WorkflowRunListOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("expected workflow runs to parse, got %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected two runs, got %+v", got)
+	}
+	if got[0].ID != 101 || got[0].RunNumber != 77 || got[0].WorkflowName != "CI" || got[0].Actor != "0maru" || got[0].ShortSHA() != "abcdef1" {
+		t.Fatalf("unexpected first run: %+v", got[0])
+	}
+	if got[1].WorkflowName != "Fallback name" || got[1].Conclusion != "failure" || got[1].Actor != "teammate" {
+		t.Fatalf("unexpected second run: %+v", got[1])
+	}
+}
+
+func TestCLIService_WorkflowRunParsesSingleRunWithActorFallback(t *testing.T) {
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("run", "view", "101", "--repo", repo, "--json", runViewFields): []byte(`{"databaseId":101,"number":77,"workflowName":"CI","headBranch":"main","event":"push","status":"completed","conclusion":"success","headSha":"abcdef1234567890","displayTitle":"Build main","url":"https://example.test/runs/101","createdAt":"2026-06-20T12:00:00Z","updatedAt":"2026-06-20T12:04:00Z"}`),
+		commandKey("api", "repos/"+repo+"/actions/runs/101"):                      []byte(`{"id":101,"triggering_actor":{"login":"0maru"}}`),
+	}}
+	service := CLIService{Runner: runner}
+
+	got, err := service.WorkflowRun(context.Background(), repo, 101)
+	if err != nil {
+		t.Fatalf("expected workflow run to parse, got %v", err)
+	}
+	if got.ID != 101 || got.Actor != "0maru" || got.StatusLabel() != "success" {
+		t.Fatalf("unexpected workflow run: %+v", got)
+	}
+}
+
+func TestCLIService_WorkflowRunJobsParsesGHOutput(t *testing.T) {
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("run", "view", "101", "--repo", repo, "--json", runJobsFields): []byte(`{"jobs":[{"databaseId":201,"name":"test","status":"completed","conclusion":"failure","startedAt":"2026-06-20T12:00:00Z","completedAt":"2026-06-20T12:04:00Z","url":"https://example.test/jobs/201","steps":[{"number":1,"name":"Checkout","status":"completed","conclusion":"success"},{"number":2,"name":"Go test","status":"completed","conclusion":"failure"}]}]}`),
+	}}
+	service := CLIService{Runner: runner}
+
+	got, err := service.WorkflowRunJobs(context.Background(), repo, 101)
+	if err != nil {
+		t.Fatalf("expected jobs to parse, got %v", err)
+	}
+	if len(got) != 1 || got[0].ID != 201 || got[0].Conclusion != "failure" || len(got[0].Steps) != 2 || got[0].Steps[1].Conclusion != "failure" {
+		t.Fatalf("unexpected jobs: %+v", got)
+	}
+}
+
+func TestCLIService_JobAnnotationsParsesGHOutput(t *testing.T) {
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("api", "repos/"+repo+"/check-runs/201/annotations"): []byte(`[{"path":"internal/app/model.go","start_line":42,"end_line":42,"annotation_level":"failure","title":"Test failure","message":"expected preview"}]`),
+	}}
+	service := CLIService{Runner: runner}
+
+	got, err := service.JobAnnotations(context.Background(), repo, 201)
+	if err != nil {
+		t.Fatalf("expected annotations to parse, got %v", err)
+	}
+	want := []workbench.AnnotationRef{{Path: "internal/app/model.go", StartLine: 42, EndLine: 42, Level: "failure", Title: "Test failure", Message: "expected preview"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %+v, got %+v", want, got)
+	}
+}
+
+func TestCLIService_WorkflowRunLogsFetchesRunAndJobScopedLogs(t *testing.T) {
+	repo := "0maru/gh-zen"
+	jobID := int64(201)
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("run", "view", "101", "--repo", repo, "--log-failed"):                 []byte("line 1\nline 2\n"),
+		commandKey("run", "view", "101", "--repo", repo, "--job", "201", "--log"):        []byte("job line\n"),
+		commandKey("run", "view", "101", "--repo", repo, "--job", "201", "--log-failed"): []byte("failed job line\n"),
+	}}
+	service := CLIService{Runner: runner}
+
+	runLog, err := service.WorkflowRunLogs(context.Background(), repo, 101, LogFetchOptions{FailedOnly: true})
+	if err != nil {
+		t.Fatalf("expected run log, got %v", err)
+	}
+	if !reflect.DeepEqual(runLog.Lines, []string{"line 1", "line 2"}) || !runLog.Failed || runLog.JobID != 0 {
+		t.Fatalf("unexpected run log: %+v", runLog)
+	}
+
+	jobLog, err := service.WorkflowRunLogs(context.Background(), repo, 101, LogFetchOptions{JobID: &jobID})
+	if err != nil {
+		t.Fatalf("expected job log, got %v", err)
+	}
+	if !reflect.DeepEqual(jobLog.Lines, []string{"job line"}) || jobLog.JobID != jobID || jobLog.Failed {
+		t.Fatalf("unexpected job log: %+v", jobLog)
+	}
+
+	failedJobLog, err := service.WorkflowRunLogs(context.Background(), repo, 101, LogFetchOptions{JobID: &jobID, FailedOnly: true})
+	if err != nil {
+		t.Fatalf("expected failed job log, got %v", err)
+	}
+	if !reflect.DeepEqual(failedJobLog.Lines, []string{"failed job line"}) || failedJobLog.JobID != jobID || !failedJobLog.Failed {
+		t.Fatalf("unexpected failed job log: %+v", failedJobLog)
+	}
+}
+
+func TestCLIService_WorkflowRunLogsTailsLargeOutput(t *testing.T) {
+	repo := "0maru/gh-zen"
+	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
+		commandKey("run", "view", "101", "--repo", repo, "--log"): []byte("one\ntwo\nthree\n"),
+	}}
+	service := CLIService{Runner: runner}
+
+	got, err := service.WorkflowRunLogs(context.Background(), repo, 101, LogFetchOptions{TailLines: 2})
+	if err != nil {
+		t.Fatalf("expected log tail, got %v", err)
+	}
+	if !reflect.DeepEqual(got.Lines, []string{"two", "three"}) {
+		t.Fatalf("expected last two lines, got %+v", got.Lines)
+	}
+}
+
 func TestCLIService_ProvidesDataForWorkbenchEnrichment(t *testing.T) {
 	repo := workbench.RepoRef{Owner: "0maru", Name: "gh-zen"}
 	runner := &fakeRunnerByCommand{outputs: map[string][]byte{

--- a/internal/github/service_test.go
+++ b/internal/github/service_test.go
@@ -238,7 +238,7 @@ func TestCLIService_WorkflowRunJobsParsesGHOutput(t *testing.T) {
 func TestCLIService_JobAnnotationsParsesGHOutput(t *testing.T) {
 	repo := "0maru/gh-zen"
 	runner := &fakeRunnerByCommand{outputs: map[string][]byte{
-		commandKey("api", "repos/"+repo+"/check-runs/201/annotations"): []byte(`[{"path":"internal/app/model.go","start_line":42,"end_line":42,"annotation_level":"failure","title":"Test failure","message":"expected preview"}]`),
+		commandKey("api", "repos/"+repo+"/check-runs/201/annotations", "--paginate", "--slurp"): []byte(`[[{"path":"internal/app/model.go","start_line":42,"end_line":42,"annotation_level":"failure","title":"Test failure","message":"expected preview"}],[{"path":"internal/app/view.go","start_line":7,"end_line":8,"annotation_level":"warning","title":"Lint","message":"second page"}]]`),
 	}}
 	service := CLIService{Runner: runner}
 
@@ -246,7 +246,10 @@ func TestCLIService_JobAnnotationsParsesGHOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected annotations to parse, got %v", err)
 	}
-	want := []workbench.AnnotationRef{{Path: "internal/app/model.go", StartLine: 42, EndLine: 42, Level: "failure", Title: "Test failure", Message: "expected preview"}}
+	want := []workbench.AnnotationRef{
+		{Path: "internal/app/model.go", StartLine: 42, EndLine: 42, Level: "failure", Title: "Test failure", Message: "expected preview"},
+		{Path: "internal/app/view.go", StartLine: 7, EndLine: 8, Level: "warning", Title: "Lint", Message: "second page"},
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("expected %+v, got %+v", want, got)
 	}

--- a/internal/workbench/fixtures.go
+++ b/internal/workbench/fixtures.go
@@ -1,5 +1,7 @@
 package workbench
 
+import "time"
+
 func FakeRepos() []RepoRef {
 	return []RepoRef{
 		{Owner: "0maru", Name: "gh-zen"},
@@ -73,6 +75,146 @@ func FakeWorkItems() []WorkItem {
 			Issue:  &IssueRef{Number: 34, Title: "Branch preview UX", State: "open", URL: "https://github.com/0maru/gh-zen/issues/34", Certain: false, Source: IssueLinkSourceBranch},
 			Checks: CheckSummary{State: CheckUnknown},
 			Local:  &LocalStatus{State: LocalUnknown, Summary: "unstarted"},
+		},
+	}
+}
+
+func FakeWorkflowRuns() []WorkflowRunRef {
+	created := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	return []WorkflowRunRef{
+		{
+			ID:           1001,
+			RunNumber:    77,
+			WorkflowName: "CI",
+			Branch:       "main",
+			Event:        "push",
+			Status:       "completed",
+			Conclusion:   "success",
+			Actor:        "0maru",
+			HeadSHA:      "3da43e7cafe1234567890abcdef1234567890ab",
+			Title:        "Set up GitHub CLI extension foundation",
+			URL:          "https://github.com/0maru/gh-zen/actions/runs/1001",
+			CreatedAt:    created,
+			UpdatedAt:    created.Add(4 * time.Minute),
+		},
+		{
+			ID:           1002,
+			RunNumber:    78,
+			WorkflowName: "CI",
+			Branch:       "feat/config-loader",
+			Event:        "pull_request",
+			Status:       "completed",
+			Conclusion:   "failure",
+			Actor:        "teammate",
+			HeadSHA:      "a1b2c3d4e5f678901234567890abcdef12345678",
+			Title:        "Add config defaults",
+			URL:          "https://github.com/0maru/gh-zen/actions/runs/1002",
+			CreatedAt:    created.Add(1 * time.Hour),
+			UpdatedAt:    created.Add(1*time.Hour + 8*time.Minute),
+		},
+		{
+			ID:           1003,
+			RunNumber:    79,
+			WorkflowName: "Release",
+			Branch:       "main",
+			Event:        "workflow_dispatch",
+			Status:       "in_progress",
+			Actor:        "0maru",
+			HeadSHA:      "c3d4e5f678901234567890abcdef1234567890ab",
+			Title:        "Build release candidate",
+			URL:          "https://github.com/0maru/gh-zen/actions/runs/1003",
+			CreatedAt:    created.Add(2 * time.Hour),
+			UpdatedAt:    created.Add(2*time.Hour + 2*time.Minute),
+		},
+	}
+}
+
+func FakeWorkflowJobs() map[int64][]WorkflowJobRef {
+	started := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
+	return map[int64][]WorkflowJobRef{
+		1001: {
+			{
+				ID:          2001,
+				Name:        "test",
+				Status:      "completed",
+				Conclusion:  "success",
+				StartedAt:   started,
+				CompletedAt: started.Add(4 * time.Minute),
+				URL:         "https://github.com/0maru/gh-zen/actions/runs/1001/job/2001",
+				Steps: []WorkflowStepRef{
+					{Number: 1, Name: "Checkout", Status: "completed", Conclusion: "success"},
+					{Number: 2, Name: "Test", Status: "completed", Conclusion: "success"},
+				},
+			},
+		},
+		1002: {
+			{
+				ID:          2002,
+				Name:        "lint",
+				Status:      "completed",
+				Conclusion:  "success",
+				StartedAt:   started.Add(1 * time.Hour),
+				CompletedAt: started.Add(1*time.Hour + 2*time.Minute),
+				URL:         "https://github.com/0maru/gh-zen/actions/runs/1002/job/2002",
+				Steps: []WorkflowStepRef{
+					{Number: 1, Name: "Checkout", Status: "completed", Conclusion: "success"},
+					{Number: 2, Name: "Lint", Status: "completed", Conclusion: "success"},
+				},
+			},
+			{
+				ID:          2003,
+				Name:        "test",
+				Status:      "completed",
+				Conclusion:  "failure",
+				StartedAt:   started.Add(1 * time.Hour),
+				CompletedAt: started.Add(1*time.Hour + 8*time.Minute),
+				URL:         "https://github.com/0maru/gh-zen/actions/runs/1002/job/2003",
+				Steps: []WorkflowStepRef{
+					{Number: 1, Name: "Checkout", Status: "completed", Conclusion: "success"},
+					{Number: 2, Name: "Go test", Status: "completed", Conclusion: "failure"},
+				},
+			},
+		},
+		1003: {
+			{
+				ID:        2004,
+				Name:      "build",
+				Status:    "in_progress",
+				StartedAt: started.Add(2 * time.Hour),
+				URL:       "https://github.com/0maru/gh-zen/actions/runs/1003/job/2004",
+				Steps: []WorkflowStepRef{
+					{Number: 1, Name: "Checkout", Status: "completed", Conclusion: "success"},
+					{Number: 2, Name: "Build", Status: "in_progress"},
+				},
+			},
+		},
+	}
+}
+
+func FakeWorkflowAnnotations() map[int64][]AnnotationRef {
+	return map[int64][]AnnotationRef{
+		2003: {
+			{
+				Path:      "internal/app/model.go",
+				StartLine: 42,
+				EndLine:   42,
+				Level:     "failure",
+				Title:     "Test failure",
+				Message:   "expected Actions preview to include failed job summary",
+			},
+		},
+	}
+}
+
+func FakeWorkflowLogs() map[int64]WorkflowLog {
+	return map[int64]WorkflowLog{
+		1002: {
+			RunID:  1002,
+			Failed: true,
+			Lines: []string{
+				"test\tGo test\t--- FAIL: TestActionsPreview",
+				"test\tGo test\texpected Actions preview to include failed job summary",
+			},
 		},
 	}
 }

--- a/internal/workbench/types.go
+++ b/internal/workbench/types.go
@@ -3,6 +3,7 @@ package workbench
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 type RepoRef struct {
@@ -122,6 +123,135 @@ type ReviewRequestRef struct {
 type PullRequestReviewRef struct {
 	AuthorLogin string
 	State       string
+}
+
+type WorkflowRunRef struct {
+	ID           int64
+	RunNumber    int
+	WorkflowName string
+	Branch       string
+	Event        string
+	Status       string
+	Conclusion   string
+	Actor        string
+	HeadSHA      string
+	Title        string
+	URL          string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+func (r WorkflowRunRef) Label() string {
+	label := r.NumberLabel()
+	title := r.Title
+	if title == "" {
+		title = r.WorkflowName
+	}
+	if title == "" {
+		return label
+	}
+	return fmt.Sprintf("%s %s", label, title)
+}
+
+func (r WorkflowRunRef) NumberLabel() string {
+	switch {
+	case r.RunNumber > 0:
+		return fmt.Sprintf("run #%d", r.RunNumber)
+	case r.ID > 0:
+		return fmt.Sprintf("run %d", r.ID)
+	default:
+		return "run"
+	}
+}
+
+func (r WorkflowRunRef) StatusLabel() string {
+	switch {
+	case r.Conclusion != "":
+		return r.Conclusion
+	case r.Status != "":
+		return r.Status
+	default:
+		return "unknown"
+	}
+}
+
+func (r WorkflowRunRef) ShortSHA() string {
+	if len(r.HeadSHA) <= 7 {
+		return r.HeadSHA
+	}
+	return r.HeadSHA[:7]
+}
+
+type WorkflowJobRef struct {
+	ID          int64
+	Name        string
+	Status      string
+	Conclusion  string
+	StartedAt   time.Time
+	CompletedAt time.Time
+	Steps       []WorkflowStepRef
+	URL         string
+}
+
+func (j WorkflowJobRef) Label() string {
+	if j.Name != "" {
+		return j.Name
+	}
+	if j.ID > 0 {
+		return fmt.Sprintf("job %d", j.ID)
+	}
+	return "job"
+}
+
+func (j WorkflowJobRef) StatusLabel() string {
+	switch {
+	case j.Conclusion != "":
+		return j.Conclusion
+	case j.Status != "":
+		return j.Status
+	default:
+		return "unknown"
+	}
+}
+
+type WorkflowStepRef struct {
+	Name       string
+	Status     string
+	Conclusion string
+	Number     int
+}
+
+type AnnotationRef struct {
+	Path      string
+	StartLine int
+	EndLine   int
+	Level     string
+	Title     string
+	Message   string
+}
+
+func (a AnnotationRef) Label() string {
+	location := a.Path
+	if a.StartLine > 0 {
+		location = fmt.Sprintf("%s:%d", location, a.StartLine)
+	}
+	switch {
+	case a.Title != "" && location != "":
+		return location + " " + a.Title
+	case a.Title != "":
+		return a.Title
+	case location != "":
+		return location
+	default:
+		return "annotation"
+	}
+}
+
+type WorkflowLog struct {
+	RunID  int64
+	JobID  int64
+	Failed bool
+	Lines  []string
 }
 
 type ReviewSubjects struct {

--- a/internal/workbench/types_test.go
+++ b/internal/workbench/types_test.go
@@ -1,6 +1,10 @@
 package workbench
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"time"
+)
 
 func TestRepoRef_FullName_ZeroValueSafe(t *testing.T) {
 	if got := (RepoRef{}).FullName(); got != "unknown repo" {
@@ -61,6 +65,57 @@ func TestPullRequestRef_HeadLabel(t *testing.T) {
 	}
 }
 
+func TestWorkflowRunRef_HoldsGitHubActionsFields(t *testing.T) {
+	created := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	updated := created.Add(4 * time.Minute)
+	run := WorkflowRunRef{
+		ID:           1001,
+		RunNumber:    77,
+		WorkflowName: "CI",
+		Branch:       "main",
+		Event:        "push",
+		Status:       "completed",
+		Conclusion:   "success",
+		Actor:        "0maru",
+		HeadSHA:      "abcdef1234567890",
+		Title:        "Build main",
+		URL:          "https://example.test/runs/1001",
+		CreatedAt:    created,
+		UpdatedAt:    updated,
+	}
+
+	if got := run.Label(); got != "run #77 Build main" {
+		t.Fatalf("expected run label, got %q", got)
+	}
+	if got := run.NumberLabel(); got != "run #77" {
+		t.Fatalf("expected run number label, got %q", got)
+	}
+	if got := run.StatusLabel(); got != "success" {
+		t.Fatalf("expected conclusion to win status label, got %q", got)
+	}
+	if got := run.ShortSHA(); got != "abcdef1" {
+		t.Fatalf("expected short SHA, got %q", got)
+	}
+	if run.CreatedAt != created || run.UpdatedAt != updated {
+		t.Fatalf("expected timestamps to round-trip, got %+v", run)
+	}
+}
+
+func TestWorkflowJobAndAnnotationLabels(t *testing.T) {
+	job := WorkflowJobRef{ID: 2001, Name: "test", Status: "completed", Conclusion: "failure"}
+	if got := job.Label(); got != "test" {
+		t.Fatalf("expected job label, got %q", got)
+	}
+	if got := job.StatusLabel(); got != "failure" {
+		t.Fatalf("expected job status label, got %q", got)
+	}
+
+	annotation := AnnotationRef{Path: "internal/app/model.go", StartLine: 42, Title: "Test failure"}
+	if got := annotation.Label(); got != "internal/app/model.go:42 Test failure" {
+		t.Fatalf("expected annotation label, got %q", got)
+	}
+}
+
 func TestWorkItem_LocationShowsPullRequestHeadForRemotePRBranch(t *testing.T) {
 	item := WorkItem{
 		Repo:        RepoRef{Owner: "0maru", Name: "gh-zen"},
@@ -69,6 +124,42 @@ func TestWorkItem_LocationShowsPullRequestHeadForRemotePRBranch(t *testing.T) {
 	}
 	if got := item.Location(); got != "contributor/feature" {
 		t.Fatalf("expected PR head location, got %q", got)
+	}
+}
+
+func TestFakeWorkflowRuns_CoverRequiredShapes(t *testing.T) {
+	runs := FakeWorkflowRuns()
+	if len(runs) < 3 {
+		t.Fatalf("expected at least three fake workflow runs, got %d", len(runs))
+	}
+
+	var hasSuccess bool
+	var hasFailure bool
+	var hasInProgress bool
+	for _, run := range runs {
+		if run.ID == 0 || run.RunNumber == 0 || run.WorkflowName == "" || run.Branch == "" || run.Event == "" || run.Status == "" || run.Actor == "" || run.HeadSHA == "" || run.Title == "" || run.URL == "" || run.CreatedAt.IsZero() || run.UpdatedAt.IsZero() {
+			t.Fatalf("fake workflow run missing required field: %+v", run)
+		}
+		switch {
+		case strings.EqualFold(run.Conclusion, "success"):
+			hasSuccess = true
+		case strings.EqualFold(run.Conclusion, "failure"):
+			hasFailure = true
+		case strings.EqualFold(run.Status, "in_progress"):
+			hasInProgress = true
+		}
+	}
+	if !hasSuccess || !hasFailure || !hasInProgress {
+		t.Fatalf("expected success, failure, and in-progress fake runs, got %+v", runs)
+	}
+	if len(FakeWorkflowJobs()[runs[1].ID]) == 0 {
+		t.Fatalf("expected fake jobs for failing run")
+	}
+	if len(FakeWorkflowAnnotations()) == 0 {
+		t.Fatalf("expected fake annotations")
+	}
+	if len(FakeWorkflowLogs()[runs[1].ID].Lines) == 0 {
+		t.Fatalf("expected fake failed logs")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ func loadStartupWorkbenchData(startupRepo config.StartupRepository, reloader app
 	data := app.WorkbenchData{
 		Repos:          []workbench.RepoRef{repo},
 		Reloader:       reloader,
+		ActionsLoader:  app.NewGitHubActionsLoader(github.CLIService{}),
 		InitialLoading: reloader != nil,
 	}
 	return data


### PR DESCRIPTION
## Summary

- Implements 0-106.

## Source

- Linear: https://linear.app/0maru/issue/0-106/gh-zen-77-add-github-actions-browsing-view-workflow-runs-jobs
- Source type: github_issue
- Source key: 0maru/gh-zen#77
- Source URL: https://github.com/0maru/gh-zen/issues/77
- Closes 0maru/gh-zen#77

## Target

- Repository: gh-zen
- Base branch: main

## Verification

- See the Symphony/Codex run output and Linear issue comments.
